### PR TITLE
Mouse passthru in direct mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "crossterm",
  "linkify",
@@ -2382,14 +2382,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.7.0-alpha"
+version = "0.7.1-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -46,11 +46,11 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm-core = { path = "crates/term-wm-core", version = "0.7.0-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.7.0-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.7.0-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.7.0-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.7.0-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.7.1-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.7.1-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.7.1-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.7.1-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.7.1-alpha" }
 thiserror = "2.0.18"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"

--- a/crates/term-wm-core/src/component_context.rs
+++ b/crates/term-wm-core/src/component_context.rs
@@ -16,6 +16,7 @@ use crate::keybindings::KeyBindings;
 ///
 /// - `focused`: whether the component is currently focused.
 /// - `overlay`: whether the component is being rendered as an overlay (e.g. dialog).
+/// - `direct_mode`: whether the component's window is in direct (passthrough) mode.
 /// - `viewport`: logical offset describing which portion of the component's
 ///   content is currently visible inside a scrolling container.
 /// - `app_ctx`: shared reference to application identity information
@@ -24,6 +25,7 @@ use crate::keybindings::KeyBindings;
 pub struct ComponentContext {
     focused: bool,
     overlay: bool,
+    direct_mode: bool,
     viewport: ViewportContext,
     viewport_handle: Option<ViewportHandle>,
     app_ctx: Arc<AppContext>,
@@ -175,6 +177,7 @@ impl ComponentContext {
         Self {
             focused,
             overlay: false,
+            direct_mode: false,
             viewport: ViewportContext {
                 offset_x: 0,
                 offset_y: 0,
@@ -196,6 +199,11 @@ impl ComponentContext {
     /// Returns whether the component is being rendered as an overlay.
     pub const fn overlay(&self) -> bool {
         self.overlay
+    }
+
+    /// Returns whether the component's window is in direct mode.
+    pub const fn direct_mode(&self) -> bool {
+        self.direct_mode
     }
 
     /// Returns the viewport offset for this component.
@@ -251,6 +259,13 @@ impl ComponentContext {
     pub fn with_overlay(&self, overlay: bool) -> Self {
         let mut ctx = self.clone();
         ctx.overlay = overlay;
+        ctx
+    }
+
+    /// Return a new `ComponentContext` with a modified `direct_mode` flag.
+    pub fn with_direct_mode(&self, direct_mode: bool) -> Self {
+        let mut ctx = self.clone();
+        ctx.direct_mode = direct_mode;
         ctx
     }
 

--- a/crates/term-wm-core/src/component_context.rs
+++ b/crates/term-wm-core/src/component_context.rs
@@ -296,3 +296,34 @@ impl Default for ComponentContext {
         Self::new(false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_mode_defaults_to_false() {
+        let ctx = ComponentContext::new(true);
+        assert!(!ctx.direct_mode());
+    }
+
+    #[test]
+    fn direct_mode_get_set_roundtrip() {
+        let ctx = ComponentContext::new(false);
+        assert!(!ctx.direct_mode());
+        let ctx = ctx.with_direct_mode(true);
+        assert!(ctx.direct_mode());
+        let ctx = ctx.with_direct_mode(false);
+        assert!(!ctx.direct_mode());
+    }
+
+    #[test]
+    fn direct_mode_independent_of_focus() {
+        let ctx = ComponentContext::new(true).with_direct_mode(true);
+        assert!(ctx.focused());
+        assert!(ctx.direct_mode());
+        let ctx = ComponentContext::new(false).with_direct_mode(true);
+        assert!(!ctx.focused());
+        assert!(ctx.direct_mode());
+    }
+}

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -70,7 +70,12 @@ pub trait WindowProvider<Id: Copy + Eq + Ord + std::fmt::Debug + 'static>:
     WindowManagerHost<Id>
 {
     fn enumerate_windows(&mut self) -> Vec<Id>;
-    fn render_window(&mut self, frame: &mut UiFrame<'_>, window: WindowDrawContext<Id>);
+    fn render_window(
+        &mut self,
+        frame: &mut UiFrame<'_>,
+        window: WindowDrawContext<Id>,
+        ctx: &ComponentContext,
+    );
 
     fn empty_window_message(&self) -> &str {
         "No windows"
@@ -693,7 +698,10 @@ where
                     decorator.as_ref(),
                     ctx,
                     |subframe| {
-                        app.render_window(subframe, window);
+                        let ctx = app
+                            .windows()
+                            .component_context_for(window.focused, WindowId::App(window.id));
+                        app.render_window(subframe, window, &ctx);
                     },
                 );
             }
@@ -907,6 +915,7 @@ mod tests {
                 &mut self,
                 _frame: &mut crate::ui::UiFrame<'_>,
                 _window: WindowDrawContext<usize>,
+                _ctx: &ComponentContext,
             ) {
             }
         }
@@ -968,6 +977,7 @@ mod tests {
                 &mut self,
                 _frame: &mut crate::ui::UiFrame<'_>,
                 _window: WindowDrawContext<usize>,
+                _ctx: &ComponentContext,
             ) {
             }
             fn window_component(&mut self, _id: usize) -> Option<&mut dyn Component> {
@@ -1067,6 +1077,7 @@ mod tests {
                 &mut self,
                 _frame: &mut crate::ui::UiFrame<'_>,
                 _window: WindowDrawContext<usize>,
+                _ctx: &ComponentContext,
             ) {
             }
             fn window_component(&mut self, _id: usize) -> Option<&mut dyn Component> {

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -102,7 +102,12 @@ where
     A: WindowProvider<Id>,
     Id: Copy + Eq + Ord + std::fmt::Debug + 'static,
 {
-    let ctx = app.windows().component_context(true);
+    let focus_id = app.windows().focused_window();
+    let direct_mode = app.windows().direct_mode(focus_id);
+    let ctx = app
+        .windows()
+        .component_context(true)
+        .with_direct_mode(direct_mode);
 
     let mut pending_focus: Option<Id> = None;
     let mut pending_event: Option<Event> = None;

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -25,6 +25,7 @@ impl<Id: Copy + Eq + Ord + std::fmt::Debug + 'static> WindowManager<Id> {
     where
         F: FnMut(Id, &Event) -> bool,
     {
+        // Block mouse events in focused windows if direct mode is enabled
         if let Event::Mouse(mouse) = event {
             let focused = self.focused_window();
             let in_content = self.config.chrome_enabled

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -2,6 +2,7 @@ use crossterm::event::{Event, MouseEventKind};
 
 use super::WindowId;
 use super::WindowManager;
+use crate::layout::rect_contains;
 
 impl<Id: Copy + Eq + Ord + std::fmt::Debug + 'static> WindowManager<Id> {
     pub fn focus(&self) -> Id {
@@ -24,8 +25,15 @@ impl<Id: Copy + Eq + Ord + std::fmt::Debug + 'static> WindowManager<Id> {
     where
         F: FnMut(Id, &Event) -> bool,
     {
-        if matches!(event, Event::Mouse(_)) && self.handle_managed_event(event) {
-            return true;
+        if let Event::Mouse(mouse) = event {
+            let focused = self.focused_window();
+            let in_content = self.config.chrome_enabled
+                && rect_contains(self.region_for_id(focused), mouse.column, mouse.row);
+            if !(in_content && self.direct_mode(focused))
+                && self.handle_managed_event(event)
+            {
+                return true;
+            }
         }
 
         // Hover-to-scroll: route scroll events to the window under the cursor

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -29,9 +29,7 @@ impl<Id: Copy + Eq + Ord + std::fmt::Debug + 'static> WindowManager<Id> {
             let focused = self.focused_window();
             let in_content = self.config.chrome_enabled
                 && rect_contains(self.region_for_id(focused), mouse.column, mouse.row);
-            if !(in_content && self.direct_mode(focused))
-                && self.handle_managed_event(event)
-            {
+            if !(in_content && self.direct_mode(focused)) && self.handle_managed_event(event) {
                 return true;
             }
         }

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2775,6 +2775,9 @@ mod tests {
             callback_invoked,
             "normal mode: click in content area must reach component"
         );
-        assert!(consumed, "normal mode: dispatch returns the callback's result");
+        assert!(
+            consumed,
+            "normal mode: dispatch returns the callback's result"
+        );
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2763,18 +2763,18 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         });
 
-        // Without direct mode, a click in the content area would be consumed by
-        // handle_managed_event (e.g. focus_window_at). The callback should NOT
-        // be invoked for a plain Down event since chrome handles it first.
+        // In normal mode, a click in the content area is not consumed by chrome
+        // (no chrome element at that position). handle_managed_event returns
+        // false so the event flows through to the focused window callback.
         let mut callback_invoked = false;
         let consumed = wm.dispatch_focused_event(&click, |_, _| {
             callback_invoked = true;
             true
         });
         assert!(
-            !callback_invoked,
-            "normal mode: chrome must consume click before callback"
+            callback_invoked,
+            "normal mode: click in content area must reach component"
         );
-        assert!(consumed, "normal mode: chrome must consume the event");
+        assert!(consumed, "normal mode: dispatch returns the callback's result");
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -554,6 +554,14 @@ impl<Id: Copy + Eq + Ord + std::fmt::Debug + 'static> WindowManager<Id> {
         ComponentContext::new(focused).with_app_context(Arc::clone(&self.app_ctx))
     }
 
+    /// Create a [`ComponentContext`] for a specific window, including the
+    /// window's direct-mode state so children (scroll view, terminal) can
+    /// adapt their rendering and event handling automatically.
+    pub fn component_context_for(&self, focused: bool, id: WindowId<Id>) -> ComponentContext {
+        self.component_context(focused)
+            .with_direct_mode(self.direct_mode(id))
+    }
+
     /// Number of overlays that will be rendered this frame.
     pub fn visible_overlay_count(&self) -> usize {
         let mut n = 0usize;

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2602,4 +2602,179 @@ mod tests {
         wm.set_power_profile(PowerProfile::PowerSaver);
         assert_eq!(wm.power_profile, PowerProfile::PowerSaver);
     }
+
+    #[test]
+    fn dispatch_focused_event_skips_chrome_in_direct_mode_content_area() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        use crossterm::event::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut wm = WindowManager::<usize>::with_config(
+            0,
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            Box::new(NoopMenu),
+        );
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(1usize)));
+        wm.managed_draw_order = vec![WindowId::App(1usize)];
+        wm.z_order = vec![WindowId::App(1usize)];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(1usize);
+
+        let win_id = WindowId::App(1usize);
+        wm.set_direct_mode(win_id, true);
+        assert!(wm.direct_mode(win_id));
+
+        // Click within the content area — should go to focused window's
+        // callback, NOT be consumed by chrome (handle_managed_event skipped).
+        let content = wm.region_for_id(win_id);
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y + 1,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let mut received = false;
+        let _consumed = wm.dispatch_focused_event(&click, |_, _| {
+            received = true;
+            true
+        });
+        assert!(received, "event must reach the focused-window callback");
+        // consumed may be true or false depending on what the callback returns.
+        // The key assertion is 'received' was set to true — meaning the event
+        // was routed to the window component, not consumed by chrome.
+    }
+
+    #[test]
+    fn dispatch_focused_event_still_routes_header_d_click_in_direct_mode() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        use crossterm::event::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut wm = WindowManager::<usize>::with_config(
+            0,
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            Box::new(NoopMenu),
+        );
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(1usize)));
+        wm.managed_draw_order = vec![WindowId::App(1usize)];
+        wm.z_order = vec![WindowId::App(1usize)];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(1usize);
+
+        let win_id = WindowId::App(1usize);
+        wm.set_direct_mode(win_id, true);
+
+        // Header D button click — coordinates on the header, NOT in content area.
+        let full_rect = wm.full_region_for_id(win_id);
+        let outer_right = full_rect
+            .x
+            .saturating_add(full_rect.width)
+            .saturating_sub(1);
+        let close_x = outer_right.saturating_sub(2);
+        let max_x = close_x.saturating_sub(2);
+        let min_x = max_x.saturating_sub(2);
+        let kb_x = min_x.saturating_sub(2);
+        let kb_y = full_rect.y.saturating_add(1); // header row
+        assert_eq!(
+            wm.decorator().hit_test(full_rect, kb_x, kb_y),
+            crate::window::decorator::HeaderAction::ToggleDirectMode,
+        );
+
+        assert!(wm.direct_mode(win_id), "direct mode enabled before click");
+
+        // This click is on the header (not content area) — chrome should still
+        // handle it despite direct mode being on.
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: kb_x,
+            row: kb_y,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let mut callback_invoked = false;
+        let consumed = wm.dispatch_focused_event(&click, |_, _| {
+            callback_invoked = true;
+            true
+        });
+
+        // The header D button click should be consumed by chrome, NOT reaching
+        // the window callback, and should toggle direct_mode off.
+        assert!(
+            !callback_invoked,
+            "header D click must not reach window callback"
+        );
+        assert!(consumed, "header D click must be consumed by chrome");
+        assert!(
+            !wm.direct_mode(win_id),
+            "header D click must toggle direct_mode off"
+        );
+    }
+
+    #[test]
+    fn dispatch_focused_event_normal_behavior_when_not_direct_mode() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        use crossterm::event::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut wm = WindowManager::<usize>::with_config(
+            0,
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            Box::new(NoopMenu),
+        );
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(1usize)));
+        wm.managed_draw_order = vec![WindowId::App(1usize)];
+        wm.z_order = vec![WindowId::App(1usize)];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(1usize);
+
+        let win_id = WindowId::App(1usize);
+        assert!(!wm.direct_mode(win_id), "direct mode is off");
+
+        let content = wm.region_for_id(win_id);
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y + 1,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        // Without direct mode, a click in the content area would be consumed by
+        // handle_managed_event (e.g. focus_window_at). The callback should NOT
+        // be invoked for a plain Down event since chrome handles it first.
+        let mut callback_invoked = false;
+        let consumed = wm.dispatch_focused_event(&click, |_, _| {
+            callback_invoked = true;
+            true
+        });
+        assert!(
+            !callback_invoked,
+            "normal mode: chrome must consume click before callback"
+        );
+        assert!(consumed, "normal mode: chrome must consume the event");
+    }
 }

--- a/crates/term-wm-pty-engine/src/input_encoding.rs
+++ b/crates/term-wm-pty-engine/src/input_encoding.rs
@@ -79,9 +79,21 @@ pub fn mouse_event_allowed(mode: MouseProtocolMode, kind: MouseEventKind) -> boo
     use MouseEventKind::*;
     match mode {
         MouseProtocolMode::None => false,
-        MouseProtocolMode::Press => matches!(kind, Down(_)),
-        MouseProtocolMode::PressRelease => matches!(kind, Down(_) | Up(_)),
-        MouseProtocolMode::ButtonMotion => matches!(kind, Down(_) | Up(_) | Drag(_)),
+        MouseProtocolMode::Press => {
+            matches!(kind, Down(_) | ScrollUp | ScrollDown | ScrollLeft | ScrollRight)
+        }
+        MouseProtocolMode::PressRelease => {
+            matches!(
+                kind,
+                Down(_) | Up(_) | ScrollUp | ScrollDown | ScrollLeft | ScrollRight
+            )
+        }
+        MouseProtocolMode::ButtonMotion => {
+            matches!(
+                kind,
+                Down(_) | Up(_) | Drag(_) | ScrollUp | ScrollDown | ScrollLeft | ScrollRight
+            )
+        }
         MouseProtocolMode::AnyMotion => true,
     }
 }

--- a/crates/term-wm-pty-engine/src/input_encoding.rs
+++ b/crates/term-wm-pty-engine/src/input_encoding.rs
@@ -287,6 +287,23 @@ mod tests {
             MouseProtocolMode::AnyMotion,
             MouseEventKind::Moved
         ));
+        // Scroll events are press-type (codes 64/65); allowed in Press and above
+        assert!(
+            mouse_event_allowed(MouseProtocolMode::Press, ScrollDown),
+            "ScrollDown should be allowed in Press mode"
+        );
+        assert!(
+            mouse_event_allowed(MouseProtocolMode::PressRelease, ScrollUp),
+            "ScrollUp should be allowed in PressRelease mode"
+        );
+        assert!(
+            mouse_event_allowed(MouseProtocolMode::ButtonMotion, ScrollLeft),
+            "ScrollLeft should be allowed in ButtonMotion mode"
+        );
+        assert!(
+            !mouse_event_allowed(MouseProtocolMode::None, ScrollDown),
+            "ScrollDown should be denied in None mode"
+        );
     }
 
     // --- mouse_event_to_bytes ---

