### PR TITLE
fix: PTY scrollback regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2517,14 +2517,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "arboard",
  "arc-swap",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.4-alpha"
+version = "0.8.5-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -50,11 +50,11 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.4-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.4-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.4-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.4-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.4-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.5-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.5-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.5-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.5-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.5-alpha" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -360,11 +360,16 @@ impl Pty {
     /// If the reader thread has published new content, performs a
     /// lock-free load from ArcSwap (no clone, no mutex contention).
     /// Also handles periodic foreground title polling and DSR responses.
+    /// Always returns a reference to `cached_screen`, which reflects both
+    /// new screen data (synced from ArcSwap on dirty) and any mutations
+    /// made via `screen_mut()` (e.g., `set_scrollback`).
     pub fn screen(&mut self) -> &vt100::Screen {
         self.poll_foreground();
         if self.dirty.swap(false, Ordering::Acquire) {
             // Lock-free load — atomic refcount increment, no clone.
-            self.screen_arc = Some(self.shared_screen.load_full());
+            let fresh = self.shared_screen.load_full();
+            self.cached_screen = (*fresh).clone();
+            self.screen_arc = Some(fresh);
 
             // Unpark the reader thread so it can read the next batch.
             if let Some(reader) = &self.reader {
@@ -372,16 +377,13 @@ impl Pty {
             }
 
             // Send DSR response if requested by the reader thread.
-            if self.dsr_requested.swap(false, Ordering::Relaxed)
-                && let Some(ref screen) = self.screen_arc
-            {
-                let (row, col) = screen.cursor_position();
+            if self.dsr_requested.swap(false, Ordering::Relaxed) {
+                let (row, col) = self.cached_screen.cursor_position();
                 let response = format!("\x1b[{};{}R", row.saturating_add(1), col.saturating_add(1));
                 let _ = self.write_bytes(response.as_bytes());
             }
         }
-        // Return reference to the Arc contents — borrows self via screen_arc.
-        self.screen_arc.as_deref().unwrap_or(&self.cached_screen)
+        &self.cached_screen
     }
 
     pub fn bytes_received(&self) -> usize {
@@ -398,12 +400,8 @@ impl Pty {
     }
 
     pub fn screen_mut(&mut self) -> &mut vt100::Screen {
-        // Ensure screen_arc is populated, then clone into cached_screen
-        // for mutation. This clone only happens on the rare mutable path.
+        // `screen()` already syncs `cached_screen` from ArcSwap on dirty.
         self.screen();
-        if let Some(ref screen_arc) = self.screen_arc {
-            self.cached_screen = (**screen_arc).clone();
-        }
         &mut self.cached_screen
     }
 
@@ -732,6 +730,7 @@ mod tests {
     use super::*;
     use std::io;
     use std::io::Cursor;
+    use std::io::Write;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -1026,6 +1025,163 @@ mod tests {
         let cell = screen.cell(0, 0);
         assert!(cell.is_some(), "expected a cell at (0,0)");
         assert_eq!(cell.unwrap().contents(), "c");
+
+        // Clean up.
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn set_scrollback_mutation_visible_through_scrollback_and_screen() {
+        // Regression test: Pty::screen() must return &cached_screen (which
+        // reflects mutations like set_scrollback), not &screen_arc (the raw
+        // ArcSwap snapshot which is never mutated).
+        //
+        // Generate enough output (30 lines in a 24-row terminal) to fill the
+        // scrollback buffer so that set_scrollback(N) isn't clamped to 0.
+        let cmd = CommandBuilder::new("cat");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        // Consume any initial dirty so cached_screen is synced from screen_arc.
+        let _s = pty.screen();
+
+        // Publish a screen with enough content to fill scrollback.
+        // 30 lines in a 24-row terminal → 6 lines in the scrollback buffer.
+        let mut lines = Vec::new();
+        for i in 0..30 {
+            writeln!(lines, "line {}", i).unwrap();
+        }
+        let mut parser = vt100::Parser::new(24, 80, 100);
+        parser.process(&lines);
+        pty.shared_screen.store(Arc::new(parser.screen().clone()));
+        pty.dirty.store(true, Ordering::Release);
+
+        // Load into cached_screen.
+        let _s = pty.screen();
+
+        // Start at bottom (scrollback == 0).
+        assert_eq!(pty.scrollback(), 0);
+
+        // ── The core of the bug ─────────────────────────────────────
+        // set_scrollback mutates cached_screen via screen_mut().
+        // screen() MUST return &cached_screen so the mutation is visible.
+        let sb_available = pty.max_scrollback();
+        assert!(
+            sb_available >= 3,
+            "need at least 3 scrollback lines, got {sb_available}"
+        );
+        pty.set_scrollback(3);
+
+        // scrollback() → screen() → must see the mutation.
+        assert_eq!(
+            pty.scrollback(),
+            3,
+            "scrollback() must reflect set_scrollback"
+        );
+
+        // screen().scrollback() → must also see the mutation.
+        assert_eq!(
+            pty.screen().scrollback(),
+            3,
+            "screen().scrollback() must reflect set_scrollback"
+        );
+
+        // Verify the raw ArcSwap snapshot was NOT mutated (sanity check
+        // that we're truly testing cached_screen vs screen_arc).
+        if let Some(ref screen_arc) = pty.screen_arc {
+            assert_eq!(
+                screen_arc.scrollback(),
+                0,
+                "the ArcSwap snapshot must remain untouched by set_scrollback"
+            );
+        }
+
+        // ── Mutation survives subsequent clean screen() calls ──────
+        // Calling screen() again (dirty=false) must not clobber the mutation.
+        let _s = pty.screen();
+        assert_eq!(
+            pty.scrollback(),
+            3,
+            "mutation must survive repeated screen() calls without new data"
+        );
+
+        // ── New ArcSwap data replaces the mutation (expected) ──────
+        // When a new screen arrives via ArcSwap, the new scrollback wins.
+        let mut parser2 = vt100::Parser::new(24, 80, 100);
+        parser2.process(b"fresh output");
+        pty.shared_screen.store(Arc::new(parser2.screen().clone()));
+        pty.dirty.store(true, Ordering::Release);
+        let _s = pty.screen();
+
+        assert_eq!(
+            pty.scrollback(),
+            0,
+            "new screen data must reset scrollback to its value"
+        );
+
+        // Clean up.
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn screen_mut_then_screen_see_consistent_scrollback() {
+        // screen_mut() and screen() both go through cached_screen.
+        // Any mutation via screen_mut() must be visible through screen().
+        let cmd = CommandBuilder::new("cat");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        // Sync cached_screen.
+        let _s = pty.screen();
+
+        // Publish and load a screen with scrollback content (30 lines).
+        let mut lines = Vec::new();
+        for i in 0..30 {
+            writeln!(lines, "line {}", i).unwrap();
+        }
+        let mut parser = vt100::Parser::new(24, 80, 100);
+        parser.process(&lines);
+        pty.shared_screen.store(Arc::new(parser.screen().clone()));
+        pty.dirty.store(true, Ordering::Release);
+        let _s = pty.screen();
+
+        assert!(
+            pty.max_scrollback() >= 3,
+            "need enough scrollback for this test"
+        );
+
+        // Mutate via screen_mut() directly.
+        pty.screen_mut().set_scrollback(3);
+
+        // screen() must see the same scrollback.
+        assert_eq!(
+            pty.screen().scrollback(),
+            3,
+            "screen() must see mutation made via screen_mut()"
+        );
+
+        // Mutate via set_scrollback() which uses screen_mut() internally.
+        pty.set_scrollback(5);
+
+        assert_eq!(
+            pty.screen().scrollback(),
+            5,
+            "screen() must see mutation made via set_scrollback"
+        );
 
         // Clean up.
         if let Some(child) = pty.child.as_mut() {


### PR DESCRIPTION
make screen() return &cached_screen so scrollback mutations are visible

Pty::screen() was returning screen_arc.as_deref() (the raw ArcSwap snapshot), but set_scrollback() mutations went to cached_screen via screen_mut(). This meant scrollback() and screen().scrollback() always returned the stale value, breaking terminal viewport scrolling.

Fix: on dirty, clone the fresh ArcSwap screen into cached_screen inside screen(), then always return &cached_screen. Remove the redundant clone from screen_mut() since screen() already handles it.

Add regression tests:
set_scrollback_mutation_visible_through_scrollback_and_screen and screen_mut_then_screen_see_consistent_scrollback.