### PR TITLE
fix: Improve header drag in direct mode and handle Ctrl+Q in embedded mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2517,14 +2517,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "arboard",
  "arc-swap",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.6-alpha"
+version = "0.8.7-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -50,11 +50,11 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.6-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.6-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.6-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.6-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.6-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.7-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.7-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.7-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.7-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.7-alpha" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -431,6 +431,15 @@ where
                 // Route Tab/Shift+Tab through focus routing for embedded mode only.
                 // In standalone mode without the open overlay, Tab passes through.
                 if !wm_mode
+                    && let Event::Key(key) = &evt
+                    && key.kind == KeyEventKind::Press
+                    && app.windows().keybindings().matches(Action::Quit, key)
+                {
+                    app.open_exit_confirm();
+                    update_selection_snapshot(app);
+                    return flush_state_changes(app, ControlFlow::Continue);
+                }
+                if !wm_mode
                     && matches!(evt, Event::Key(_))
                     && app.windows().handle_focus_event(&evt, focus_regions)
                 {

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -34,7 +34,12 @@ impl WindowManager {
             let focused = self.focused_window();
             let in_content = self.config.chrome_enabled
                 && rect_contains(self.region_for_key(focused), mouse.column, mouse.row);
-            if !(in_content && self.direct_mode(focused)) && self.handle_managed_event(event) {
+            if !(in_content
+                && self.direct_mode(focused)
+                && self.drag_header.is_none()
+                && self.drag_resize.is_none())
+                && self.handle_managed_event(event)
+            {
                 return true;
             }
         }

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -29,7 +29,10 @@ impl WindowManager {
     where
         F: FnMut(WindowKey, &Event) -> bool,
     {
-        // Block mouse events in focused windows if direct mode is enabled
+        // In direct mode, mouse events over the content area bypass chrome
+        // and go straight to the terminal component, unless a header or
+        // resize drag is in progress, in which case the cursor entering
+        // the content area should not cancel the drag.
         if let Event::Mouse(mouse) = event {
             let focused = self.focused_window();
             let in_content = self.config.chrome_enabled

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2657,6 +2657,132 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_focused_event_still_drags_header_in_direct_mode() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        use crate::window::FloatRectSpec;
+        use crossterm::event::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+        );
+        let keys = make_keys(&mut wm, 100);
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        wm.managed_draw_order = vec![keys[1]];
+        wm.z_order = vec![keys[1]];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(keys[1]);
+
+        let win_key = keys[1];
+        wm.set_direct_mode(win_key, true);
+        assert!(wm.direct_mode(win_key));
+
+        // Set a known floating rect so we can verify movement.
+        wm.set_floating_rect(
+            win_key,
+            Some(FloatRectSpec::Absolute(crate::window::FloatRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 20,
+            })),
+        );
+
+        // The window is now floating; floating_headers should contain its header.
+        let header_rect = wm
+            .floating_headers
+            .iter()
+            .find(|h| h.key == win_key)
+            .expect("floating header should exist")
+            .rect;
+
+        // MouseDown on the header — should start a drag via chrome.
+        let click_col = header_rect.x;
+        let click_row = header_rect.y;
+        let down = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: click_col,
+            row: click_row,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let mut callback_count = 0;
+        let consumed_down = wm.dispatch_focused_event(&down, |_, _| {
+            callback_count += 1;
+            true
+        });
+        assert!(consumed_down, "down event must be consumed by chrome");
+        assert_eq!(
+            callback_count, 0,
+            "callback must not be called for header down"
+        );
+        assert!(wm.drag_header.is_some(), "drag must be in progress");
+
+        // Now send a Drag event with the cursor deep into the content area.
+        // Without the fix, in_content=true + direct_mode=true would block it.
+        let content = wm.region_for_key(win_key);
+        let drag_col = content.x + content.width / 2;
+        let drag_row = content.y + content.height / 2;
+        let drag = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: drag_col,
+            row: drag_row,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let consumed_drag = wm.dispatch_focused_event(&drag, |_, _| {
+            callback_count += 1;
+            true
+        });
+        assert!(
+            consumed_drag,
+            "drag event deep in content area must still be consumed by chrome"
+        );
+        assert_eq!(
+            callback_count, 0,
+            "callback must not be called during drag in direct mode"
+        );
+
+        // The window should have moved.
+        let moved = match wm.floating_rect(win_key) {
+            Some(FloatRectSpec::Absolute(fr)) => fr,
+            _ => panic!("expected absolute floating rect"),
+        };
+        assert!(
+            moved.y > 0 || moved.x > 0,
+            "window must have moved during drag (moved: {:?}, start: (0,0))",
+            (moved.x, moved.y)
+        );
+
+        // MouseUp — should end the drag.
+        let up = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: drag_col,
+            row: drag_row,
+            modifiers: KeyModifiers::NONE,
+        });
+        let consumed_up = wm.dispatch_focused_event(&up, |_, _| {
+            callback_count += 1;
+            true
+        });
+        assert!(consumed_up, "up event must be consumed by chrome");
+        assert_eq!(
+            callback_count, 0,
+            "callback must not be called for header up"
+        );
+        assert!(wm.drag_header.is_none(), "drag must be finished after up");
+    }
+
+    #[test]
     fn dispatch_focused_event_normal_behavior_when_not_direct_mode() {
         use crate::layout::{LayoutNode, TilingLayout};
         use crossterm::event::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};


### PR DESCRIPTION
- dispatch_focused_event: skip direct-mode content check during active drags so the cursor entering the content area doesn't cancel the drag
- runner: handle Action::Quit directly in embedded mode since WmMode dispatch is disabled when wm_overlay_enabled is false