--- a/crates/term-wm-pty-engine/src/input_encoding.rs
+++ b/crates/term-wm-pty-engine/src/input_encoding.rs
@@ -80,7 +80,10 @@ pub fn mouse_event_allowed(mode: MouseProtocolMode, kind: MouseEventKind) -> boo
     match mode {
         MouseProtocolMode::None => false,
         MouseProtocolMode::Press => {
-            matches!(kind, Down(_) | ScrollUp | ScrollDown | ScrollLeft | ScrollRight)
+            matches!(
+                kind,
+                Down(_) | ScrollUp | ScrollDown | ScrollLeft | ScrollRight
+            )
         }
         MouseProtocolMode::PressRelease => {
             matches!(

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -631,4 +631,102 @@ mod tests {
         assert!(rect_contains(r2, 1, 1));
         assert!(!rect_contains(r2, 3, 1));
     }
+
+    // --- Direct mode scroll tests ---
+
+    struct EventRecorder {
+        received_scroll: bool,
+    }
+    impl Component for EventRecorder {
+        fn render(&mut self, _frame: &mut UiFrame<'_>, _area: Rect, _ctx: &ComponentContext) {}
+        fn handle_event(&mut self, event: &Event, _ctx: &ComponentContext) -> bool {
+            if matches!(event, Event::Mouse(m)
+                if matches!(m.kind, MouseEventKind::ScrollUp | MouseEventKind::ScrollDown)
+            ) {
+                self.received_scroll = true;
+            }
+            false
+        }
+    }
+
+    #[test]
+    fn scroll_view_consumes_scroll_in_normal_mode() {
+        use crossterm::event::KeyModifiers;
+
+        let mut sv = ScrollViewComponent::new(EventRecorder {
+            received_scroll: false,
+        });
+
+        let ctx = ComponentContext::new(true);
+        let scroll_down = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 5,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        // Without direct mode, scroll event should be consumed by scroll view.
+        let consumed = sv.handle_event(&scroll_down, &ctx);
+        assert!(consumed, "scroll must be consumed in normal mode");
+    }
+
+    #[test]
+    fn scroll_view_passes_scroll_in_direct_mode() {
+        use crossterm::event::KeyModifiers;
+
+        let mut sv = ScrollViewComponent::new(EventRecorder {
+            received_scroll: false,
+        });
+
+        // Direct mode context
+        let ctx = ComponentContext::new(true).with_direct_mode(true);
+        let scroll_down = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 5,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let consumed = sv.handle_event(&scroll_down, &ctx);
+        // In direct mode, scroll should NOT be consumed by scroll view —
+        // it falls through to the child. Our EventRecorder returns false
+        // so consumed is false.
+        assert!(!consumed, "scroll must NOT be consumed in direct mode");
+        assert!(
+            sv.content.received_scroll,
+            "scroll must reach child component in direct mode"
+        );
+    }
+
+    #[test]
+    fn non_scroll_mouse_events_unaffected_by_direct_mode() {
+        use crossterm::event::KeyModifiers;
+
+        let mut sv = ScrollViewComponent::new(EventRecorder {
+            received_scroll: false,
+        });
+
+        let ctx_dm = ComponentContext::new(true).with_direct_mode(true);
+        let ctx_normal = ComponentContext::new(true);
+
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        // Direct mode: non-scroll events pass through to child
+        let consumed_dm = sv.handle_event(&click, &ctx_dm);
+        assert!(
+            !consumed_dm,
+            "non-scroll click should not be consumed regardless"
+        );
+
+        // Normal mode: non-scroll events pass through to child (only scroll is consumed)
+        sv.content.received_scroll = false;
+        let consumed_normal = sv.handle_event(&click, &ctx_normal);
+        assert!(
+            !consumed_normal,
+            "non-scroll click should not be consumed in normal mode either"
+        );
+    }
 }

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -409,8 +409,11 @@ impl<C: Component> Component for ScrollViewComponent<C> {
             }
         }
 
-        // Mouse Wheel (Common)
-        if let Event::Mouse(mouse) = event {
+        // Mouse Wheel (Common) — skip in direct mode so scroll passes through
+        // to the terminal component for encoding and forwarding to the PTY app.
+        if !ctx.direct_mode()
+            && let Event::Mouse(mouse) = event
+        {
             match mouse.kind {
                 MouseEventKind::ScrollUp => {
                     let mut st = self.shared_state.borrow_mut();

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -308,39 +308,41 @@ impl<C: Component> Component for ScrollViewComponent<C> {
                 continue;
             }
 
-            // 5. Render Scrollbars with finalized layout
-            if needs_vertical {
-                let sb_area = Rect {
-                    x: area.x + area.width.saturating_sub(1),
-                    y: area.y,
-                    width: 1,
-                    height: inner_area.height,
-                };
-                render_scrollbar_oriented(
-                    frame,
-                    sb_area,
-                    content_h,
-                    inner_area.height as usize,
-                    off_y,
-                    ScrollbarOrientation::VerticalRight,
-                );
-            }
+            // 5. Render Scrollbars with finalized layout (skip in direct mode)
+            if !ctx.direct_mode() {
+                if needs_vertical {
+                    let sb_area = Rect {
+                        x: area.x + area.width.saturating_sub(1),
+                        y: area.y,
+                        width: 1,
+                        height: inner_area.height,
+                    };
+                    render_scrollbar_oriented(
+                        frame,
+                        sb_area,
+                        content_h,
+                        inner_area.height as usize,
+                        off_y,
+                        ScrollbarOrientation::VerticalRight,
+                    );
+                }
 
-            if needs_horizontal {
-                let sb_area = Rect {
-                    x: area.x,
-                    y: area.y + area.height.saturating_sub(1),
-                    width: inner_area.width,
-                    height: 1,
-                };
-                render_scrollbar_oriented(
-                    frame,
-                    sb_area,
-                    content_w,
-                    inner_area.width as usize,
-                    off_x,
-                    ScrollbarOrientation::HorizontalBottom,
-                );
+                if needs_horizontal {
+                    let sb_area = Rect {
+                        x: area.x,
+                        y: area.y + area.height.saturating_sub(1),
+                        width: inner_area.width,
+                        height: 1,
+                    };
+                    render_scrollbar_oriented(
+                        frame,
+                        sb_area,
+                        content_w,
+                        inner_area.width as usize,
+                        off_x,
+                        ScrollbarOrientation::HorizontalBottom,
+                    );
+                }
             }
 
             break;

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -71,7 +71,7 @@ impl Component for TerminalComponent {
         self.render_screen(frame, area, ctx);
     }
 
-    fn handle_event(&mut self, event: &Event, _ctx: &ComponentContext) -> bool {
+    fn handle_event(&mut self, event: &Event, ctx: &ComponentContext) -> bool {
         match event {
             Event::Key(key) => {
                 if key.kind == KeyEventKind::Release {
@@ -104,12 +104,14 @@ impl Component for TerminalComponent {
                 true
             }
             Event::Mouse(mouse) => {
-                let selection_ready = self.selection_enabled;
-                if handle_selection_mouse(self, selection_ready, mouse) {
-                    return true;
-                }
-                if self.try_handle_link_click(mouse) {
-                    return true;
+                if !ctx.direct_mode() {
+                    let selection_ready = self.selection_enabled;
+                    if handle_selection_mouse(self, selection_ready, mouse) {
+                        return true;
+                    }
+                    if self.try_handle_link_click(mouse) {
+                        return true;
+                    }
                 }
                 if !rect_contains(self.last_area, mouse.column, mouse.row) {
                     return false;

--- a/examples/dual_image.rs
+++ b/examples/dual_image.rs
@@ -115,7 +115,12 @@ impl WindowProvider<PaneId> for App {
         vec![PaneId::Left, PaneId::Right]
     }
 
-    fn render_window(&mut self, frame: &mut UiFrame<'_>, window: WindowDrawContext<PaneId>) {
+    fn render_window(
+        &mut self,
+        frame: &mut UiFrame<'_>,
+        window: WindowDrawContext<PaneId>,
+        _ctx: &ComponentContext,
+    ) {
         match window.id {
             PaneId::Left => {
                 render_pane(frame, &mut self.left, window.surface.inner, window.focused)

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use term_wm::io::{
 };
 use term_wm::runner::{WindowManagerHost, WindowProvider, run_window_app};
 use term_wm::ui::UiFrame;
-use term_wm::window::{OverlayId, SystemWindowId, WindowDrawContext, WindowManager};
+use term_wm::window::{OverlayId, SystemWindowId, WindowDrawContext, WindowId, WindowManager};
 use term_wm::wm_config::WmConfig;
 use term_wm::{ScrollViewComponent, TerminalComponent, default_shell_command};
 use term_wm_sys_ui_components::wm_debug_log::{
@@ -281,7 +281,10 @@ impl WindowProvider<PaneId> for App {
     }
 
     fn render_window(&mut self, frame: &mut UiFrame<'_>, window: WindowDrawContext<PaneId>) {
-        let ctx = self.windows.component_context(window.focused);
+        let direct_mode = self.windows.direct_mode(WindowId::App(window.id));
+        let ctx = self.windows
+            .component_context(window.focused)
+            .with_direct_mode(direct_mode);
         render_pane(frame, self, window.id, window.surface.inner, ctx);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use term_wm::io::{
 };
 use term_wm::runner::{WindowManagerHost, WindowProvider, run_window_app};
 use term_wm::ui::UiFrame;
-use term_wm::window::{OverlayId, SystemWindowId, WindowDrawContext, WindowId, WindowManager};
+use term_wm::window::{OverlayId, SystemWindowId, WindowDrawContext, WindowManager};
 use term_wm::wm_config::WmConfig;
 use term_wm::{ScrollViewComponent, TerminalComponent, default_shell_command};
 use term_wm_sys_ui_components::wm_debug_log::{
@@ -280,12 +280,13 @@ impl WindowProvider<PaneId> for App {
             .collect()
     }
 
-    fn render_window(&mut self, frame: &mut UiFrame<'_>, window: WindowDrawContext<PaneId>) {
-        let direct_mode = self.windows.direct_mode(WindowId::App(window.id));
-        let ctx = self.windows
-            .component_context(window.focused)
-            .with_direct_mode(direct_mode);
-        render_pane(frame, self, window.id, window.surface.inner, ctx);
+    fn render_window(
+        &mut self,
+        frame: &mut UiFrame<'_>,
+        window: WindowDrawContext<PaneId>,
+        ctx: &ComponentContext,
+    ) {
+        render_pane(frame, self, window.id, window.surface.inner, ctx.clone());
     }
 
     fn empty_window_message(&self) -> &str {

--- a/tests/panic_debug_log.rs
+++ b/tests/panic_debug_log.rs
@@ -8,7 +8,7 @@ use ratatui::backend::TestBackend;
 
 use term_wm::app_context::AppContext;
 use term_wm::bottom_panel_trait::BottomPanel;
-use term_wm::components::MenuOverlay;
+use term_wm::components::{ComponentContext, MenuOverlay};
 use term_wm::io::{EventSource, RenderTarget};
 use term_wm::runner::{WindowManagerHost, WindowProvider, run_app};
 use term_wm::top_panel_trait::TopPanel;
@@ -96,7 +96,13 @@ impl WindowProvider<usize> for SparseApp {
         if self.draws < 3 { vec![1] } else { vec![] }
     }
 
-    fn render_window(&mut self, _frame: &mut UiFrame<'_>, _window: WindowDrawContext<usize>) {}
+    fn render_window(
+        &mut self,
+        _frame: &mut UiFrame<'_>,
+        _window: WindowDrawContext<usize>,
+        _ctx: &ComponentContext,
+    ) {
+    }
 }
 
 #[test]


### PR DESCRIPTION
Enables direct mouse passthru to connected apps when `direct mode` is enabled.