### PR TITLE
feat: BSP tiling layout with void nodes, corner/edge snap, and drag pipeline tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2480,6 +2480,7 @@ dependencies = [
  "indoc",
  "line-ending",
  "portable-pty",
+ "proptest",
  "ratatui",
  "term-wm-console",
  "term-wm-core",
@@ -2494,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2505,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2522,14 +2523,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2542,11 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2560,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.10-alpha"
+version = "0.8.11-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -52,14 +52,14 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm = { path = ".", version = "0.8.10-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.8.10-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.10-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.10-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.10-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.8.10-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.10-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.10-alpha" }
+term-wm = { path = ".", version = "0.8.11-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.8.11-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.11-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.11-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.11-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.8.11-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.11-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.11-alpha" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
@@ -97,4 +97,5 @@ webbrowser = { workspace = true }
 indoc = { workspace = true }
 
 [dev-dependencies]
+proptest = { workspace = true }
 term-wm-render = { workspace = true }

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -1097,6 +1097,75 @@ pub fn render_resize_outline(
     }
 }
 
+/// Render a ghost preview rectangle with dashed borders and a light shade fill.
+/// Used during drag operations to show where a window will land when released.
+pub fn render_ghost_preview(buf: &mut Buffer, preview_rect: LayoutRect, theme: &Theme) {
+    use ratatui::style::Modifier;
+    let rect = layout_rect_to_rect(preview_rect);
+    let clip = rect.intersection(buf.area);
+    if clip.width < 2 || clip.height < 2 {
+        return;
+    }
+
+    let fg_color = theme.accent.to_ratatui();
+    let left = clip.x;
+    let right = clip.x + clip.width - 1;
+    let top = clip.y;
+    let bottom = clip.y + clip.height - 1;
+
+    // Corners
+    for &(pos, sym) in &[
+        ((left, top), "┌"),
+        ((right, top), "┐"),
+        ((left, bottom), "└"),
+        ((right, bottom), "┘"),
+    ] {
+        if let Some(cell) = buf.cell_mut(pos) {
+            cell.set_symbol(sym);
+            cell.set_fg(fg_color);
+            cell.modifier.insert(Modifier::DIM);
+        }
+    }
+
+    // Top/bottom edges (horizontal dashes)
+    if clip.width > 2 {
+        for x in (left + 1)..right {
+            for &y in &[top, bottom] {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_symbol("─");
+                    cell.set_fg(fg_color);
+                    cell.modifier.insert(Modifier::DIM);
+                }
+            }
+        }
+    }
+
+    // Left/right edges (vertical dashes)
+    if clip.height > 2 {
+        for y in (top + 1)..bottom {
+            for &x in &[left, right] {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_symbol("│");
+                    cell.set_fg(fg_color);
+                    cell.modifier.insert(Modifier::DIM);
+                }
+            }
+        }
+    }
+
+    // Interior shade fill — pure background tint, preserves underlying text
+    if clip.width > 2 && clip.height > 2 {
+        let preview_bg = theme.accent.to_ratatui();
+        for y in (top + 1)..bottom {
+            for x in (left + 1)..right {
+                if let Some(cell) = buf.cell_mut((x, y)) {
+                    cell.set_bg(preview_bg);
+                }
+            }
+        }
+    }
+}
+
 /// Convert core `Color` to ratatui `Color`.
 pub trait ColorConvert {
     fn to_ratatui(self) -> ratatui::style::Color;

--- a/crates/term-wm-core/src/actions.rs
+++ b/crates/term-wm-core/src/actions.rs
@@ -292,4 +292,9 @@ pub enum SystemTask {
     /// The drag-snap timeout has elapsed — auto-apply the pending layout
     /// snap for the window that was being dragged.
     DragSnap,
+    /// Periodic tick while a drag cursor is held stationary inside a magnetic
+    /// edge-resistance zone.  Drives the temporal-dwell visual hint without
+    /// requiring mouse motion events (which stop flowing when the user holds
+    /// the mouse still).
+    TemporalDwellTick,
 }

--- a/crates/term-wm-core/src/keybindings.rs
+++ b/crates/term-wm-core/src/keybindings.rs
@@ -104,6 +104,7 @@ impl Default for KeyBindings {
             ScrollUp: [ (KeyCode::Up, KeyModifiers::NONE) ],
             ScrollDown: [ (KeyCode::Down, KeyModifiers::NONE) ],
             ToggleSelection: [ (KeyCode::Char(' '), KeyModifiers::NONE) ],
+
         }
     }
 }

--- a/crates/term-wm-core/src/layout/tiling.rs
+++ b/crates/term-wm-core/src/layout/tiling.rs
@@ -1,12 +1,16 @@
 use crate::Rect;
 use crate::layout::{Constraint, Direction, Layout};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use term_wm_layout_engine::LayoutRect;
+
+static VOID_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 
 use super::{FloatingPane, RegionMap, gap_size, rect_contains};
 
 #[derive(Debug, Clone)]
 pub enum LayoutNode<Id: Copy + Eq + Ord> {
     Leaf(Id),
+    Void(usize),
     Split {
         direction: Direction,
         children: Vec<LayoutNode<Id>>,
@@ -119,6 +123,43 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
         Some(current)
     }
 
+    /// Collect all leaf IDs in order from the tree.
+    pub fn collect_leaves(&self) -> Vec<Id> {
+        let mut ids = Vec::new();
+        self.collect_leaves_recursive(&mut ids);
+        ids
+    }
+
+    fn collect_leaves_recursive(&self, out: &mut Vec<Id>) {
+        match self {
+            LayoutNode::Leaf(id) => out.push(*id),
+            LayoutNode::Split { children, .. } => {
+                for child in children {
+                    child.collect_leaves_recursive(out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Build a flat split node from a list of leaf IDs.
+    pub fn build_flat(direction: Direction, ids: Vec<Id>) -> Self {
+        if ids.is_empty() {
+            return LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+        }
+        if ids.len() == 1 {
+            return LayoutNode::leaf(ids[0]);
+        }
+        let n = ids.len();
+        LayoutNode::Split {
+            direction,
+            children: ids.into_iter().map(LayoutNode::leaf).collect(),
+            weights: vec![1.0; n],
+            constraints: Vec::new(),
+            resizable: true,
+        }
+    }
+
     pub fn subtree_any<F>(&self, mut predicate: F) -> bool
     where
         F: FnMut(Id) -> bool,
@@ -129,6 +170,7 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
         ) -> bool {
             match node {
                 LayoutNode::Leaf(id) => predicate(*id),
+                LayoutNode::Void(_) => false,
                 LayoutNode::Split { children, .. } => {
                     children.iter().any(|child| walk(child, predicate))
                 }
@@ -206,6 +248,7 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
     pub fn remove_leaf(&mut self, id: Id) -> bool {
         match self {
             LayoutNode::Leaf(_) => false,
+            LayoutNode::Void(_) => false,
             LayoutNode::Split {
                 children,
                 weights,
@@ -234,7 +277,6 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
 
                     if children[index].remove_leaf(id) {
                         removed = true;
-                        // If the child split created an empty split, remove it
                         let is_empty_split = match &children[index] {
                             LayoutNode::Split { children: s, .. } => s.is_empty(),
                             _ => false,
@@ -253,9 +295,14 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
 
                     index += 1;
                 }
-                if removed && children.len() == 1 {
-                    let only = children.remove(0);
-                    *self = only;
+                if removed {
+                    if children.len() == 1 {
+                        let only = children.remove(0);
+                        *self = only;
+                    } else if children.iter().all(|c| matches!(c, LayoutNode::Void(_))) {
+                        *self = LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+                        return true;
+                    }
                 }
                 removed
             }
@@ -268,33 +315,123 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
                 if *current != target {
                     return false;
                 }
-                let (direction, children) = match position {
-                    InsertPosition::Left => (
-                        Direction::Horizontal,
-                        vec![LayoutNode::leaf(insert), LayoutNode::leaf(*current)],
-                    ),
-                    InsertPosition::Right => (
-                        Direction::Horizontal,
-                        vec![LayoutNode::leaf(*current), LayoutNode::leaf(insert)],
-                    ),
-                    InsertPosition::Top => (
-                        Direction::Vertical,
-                        vec![LayoutNode::leaf(insert), LayoutNode::leaf(*current)],
-                    ),
-                    InsertPosition::Bottom => (
-                        Direction::Vertical,
-                        vec![LayoutNode::leaf(*current), LayoutNode::leaf(insert)],
-                    ),
-                };
-                *self = LayoutNode::Split {
-                    direction,
-                    children,
-                    weights: vec![1.0, 1.0],
-                    constraints: Vec::new(),
-                    resizable: true,
-                };
+                match position {
+                    InsertPosition::Left => {
+                        *self = LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(insert), LayoutNode::leaf(*current)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::Right => {
+                        *self = LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(*current), LayoutNode::leaf(insert)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::Top => {
+                        *self = LayoutNode::Split {
+                            direction: Direction::Vertical,
+                            children: vec![LayoutNode::leaf(insert), LayoutNode::leaf(*current)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::Bottom => {
+                        *self = LayoutNode::Split {
+                            direction: Direction::Vertical,
+                            children: vec![LayoutNode::leaf(*current), LayoutNode::leaf(insert)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::TopLeft => {
+                        let inner = LayoutNode::Split {
+                            direction: Direction::Vertical,
+                            children: vec![
+                                LayoutNode::leaf(insert),
+                                LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed)),
+                            ],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                        *self = LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![inner, LayoutNode::leaf(*current)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::TopRight => {
+                        let inner = LayoutNode::Split {
+                            direction: Direction::Vertical,
+                            children: vec![
+                                LayoutNode::leaf(insert),
+                                LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed)),
+                            ],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                        *self = LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(*current), inner],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::BottomLeft => {
+                        let inner = LayoutNode::Split {
+                            direction: Direction::Vertical,
+                            children: vec![
+                                LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed)),
+                                LayoutNode::leaf(insert),
+                            ],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                        *self = LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![inner, LayoutNode::leaf(*current)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                    InsertPosition::BottomRight => {
+                        let inner = LayoutNode::Split {
+                            direction: Direction::Vertical,
+                            children: vec![
+                                LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed)),
+                                LayoutNode::leaf(insert),
+                            ],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                        *self = LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(*current), inner],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        };
+                    }
+                }
                 true
             }
+            LayoutNode::Void(_) => false,
             LayoutNode::Split { children, .. } => {
                 for child in children.iter_mut() {
                     if child.insert_leaf(target, insert, position) {
@@ -317,6 +454,7 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
             LayoutNode::Leaf(id) => {
                 regions.push((*id, area));
             }
+            LayoutNode::Void(_) => {}
             LayoutNode::Split {
                 direction,
                 children,
@@ -348,6 +486,136 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
                     }
                 }
             }
+        }
+    }
+}
+
+impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
+    pub fn void_regions(&self, area: Rect) -> Vec<(usize, Rect)> {
+        let mut rects = Vec::new();
+        self.void_regions_recursive(area, &mut rects);
+        rects
+    }
+
+    fn void_regions_recursive(&self, area: Rect, out: &mut Vec<(usize, Rect)>) {
+        match self {
+            LayoutNode::Void(id) => out.push((*id, area)),
+            LayoutNode::Split {
+                direction,
+                children,
+                weights,
+                constraints,
+                resizable,
+            } => {
+                let (rects, _) = split_rects_with_gaps(
+                    *direction,
+                    area,
+                    weights,
+                    constraints,
+                    children.len(),
+                    *resizable,
+                );
+                for (child, sub) in children.iter().zip(rects) {
+                    child.void_regions_recursive(sub, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Post-removal cleanup: remove Void children and collapse degenerate splits.
+    ///
+    /// After removing a leaf from the tree, this pass ensures:
+    /// 1. Void children (from remove_leaf) are removed from multi-child splits
+    /// 2. Splits with 0 children → Void
+    /// 3. Splits with 1 child → replace with that child
+    /// 4. Splits where ALL children are Void → replace with Void
+    ///
+    /// Call this after every `remove_leaf` to keep the layout clean.
+    #[allow(clippy::single_match)]
+    pub fn cleanup_after_removal(&mut self) {
+        match self {
+            LayoutNode::Split {
+                children,
+                weights,
+                constraints,
+                ..
+            } => {
+                // Recurse first
+                for child in children.iter_mut() {
+                    child.cleanup_after_removal();
+                }
+                // Remove Void children and corresponding weights/constraints
+                let mut i = 0;
+                while i < children.len() {
+                    if matches!(children[i], LayoutNode::Void(_)) {
+                        children.remove(i);
+                        if i < weights.len() {
+                            weights.remove(i);
+                        }
+                        if i < constraints.len() {
+                            constraints.remove(i);
+                        }
+                        // Don't increment — next element shifted into this index
+                    } else {
+                        i += 1;
+                    }
+                }
+                // Contract degenerate splits
+                match children.len() {
+                    0 => {
+                        *self = LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+                    }
+                    1 => {
+                        let only = children.remove(0);
+                        *self = only;
+                    }
+                    _ => {
+                        if children.iter().all(|c| matches!(c, LayoutNode::Void(_))) {
+                            *self =
+                                LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Reset all split weights to 1.0 so every leaf gets equal space.
+    /// Call after any snap insertion to rebalance the layout.
+    #[allow(clippy::single_match)]
+    pub fn normalize_weights(&mut self) {
+        match self {
+            LayoutNode::Split {
+                weights, children, ..
+            } => {
+                for w in weights.iter_mut() {
+                    *w = 1.0;
+                }
+                for child in children.iter_mut() {
+                    child.normalize_weights();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn replace_void_by_id(&mut self, void_id: usize, new_leaf: LayoutNode<Id>) -> bool {
+        match self {
+            LayoutNode::Void(id) if *id == void_id => {
+                *self = new_leaf;
+                true
+            }
+            LayoutNode::Split { children, .. } => {
+                for child in children.iter_mut() {
+                    if child.replace_void_by_id(void_id, new_leaf.clone()) {
+                        return true;
+                    }
+                }
+                false
+            }
+            _ => false,
         }
     }
 }
@@ -394,35 +662,278 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
     }
 
     pub fn split_root(&mut self, insert: Id, position: InsertPosition) {
-        let (direction, children) = match position {
-            InsertPosition::Left => (
-                Direction::Horizontal,
-                vec![LayoutNode::leaf(insert), self.root.clone()],
-            ),
-            InsertPosition::Right => (
-                Direction::Horizontal,
-                vec![self.root.clone(), LayoutNode::leaf(insert)],
-            ),
-            InsertPosition::Top => (
-                Direction::Vertical,
-                vec![LayoutNode::leaf(insert), self.root.clone()],
-            ),
-            InsertPosition::Bottom => (
-                Direction::Vertical,
-                vec![self.root.clone(), LayoutNode::leaf(insert)],
-            ),
-        };
-        self.root = LayoutNode::Split {
-            direction,
-            children,
-            weights: vec![1.0, 1.0],
-            constraints: Vec::new(),
-            resizable: true,
+        if matches!(self.root, LayoutNode::Void(_)) {
+            self.root = LayoutNode::leaf(insert);
+            return;
+        }
+        self.root = match position {
+            InsertPosition::Left => LayoutNode::Split {
+                direction: Direction::Horizontal,
+                children: vec![LayoutNode::leaf(insert), self.root.clone()],
+                weights: vec![1.0, 1.0],
+                constraints: Vec::new(),
+                resizable: true,
+            },
+            InsertPosition::Right => LayoutNode::Split {
+                direction: Direction::Horizontal,
+                children: vec![self.root.clone(), LayoutNode::leaf(insert)],
+                weights: vec![1.0, 1.0],
+                constraints: Vec::new(),
+                resizable: true,
+            },
+            InsertPosition::Top => LayoutNode::Split {
+                direction: Direction::Vertical,
+                children: vec![LayoutNode::leaf(insert), self.root.clone()],
+                weights: vec![1.0, 1.0],
+                constraints: Vec::new(),
+                resizable: true,
+            },
+            InsertPosition::Bottom => LayoutNode::Split {
+                direction: Direction::Vertical,
+                children: vec![self.root.clone(), LayoutNode::leaf(insert)],
+                weights: vec![1.0, 1.0],
+                constraints: Vec::new(),
+                resizable: true,
+            },
+            InsertPosition::TopLeft => {
+                // Extract all windows. D goes top-left, first remaining goes
+                // top-right, rest fill the bottom half.
+                let mut ids = self.root.collect_leaves();
+                ids.retain(|id| *id != insert);
+                if ids.is_empty() {
+                    return self.root = LayoutNode::leaf(insert);
+                }
+                let first = ids.remove(0);
+                if ids.is_empty() {
+                    // Exactly 2 windows — split only the dragged window's
+                    // side.  The other window stays in its lane at full height.
+                    // The unused quadrant becomes a Void placeholder.
+                    let void_id = VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    self.root = LayoutNode::Split {
+                        direction: Direction::Horizontal,
+                        children: vec![
+                            LayoutNode::Split {
+                                direction: Direction::Vertical,
+                                children: vec![LayoutNode::leaf(insert), LayoutNode::Void(void_id)],
+                                weights: vec![1.0, 1.0],
+                                constraints: Vec::new(),
+                                resizable: true,
+                            },
+                            LayoutNode::leaf(first),
+                        ],
+                        weights: vec![1.0, 1.0],
+                        constraints: Vec::new(),
+                        resizable: true,
+                    };
+                    return;
+                }
+                let bottom = LayoutNode::build_flat(Direction::Horizontal, ids);
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![
+                        LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(insert), LayoutNode::leaf(first)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        },
+                        bottom,
+                    ],
+                    weights: vec![1.0, 1.0],
+                    constraints: Vec::new(),
+                    resizable: true,
+                }
+            }
+            InsertPosition::TopRight => {
+                let mut ids = self.root.collect_leaves();
+                ids.retain(|id| *id != insert);
+                if ids.is_empty() {
+                    return self.root = LayoutNode::leaf(insert);
+                }
+                let first = ids.remove(0);
+                if ids.is_empty() {
+                    let void_id = VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    self.root = LayoutNode::Split {
+                        direction: Direction::Horizontal,
+                        children: vec![
+                            LayoutNode::leaf(first),
+                            LayoutNode::Split {
+                                direction: Direction::Vertical,
+                                children: vec![LayoutNode::leaf(insert), LayoutNode::Void(void_id)],
+                                weights: vec![1.0, 1.0],
+                                constraints: Vec::new(),
+                                resizable: true,
+                            },
+                        ],
+                        weights: vec![1.0, 1.0],
+                        constraints: Vec::new(),
+                        resizable: true,
+                    };
+                    return;
+                }
+                let bottom = LayoutNode::build_flat(Direction::Horizontal, ids);
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![
+                        LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(first), LayoutNode::leaf(insert)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        },
+                        bottom,
+                    ],
+                    weights: vec![1.0, 1.0],
+                    constraints: Vec::new(),
+                    resizable: true,
+                }
+            }
+            InsertPosition::BottomLeft => {
+                let mut ids = self.root.collect_leaves();
+                ids.retain(|id| *id != insert);
+                if ids.is_empty() {
+                    return self.root = LayoutNode::leaf(insert);
+                }
+                let first = ids.remove(0);
+                if ids.is_empty() {
+                    let void_id = VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    self.root = LayoutNode::Split {
+                        direction: Direction::Horizontal,
+                        children: vec![
+                            LayoutNode::Split {
+                                direction: Direction::Vertical,
+                                children: vec![LayoutNode::Void(void_id), LayoutNode::leaf(insert)],
+                                weights: vec![1.0, 1.0],
+                                constraints: Vec::new(),
+                                resizable: true,
+                            },
+                            LayoutNode::leaf(first),
+                        ],
+                        weights: vec![1.0, 1.0],
+                        constraints: Vec::new(),
+                        resizable: true,
+                    };
+                    return;
+                }
+                let top = LayoutNode::build_flat(Direction::Horizontal, ids);
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![
+                        top,
+                        LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(insert), LayoutNode::leaf(first)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        },
+                    ],
+                    weights: vec![1.0, 1.0],
+                    constraints: Vec::new(),
+                    resizable: true,
+                }
+            }
+            InsertPosition::BottomRight => {
+                let mut ids = self.root.collect_leaves();
+                ids.retain(|id| *id != insert);
+                if ids.is_empty() {
+                    return self.root = LayoutNode::leaf(insert);
+                }
+                let first = ids.remove(0);
+                if ids.is_empty() {
+                    let void_id = VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+                    self.root = LayoutNode::Split {
+                        direction: Direction::Horizontal,
+                        children: vec![
+                            LayoutNode::leaf(first),
+                            LayoutNode::Split {
+                                direction: Direction::Vertical,
+                                children: vec![LayoutNode::Void(void_id), LayoutNode::leaf(insert)],
+                                weights: vec![1.0, 1.0],
+                                constraints: Vec::new(),
+                                resizable: true,
+                            },
+                        ],
+                        weights: vec![1.0, 1.0],
+                        constraints: Vec::new(),
+                        resizable: true,
+                    };
+                    return;
+                }
+                let top = LayoutNode::build_flat(Direction::Horizontal, ids);
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![
+                        top,
+                        LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(first), LayoutNode::leaf(insert)],
+                            weights: vec![1.0, 1.0],
+                            constraints: Vec::new(),
+                            resizable: true,
+                        },
+                    ],
+                    weights: vec![1.0, 1.0],
+                    constraints: Vec::new(),
+                    resizable: true,
+                }
+            }
         };
     }
 
     pub fn regions(&self, area: Rect) -> Vec<(Id, Rect)> {
         self.root.layout(area)
+    }
+
+    pub fn void_regions(&self, area: Rect) -> Vec<(usize, Rect)> {
+        self.root.void_regions(area)
+    }
+
+    pub fn replace_void_by_id(&mut self, void_id: usize, new_leaf: LayoutNode<Id>) -> bool {
+        self.root.replace_void_by_id(void_id, new_leaf)
+    }
+
+    pub fn project_insert_void(&self, insert: Id, void_id: usize, area: Rect) -> Option<Rect> {
+        let mut root = self.root.clone();
+        root.remove_leaf(insert);
+        if root.replace_void_by_id(void_id, LayoutNode::leaf(insert)) {
+            root.layout(area)
+                .into_iter()
+                .find(|(id, _)| *id == insert)
+                .map(|(_, r)| r)
+        } else {
+            None
+        }
+    }
+
+    /// Dry-run insert into a cloned layout. Returns the exact `Rect` the
+    /// inserted leaf would occupy after `apply_snap`.
+    pub fn project_insert(
+        &self,
+        target: Option<Id>,
+        insert: Id,
+        position: InsertPosition,
+        area: Rect,
+    ) -> Option<Rect> {
+        let mut root = self.root.clone();
+        // Cull stale leaf before re-insertion — the window may still be in
+        // the tree (detach_to_floating does not remove it).
+        root.remove_leaf(insert);
+        let success = match target {
+            Some(t) => root.insert_leaf(t, insert, position),
+            None => false,
+        };
+        if !success {
+            let mut dummy_layout = TilingLayout::new(root);
+            dummy_layout.split_root(insert, position);
+            root = dummy_layout.root().clone();
+        }
+        root.layout(area)
+            .into_iter()
+            .find(|(id, _)| *id == insert)
+            .map(|(_, r)| r)
     }
 
     pub fn handles(&self, area: Rect) -> Vec<SplitHandle> {

--- a/crates/term-wm-core/src/layout/tiling.rs
+++ b/crates/term-wm-core/src/layout/tiling.rs
@@ -245,6 +245,8 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
         true
     }
 
+    /// Remove a leaf by ID from a Split parent.  Returns false if the node
+    /// itself is a Leaf (caller must handle via `clear_leaf` or similar).
     pub fn remove_leaf(&mut self, id: Id) -> bool {
         match self {
             LayoutNode::Leaf(_) => false,
@@ -306,6 +308,17 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
                 }
                 removed
             }
+        }
+    }
+
+    /// If this node is a `Leaf(id)`, replace it with `Void` and return true.
+    /// Useful when `remove_leaf` failed because the target IS the root.
+    pub fn clear_leaf(&mut self, id: Id) -> bool {
+        if matches!(self, LayoutNode::Leaf(current) if *current == id) {
+            *self = LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+            true
+        } else {
+            false
         }
     }
 
@@ -663,7 +676,41 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
 
     pub fn split_root(&mut self, insert: Id, position: InsertPosition) {
         if matches!(self.root, LayoutNode::Void(_)) {
-            self.root = LayoutNode::leaf(insert);
+            let void_id = VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+            self.root = match position {
+                InsertPosition::Left | InsertPosition::TopLeft | InsertPosition::BottomLeft => {
+                    LayoutNode::Split {
+                        direction: Direction::Horizontal,
+                        children: vec![LayoutNode::leaf(insert), LayoutNode::Void(void_id)],
+                        weights: vec![1.0, 1.0],
+                        constraints: Vec::new(),
+                        resizable: true,
+                    }
+                }
+                InsertPosition::Right | InsertPosition::TopRight | InsertPosition::BottomRight => {
+                    LayoutNode::Split {
+                        direction: Direction::Horizontal,
+                        children: vec![LayoutNode::Void(void_id), LayoutNode::leaf(insert)],
+                        weights: vec![1.0, 1.0],
+                        constraints: Vec::new(),
+                        resizable: true,
+                    }
+                }
+                InsertPosition::Top => LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![LayoutNode::leaf(insert), LayoutNode::Void(void_id)],
+                    weights: vec![1.0, 1.0],
+                    constraints: Vec::new(),
+                    resizable: true,
+                },
+                InsertPosition::Bottom => LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![LayoutNode::Void(void_id), LayoutNode::leaf(insert)],
+                    weights: vec![1.0, 1.0],
+                    constraints: Vec::new(),
+                    resizable: true,
+                },
+            };
             return;
         }
         self.root = match position {
@@ -920,7 +967,13 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
         let mut root = self.root.clone();
         // Cull stale leaf before re-insertion — the window may still be in
         // the tree (detach_to_floating does not remove it).
-        root.remove_leaf(insert);
+        let removed = root.remove_leaf(insert);
+        if !removed && matches!(&root, LayoutNode::Leaf(id) if *id == insert) {
+            // The tree is a single leaf matching insert — cannot remove a
+            // leaf from itself.  Replace with Void so split_root doesn't
+            // create duplicate entries.
+            root = LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+        }
         let success = match target {
             Some(t) => root.insert_leaf(t, insert, position),
             None => false,

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -178,6 +178,9 @@ where
                     SystemTask::DragSnap => {
                         app.wm().apply_drag_snap_if_pending();
                     }
+                    SystemTask::TemporalDwellTick => {
+                        app.wm().on_temporal_dwell_tick();
+                    }
                 }
             }
 

--- a/crates/term-wm-core/src/window/entry.rs
+++ b/crates/term-wm-core/src/window/entry.rs
@@ -32,6 +32,9 @@ pub struct Window {
     /// System windows are kept in the SlotMap after close so they can
     /// be shown again later (debug log, help overlay, etc.).
     pub is_system_window: bool,
+    /// Decoupled maximization state flag.  Set when the window is maximized,
+    /// cleared when restored.  Must NOT be derived from geometry comparison.
+    pub is_maximized: bool,
     /// The renderable component. Every window has one.
     /// For chrome-only windows, use `NoopComponent`.
     pub component: Box<dyn Component<TermWmAction>>,
@@ -48,6 +51,7 @@ impl Window {
             creation_order,
             direct_mode: false,
             is_system_window: false,
+            is_maximized: false,
             component,
         }
     }

--- a/crates/term-wm-core/src/window/window_manager/chrome.rs
+++ b/crates/term-wm-core/src/window/window_manager/chrome.rs
@@ -31,16 +31,25 @@ impl WindowManager {
         });
         if let Some(current) = self.floating_rect(key) {
             if current == full {
+                // Unmaximize: restore previous geometry
                 if let Some(prev) = self.take_prev_floating_rect(key) {
                     self.set_floating_rect(key, Some(prev));
                 }
+                if let Some(w) = self.windows.get_mut(key) {
+                    w.is_maximized = false;
+                }
             } else {
+                // Maximize: save current and expand
                 self.set_prev_floating_rect(key, Some(current));
                 self.set_floating_rect(key, Some(full));
+                if let Some(w) = self.windows.get_mut(key) {
+                    w.is_maximized = true;
+                }
             }
             self.bring_floating_to_front_key(key);
             return;
         }
+        // Tiled window → detach and maximize
         let prev_rect = if let Some(rect) = self.regions.get(key) {
             FloatRectSpec::Absolute(crate::window::FloatRect {
                 x: rect.x,
@@ -56,8 +65,15 @@ impl WindowManager {
                 height: 100,
             }
         };
+
+        // Purge from tiling tree before expanding to floating full-screen
+        self.detach_from_tiling_layout(key);
+
         self.set_prev_floating_rect(key, Some(prev_rect));
         self.set_floating_rect(key, Some(full));
+        if let Some(w) = self.windows.get_mut(key) {
+            w.is_maximized = true;
+        }
         self.bring_floating_to_front_key(key);
     }
 

--- a/crates/term-wm-core/src/window/window_manager/drag.rs
+++ b/crates/term-wm-core/src/window/window_manager/drag.rs
@@ -1,9 +1,15 @@
 use crate::Rect;
-use term_wm_layout_engine::{EdgeResistance, LayoutRect, detect_quadrant};
+use term_wm_layout_engine::{EdgeResistance, LayoutRect, detect_corner_snap, detect_edge_snap};
 
-use super::WindowManager;
+use super::{SnapPreviewState, WindowManager};
 use crate::layout::InsertPosition;
 use crate::window::WindowKey;
+
+/// Cells from screen edge that triggers edge-snap preview.
+const EDGE_SNAP_THRESHOLD: u16 = 3;
+
+/// Cells from screen corner that triggers corner-snap preview.
+const CORNER_SNAP_THRESHOLD: u16 = 6;
 
 impl WindowManager {
     pub(super) fn focus_window_at(&mut self, column: u16, row: u16) -> bool {
@@ -20,6 +26,7 @@ impl WindowManager {
         true
     }
 
+    #[allow(dead_code)]
     pub(super) fn detach_to_floating(&mut self, key: WindowKey, rect: Rect) -> bool {
         if self.is_window_floating(key) {
             return true;
@@ -27,6 +34,9 @@ impl WindowManager {
         if self.managed_layout.is_none() {
             return false;
         }
+
+        // Purge the window from the tiling tree before marking it floating
+        self.detach_from_tiling_layout(key);
 
         let width = rect.width.max(1);
         let height = rect.height.max(1);
@@ -64,6 +74,8 @@ impl WindowManager {
         start_mouse_y: u16,
         initial_x: i32,
         initial_y: i32,
+        velocity_exceeded: bool,
+        resistance: &mut EdgeResistance,
     ) {
         let panel_active = self.panel_active();
         let bounds = self.managed_area;
@@ -81,14 +93,30 @@ impl WindowManager {
             y = bounds_y;
         }
 
-        let mut resistance = EdgeResistance::default_tui();
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+
         let bounds_layout = LayoutRect {
             x: bounds.x,
             y: bounds.y,
             width: bounds.width,
             height: bounds.height,
         };
-        let x = resistance.apply_x(x, bounds_layout);
+
+        // Skip magnetic snapping if velocity threshold exceeded
+        let x = if velocity_exceeded {
+            x
+        } else {
+            resistance.apply_x(x, bounds_layout, now_ns)
+        };
+
+        let y = if velocity_exceeded {
+            y
+        } else {
+            resistance.apply_y(y, bounds_layout, now_ns)
+        };
 
         self.set_floating_rect(
             key,
@@ -104,87 +132,167 @@ impl WindowManager {
         self.mark_layout_dirty();
     }
 
+    /// Check the BSP projection cache, and if missing, perform a dry-run
+    /// insert into a cloned layout tree and cache the result.
+    /// Returns the exact `Rect` the inserted leaf would occupy.
+    fn get_projected_preview(
+        &mut self,
+        dragging_key: WindowKey,
+        state: SnapPreviewState,
+        area: Rect,
+    ) -> Option<Rect> {
+        if let Some((s, a, r)) = &self.snap_projection_cache
+            && *s == state
+            && *a == area
+        {
+            return *r;
+        }
+        let rect = match state {
+            SnapPreviewState::Corner(pos) | SnapPreviewState::Edge(pos) => self
+                .managed_layout
+                .as_ref()
+                .and_then(|layout| layout.project_insert(None, dragging_key, pos, area)),
+            SnapPreviewState::TiledInsert(target_key, pos) => {
+                self.managed_layout.as_ref().and_then(|layout| {
+                    layout.project_insert(Some(target_key), dragging_key, pos, area)
+                })
+            }
+            SnapPreviewState::VoidInsert(void_id) => self
+                .managed_layout
+                .as_ref()
+                .and_then(|layout| layout.project_insert_void(dragging_key, void_id, area)),
+            SnapPreviewState::Maximize => None,
+        };
+        self.snap_projection_cache = Some((state, area, rect));
+        rect
+    }
+
+    /// Update the snap preview state during a drag operation.
+    ///
+    /// Spatial priority order (smallest region first):
+    /// 1. Corner snap (TopLeft/TopRight/BottomLeft/BottomRight)
+    /// 2. Sacred top edge maximize (y=0, deferred to release)
+    /// 3. Edge snap (Left/Right/Top/Bottom half-screen) — checked first
+    ///    when cursor is near a screen edge, even if inside a tiled window
+    /// 4. Tiled insert (quadrant-based) — when inside a tiled window
+    ///    but NOT near a screen edge
+    /// 5. Void region (Snap Assist receptacle)
+    /// 6. Edge snap fallback — when not inside any window
+    ///
+    /// `detach_coordinate` is passed separately for post-decouple suppression
+    /// (self.mouse_capture is `None` during the extract-operate-restore cycle).
     pub(super) fn update_snap_preview(
         &mut self,
         dragging_key: WindowKey,
         mouse_x: u16,
         mouse_y: u16,
+        detach_coordinate: &mut Option<(u16, u16)>,
     ) {
-        self.drag_snap = None;
         let area = self.managed_area;
 
-        let target = self.z_order.iter().rev().find_map(|&key| {
-            if key == dragging_key {
-                return None;
+        // Post-decouple suppression: if detach_coordinate is set, suppress all
+        // snap previews until the cursor moves 2+ cells from the decouple point.
+        const SUPPRESS_THRESHOLD_SQ: u32 = 2 * 2;
+        if let Some((decouple_x, decouple_y)) = *detach_coordinate {
+            let dx = u32::from(mouse_x.abs_diff(decouple_x));
+            let dy = u32::from(mouse_y.abs_diff(decouple_y)).saturating_mul(2);
+            let dist_sq = dx.saturating_mul(dx).saturating_add(dy.saturating_mul(dy));
+            if dist_sq < SUPPRESS_THRESHOLD_SQ {
+                // Keep existing snap state visible — don't clear
+                return;
             }
-            if self.managed_layout.is_some() && self.is_window_floating(key) {
-                return None;
-            }
-            let rect = self.regions.get(key)?;
-            if crate::layout::rect_contains(rect, mouse_x, mouse_y) {
-                Some((key, rect))
-            } else {
-                None
-            }
-        });
-
-        if let Some((target_key, rect)) = target {
-            let target_layout = LayoutRect {
-                x: rect.x,
-                y: rect.y,
-                width: rect.width,
-                height: rect.height,
-            };
-
-            let quadrant = detect_quadrant(mouse_x, mouse_y, &target_layout);
-            let pos = match quadrant {
-                term_wm_layout_engine::Quadrant::East => InsertPosition::Right,
-                term_wm_layout_engine::Quadrant::West => InsertPosition::Left,
-                term_wm_layout_engine::Quadrant::North => InsertPosition::Top,
-                term_wm_layout_engine::Quadrant::South => InsertPosition::Bottom,
-            };
-
-            let engine_preview = term_wm_layout_engine::tiled_preview_rect(target_layout, pos);
-            let preview = Rect {
-                x: engine_preview.x,
-                y: engine_preview.y,
-                width: engine_preview.width,
-                height: engine_preview.height,
-            };
-
-            self.drag_snap = Some((Some(target_key), pos, preview));
-            return;
+            *detach_coordinate = None;
         }
 
-        let managed_layout = LayoutRect {
+        let managed_layout_rect = LayoutRect {
             x: area.x,
             y: area.y,
             width: area.width,
             height: area.height,
         };
 
-        let position = term_wm_layout_engine::detect_edge_snap(mouse_x, mouse_y, managed_layout, 2);
-
-        if let Some(pos) = position {
-            let engine_preview = term_wm_layout_engine::edge_preview_rect(managed_layout, pos);
-            let mut preview = Rect {
-                x: engine_preview.x,
-                y: engine_preview.y,
-                width: engine_preview.width,
-                height: engine_preview.height,
-            };
-
-            if self.managed_layout.is_none() {
-                preview = area;
-            }
-
-            self.drag_snap = Some((None, pos, preview));
+        // Priority 1: Corner snap (smallest spatial region)
+        if let Some(corner_pos) =
+            detect_corner_snap(mouse_x, mouse_y, managed_layout_rect, CORNER_SNAP_THRESHOLD)
+        {
+            let preview = self
+                .get_projected_preview(dragging_key, SnapPreviewState::Corner(corner_pos), area)
+                .unwrap_or_else(|| {
+                    let ep =
+                        term_wm_layout_engine::corner_preview_rect(managed_layout_rect, corner_pos);
+                    Rect {
+                        x: ep.x,
+                        y: ep.y,
+                        width: ep.width,
+                        height: ep.height,
+                    }
+                });
+            self.drag_snap = Some((None, corner_pos, preview));
+            self.snap_preview = Some(SnapPreviewState::Corner(corner_pos));
+            return;
         }
+
+        // Priority 2: Sacred top edge — full-screen maximize (deferred to release)
+        if mouse_y == 0 {
+            self.drag_snap = Some((None, InsertPosition::Top, area));
+            self.snap_preview = Some(SnapPreviewState::Maximize);
+            return;
+        }
+
+        // Priority 3: Edge snap
+        if let Some(pos) =
+            detect_edge_snap(mouse_x, mouse_y, managed_layout_rect, EDGE_SNAP_THRESHOLD)
+        {
+            let preview = self
+                .get_projected_preview(dragging_key, SnapPreviewState::Edge(pos), area)
+                .unwrap_or_else(|| {
+                    let ep = term_wm_layout_engine::edge_preview_rect(managed_layout_rect, pos);
+                    Rect {
+                        x: ep.x,
+                        y: ep.y,
+                        width: ep.width,
+                        height: ep.height,
+                    }
+                });
+            let preview = if self.managed_layout.is_none() {
+                area
+            } else {
+                preview
+            };
+            self.drag_snap = Some((None, pos, preview));
+            self.snap_preview = Some(SnapPreviewState::Edge(pos));
+            return;
+        }
+
+        // No snap target — clear preview
+        self.drag_snap = None;
+        self.snap_preview = None;
     }
 
     pub(super) fn apply_snap(&mut self, key: WindowKey) {
         use crate::layout::LayoutNode;
         if let Some((target, position, preview)) = self.drag_snap.take() {
+            // Void snap: replace the void placeholder in the BSP tree
+            if let Some(SnapPreviewState::VoidInsert(void_id)) = self.snap_preview {
+                if self.is_window_floating(key) {
+                    self.clear_floating_rect(key);
+                }
+                if let Some(layout) = &mut self.managed_layout {
+                    layout.root_mut().remove_leaf(key);
+                    layout.root_mut().cleanup_after_removal();
+                    layout
+                        .root_mut()
+                        .replace_void_by_id(void_id, LayoutNode::leaf(key));
+                }
+                if let Some(pos) = self.z_order.iter().position(|&z_key| z_key == key) {
+                    self.z_order.remove(pos);
+                }
+                self.z_order.push(key);
+                self.managed_draw_order = self.z_order.clone();
+                self.snap_projection_cache = None;
+                return;
+            }
+
             let other_windows_exist = if let Some(layout) = &self.managed_layout {
                 !layout.regions(self.managed_area).is_empty()
             } else {
@@ -221,6 +329,7 @@ impl WindowManager {
                 };
                 if should_retile {
                     layout.root_mut().remove_leaf(key);
+                    layout.root_mut().cleanup_after_removal();
                 } else {
                     self.bring_to_front_key(key);
                     return;
@@ -257,6 +366,7 @@ impl WindowManager {
             } else {
                 self.managed_layout = Some(crate::layout::TilingLayout::new(LayoutNode::leaf(key)));
             }
+            self.snap_projection_cache = None;
 
             let mut pending_snap = Vec::new();
             for r_key in self.regions.ids() {

--- a/crates/term-wm-core/src/window/window_manager/drag.rs
+++ b/crates/term-wm-core/src/window/window_manager/drag.rs
@@ -330,6 +330,10 @@ impl WindowManager {
                 if should_retile {
                     layout.root_mut().remove_leaf(key);
                     layout.root_mut().cleanup_after_removal();
+                    // If the tree was a single leaf matching key, remove_leaf
+                    // cannot remove it (Leaf nodes return false).  Clear it
+                    // explicitly so split_root doesn't create duplicates.
+                    layout.root_mut().clear_leaf(key);
                 } else {
                     self.bring_to_front_key(key);
                     return;

--- a/crates/term-wm-core/src/window/window_manager/drag.rs
+++ b/crates/term-wm-core/src/window/window_manager/drag.rs
@@ -397,7 +397,11 @@ impl WindowManager {
             self.focus_window_key(key);
             return true;
         }
-        if self.managed_layout.is_none() {
+        let is_void = self
+            .managed_layout
+            .as_ref()
+            .is_some_and(|l| matches!(l.root(), crate::layout::LayoutNode::Void(_)));
+        if self.managed_layout.is_none() || is_void {
             self.managed_layout = Some(crate::layout::TilingLayout::new(LayoutNode::leaf(key)));
             self.focus_window_key(key);
             return true;

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -42,10 +42,6 @@ impl WindowManager {
     }
 
     pub fn focus_app_window(&mut self, key: WindowKey) {
-        let prev = *self.focus.current();
-        if prev != key {
-            self.unmaximize_window(prev);
-        }
         self.focus.set_current(key);
         self.bring_to_front_key(key);
         self.managed_draw_order = self.z_order.clone();
@@ -53,18 +49,15 @@ impl WindowManager {
     }
 
     pub fn focus_window_key(&mut self, key: WindowKey) {
-        // If another window was maximized (full-screen floating), restore it
-        // so the newly-focused window isn't hidden behind it.
-        let prev = *self.focus.current();
-        if prev != key {
-            self.unmaximize_window(prev);
-        }
+        // Focus shifts must not mutate geometry — maximized floating windows
+        // retain their size regardless of Z-order changes.
         self.focus.set_current(key);
         self.bring_to_front_key(key);
         self.managed_draw_order = self.z_order.clone();
         self.mark_layout_dirty();
     }
 
+    #[expect(dead_code)]
     pub(super) fn unmaximize_window(&mut self, key: WindowKey) {
         use crate::window::FloatRectSpec;
         let full = FloatRectSpec::Absolute(crate::window::FloatRect {
@@ -80,6 +73,9 @@ impl WindowManager {
                 self.set_floating_rect(key, Some(prev));
             } else {
                 self.clear_floating_rect(key);
+            }
+            if let Some(w) = self.windows.get_mut(key) {
+                w.is_maximized = false;
             }
         }
     }

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -684,6 +684,7 @@ impl WindowManager {
     pub(super) fn detach_from_tiling_layout(&mut self, key: WindowKey) {
         if let Some(ref mut layout) = self.managed_layout {
             let _ = layout.root_mut().remove_leaf(key);
+            layout.root_mut().cleanup_after_removal();
         }
     }
 

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -685,6 +685,10 @@ impl WindowManager {
         if let Some(ref mut layout) = self.managed_layout {
             let _ = layout.root_mut().remove_leaf(key);
             layout.root_mut().cleanup_after_removal();
+            // If the tree was a single leaf matching key, remove_leaf
+            // cannot remove it.  Clear it explicitly to prevent stale
+            // leaves from persisting in the tree.
+            layout.root_mut().clear_leaf(key);
         }
     }
 

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -1095,7 +1095,14 @@ impl WindowManager {
                             // NOT detach it again.
                             self.snap_preview = None;
                             self.snap_projection_cache = None;
-                            self.last_header_click = None;
+                            // Only clear the double-click timer if a drag actually
+                            // occurred.  A click-only release preserves the timer so
+                            // a subsequent click can still be detected as a
+                            // double-click (toggle maximize).
+                            let drag_dist = col.abs_diff(*anchor_x) + row.abs_diff(*anchor_y);
+                            if drag_dist > 0 {
+                                self.last_header_click = None;
+                            }
                             (true, false)
                         }
                         MouseEventKind::Moved if self.drag_snap.is_some() => {

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2949,11 +2949,9 @@ mod tests {
         });
         let wm_down = crate::events::core_event_to_wm(&down).unwrap();
         assert!(wm.dispatch_mouse(&wm_down));
-        assert!(wm.is_window_floating(debug_key));
-        let start_rect = match wm.floating_rect(debug_key).expect("floating rect present") {
-            crate::window::FloatRectSpec::Absolute(fr) => fr,
-            _ => panic!("expected absolute rect"),
-        };
+        // Floating rect is deferred — Press alone must not decouple.
+        assert!(!wm.is_window_floating(debug_key));
+        let start_rect = wm.full_region(debug_key);
 
         let drag_col = header_rect.x.saturating_add(5) as u16;
         let drag_row = header_rect.y.saturating_add(1) as u16;
@@ -2965,6 +2963,7 @@ mod tests {
         });
         let wm_drag = crate::events::core_event_to_wm(&drag).unwrap();
         assert!(wm.dispatch_mouse(&wm_drag));
+        assert!(wm.is_window_floating(debug_key));
 
         let moved = match wm.floating_rect(debug_key).expect("floating rect present") {
             crate::window::FloatRectSpec::Absolute(fr) => fr,

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -39,18 +39,39 @@ use term_wm_layout_engine::{LayoutRect, apply_resize_drag_signed};
 /// Locked on `Press` via registry hit-test; all subsequent `Drag`/`Release`
 /// events route through this state, bypassing the registry entirely.
 /// Cleared on `Release`, lost focus, or timeout.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone)]
 pub(crate) enum MouseCaptureState {
     DraggingWindow {
         key: WindowKey,
+        /// Persistent edge-resistance state, stored here so that temporal
+        /// threshold and hysteresis work across frames (not stack-allocated).
+        resistance: term_wm_layout_engine::EdgeResistance,
+        /// Column at press time, used for deadzone-based detach guard.
+        anchor_x: u16,
+        /// Row at press time, used for deadzone-based detach guard.
+        anchor_y: u16,
         initial_x: i32,
         initial_y: i32,
         start_x: u16,
         start_y: u16,
+        /// Previous mouse column for velocity calculation.
+        prev_col: u16,
+        /// Previous mouse row for velocity calculation.
+        prev_row: u16,
+        /// Raw nanosecond timestamp of the previous drag event.
+        prev_time_ns: u64,
+        /// Cursor position at the moment the drag decoupled from tiling,
+        /// used to suppress snap previews for a short distance after decouple.
+        detach_coordinate: Option<(u16, u16)>,
+        /// Whether `apply_snap` has already committed the window to the
+        /// tiling tree.  Guards against double-detach when `Release`
+        /// fires after a `Moved`-triggered snap.
+        snap_applied: bool,
     },
     ResizingWindow {
         key: WindowKey,
         edge: ResizeEdge,
+        #[allow(dead_code)]
         start_rect: Rect,
         start_col: u16,
         start_row: u16,
@@ -65,6 +86,24 @@ pub(crate) enum MouseCaptureState {
     /// A Press hit a tiling layout split handle — Drag/Release events route to
     /// `TilingLayout::handle_event()` for split-ratio adjustment.
     LayoutHandle,
+}
+
+/// Preview state for ghost window rendering during drag operations.
+/// Evaluated in spatial priority order (smallest region first).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapPreviewState {
+    /// Corner quarter-screen snap (TopLeft/TopRight/BottomLeft/BottomRight).
+    Corner(InsertPosition),
+    /// Sacred top edge — full-screen maximize on release (preview only during drag).
+    Maximize,
+    /// Edge snap to left/right/bottom half-screen.
+    Edge(InsertPosition),
+    /// Tiled insert next to an existing window (quadrant-based).
+    #[allow(dead_code)]
+    TiledInsert(WindowKey, InsertPosition),
+    /// Drop into an empty void placeholder (stores void ID).
+    #[allow(dead_code)]
+    VoidInsert(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -196,6 +235,8 @@ pub struct WindowManager {
     super_timer_id: Option<TaskId>,
     /// ID of the drag-snap timer in the TaskScheduler, for cancellation.
     drag_timer_id: Option<TaskId>,
+    /// ID of the temporal-dwell tick timer, for cancellation and guard.
+    temporal_timer_id: Option<TaskId>,
     /// Handle to the shared `TaskScheduler<SystemTask>` for registering/cancelling
     /// system-level timers (super-passthrough, drag-snap).
     system_task_handle: Option<TaskHandle<SystemTask>>,
@@ -205,6 +246,11 @@ pub struct WindowManager {
     floating_resize_offscreen: bool,
     pub(crate) z_order: Vec<WindowKey>,
     pub(crate) drag_snap: Option<(Option<WindowKey>, InsertPosition, Rect)>,
+    /// Active snap preview state for ghost window rendering during drag.
+    pub(crate) snap_preview: Option<SnapPreviewState>,
+    /// Cache for BSP dry-run projection to avoid deep-cloning the layout
+    /// tree on every drag frame. Keyed by (target, position, area).
+    snap_projection_cache: Option<(SnapPreviewState, Rect, Option<Rect>)>,
     drag_last_event: Option<Instant>,
     // No separate component map — components live on the Window struct
     // in the SlotMap.  See `Window.component`.
@@ -498,7 +544,7 @@ impl WindowManager {
         }
     }
 
-    pub(crate) fn with_config(
+    pub fn with_config(
         config: WmConfig,
         app_ctx: Arc<AppContext>,
         top_component: Option<Box<dyn WmComponent>>,
@@ -569,6 +615,7 @@ impl WindowManager {
             super_pending_at: None,
             super_timer_id: None,
             drag_timer_id: None,
+            temporal_timer_id: None,
             system_task_handle: None,
             last_frame_area: Rect::default(),
             overlays: BTreeMap::new(),
@@ -576,6 +623,8 @@ impl WindowManager {
             floating_resize_offscreen,
             z_order: Vec::new(),
             drag_snap: None,
+            snap_preview: None,
+            snap_projection_cache: None,
             drag_last_event: None,
             next_window_seq: 0,
             next_title_seq: 0,
@@ -758,8 +807,21 @@ impl WindowManager {
 
     /// Return the currently hovered tiling split handle, if any.
     pub fn hovered_tiling_handle(&self) -> Option<crate::layout::tiling::SplitHandle> {
-        let area = self.managed_area;
-        self.managed_layout.as_ref()?.hovered_handle(area)
+        let (col, row) = self.hover?;
+        let pos = crate::mouse_coord::MousePosition {
+            column: col as i16,
+            row: row as i16,
+            space: crate::mouse_coord::CoordSpace::Screen,
+        };
+        if let Some((crate::hitbox_registry::HitTarget::LayoutHandle, _)) =
+            self.hitbox_registry.hit_test(pos)
+        {
+            self.managed_layout
+                .as_ref()?
+                .hovered_handle(self.managed_area)
+        } else {
+            None
+        }
     }
 
     /// Return the currently hovered floating resize handle, if any.
@@ -802,6 +864,26 @@ impl WindowManager {
         &self,
     ) -> &Option<(Option<WindowKey>, crate::layout::InsertPosition, Rect)> {
         &self.drag_snap
+    }
+
+    /// Return the target window key for dimming during a tiled-insert snap
+    /// preview, if the preview is currently active.
+    pub fn snap_preview_target_key(&self) -> Option<WindowKey> {
+        match self.snap_preview {
+            Some(SnapPreviewState::TiledInsert(key, _)) => Some(key),
+            _ => None,
+        }
+    }
+
+    /// Return a human-readable label for the current snap preview action.
+    pub fn snap_preview_action_label(&self) -> Option<&'static str> {
+        self.snap_preview.as_ref().map(|s| match s {
+            SnapPreviewState::Maximize => "maximize",
+            SnapPreviewState::Edge(_) => "snap to edge",
+            SnapPreviewState::Corner(_) => "snap to corner",
+            SnapPreviewState::TiledInsert(_, _) => "tile",
+            SnapPreviewState::VoidInsert(_) => "fill void",
+        })
     }
 
     /// Return floating pane info for rendering (key + rect).
@@ -847,6 +929,7 @@ impl WindowManager {
     ///   Phase 3 — Unhandled events fall through to false.
     ///
     /// Returns `true` if the event was consumed.
+    #[allow(clippy::collapsible_if)]
     pub fn dispatch_mouse(&mut self, event: &crate::events::WmEvent) -> bool {
         use crate::events::WmEvent;
         use crate::window::decorator::HeaderAction;
@@ -861,154 +944,260 @@ impl WindowManager {
         let col = position.column as u16;
         let row = position.row as u16;
 
-        // Phase 1 — Active capture: ongoing drag/resize/component-interaction
-        // bypasses the registry entirely.
-        if !matches!(kind, MouseEventKind::Press(_))
-            && let Some(capture) = self.mouse_capture
-        {
-            return match (capture, kind) {
-                (
+        // Phase 1 — Active capture: extract-operate-restore pattern.
+        if !matches!(kind, MouseEventKind::Press(_)) {
+            if let Some(mut capture) = self.mouse_capture.take() {
+                let (result, restore) = match &mut capture {
                     MouseCaptureState::DraggingWindow {
                         key,
+                        resistance,
+                        anchor_x,
+                        anchor_y,
                         initial_x,
                         initial_y,
                         start_x,
                         start_y,
-                    },
-                    MouseEventKind::Drag(_),
-                ) => {
-                    self.drag_last_event = Some(Instant::now());
-                    self.reset_drag_snap_timer();
-                    if self.is_window_floating(key) {
-                        self.move_floating(key, col, row, start_x, start_y, initial_x, initial_y);
-                        let dx = col.abs_diff(start_x);
-                        let dy = row.abs_diff(start_y);
-                        if dx + dy > 2 {
-                            self.update_snap_preview(key, col, row);
-                        } else {
-                            self.drag_snap = None;
+                        prev_col,
+                        prev_row,
+                        prev_time_ns,
+                        detach_coordinate,
+                        snap_applied,
+                    } => match kind {
+                        MouseEventKind::Drag(_) => {
+                            let dx = col.abs_diff(*anchor_x);
+                            let dy = row.abs_diff(*anchor_y);
+                            let is_maximized =
+                                self.windows.get(*key).is_some_and(|w| w.is_maximized);
+
+                            if dx + dy <= 2 {
+                                // Deadzone guard: ignore micro-nudges
+                                (true, true)
+                            } else if is_maximized && !(row > *anchor_y && row - *anchor_y > 2) {
+                                // Maximized and not pulling down — consume event, keep capture
+                                (true, true)
+                            } else {
+                                // Downward-drag restore for maximized windows
+                                if is_maximized {
+                                    self.toggle_maximize(*key);
+                                    if let Some(crate::window::FloatRectSpec::Absolute(fr)) =
+                                        self.floating_rect(*key)
+                                    {
+                                        *initial_x = fr.x;
+                                        *initial_y = fr.y;
+                                        *start_x = col;
+                                        *start_y = row;
+                                        *prev_col = col;
+                                        *prev_row = row;
+                                    }
+                                }
+
+                                if detach_coordinate.is_none() {
+                                    // Defer setting detach_coordinate until after
+                                    // update_snap_preview runs, so the first Drag
+                                    // event is not suppressed.
+                                }
+
+                                self.drag_last_event = Some(Instant::now());
+                                self.reset_drag_snap_timer();
+
+                                // If the window is not yet floating, this is the
+                                // first Drag event that breached the kinetic
+                                // deadzone — install the floating rect now.
+                                // start_x/start_y/initial_x/initial_y were
+                                // already set at Press time and must NOT be
+                                // touched here — they anchor the cursor-to-
+                                // window offset for move_floating.
+                                if !self.is_window_floating(*key) {
+                                    let rect = self.visible_region_for_key(*key);
+                                    self.set_floating_rect(
+                                        *key,
+                                        Some(crate::window::FloatRectSpec::Absolute(
+                                            crate::window::FloatRect {
+                                                x: rect.x,
+                                                y: rect.y,
+                                                width: rect.width.max(1),
+                                                height: rect.height.max(1),
+                                            },
+                                        )),
+                                    );
+                                    self.bring_to_front_key(*key);
+                                }
+
+                                if self.is_window_floating(*key) {
+                                    let dx = col.abs_diff(*prev_col);
+                                    let dy = row.abs_diff(*prev_row);
+                                    let now_ns = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_nanos() as u64)
+                                        .unwrap_or(*prev_time_ns);
+                                    let dt_ns = now_ns.saturating_sub(*prev_time_ns).max(1_000_000);
+                                    let dy_weighted = u32::from(dy).saturating_mul(2);
+                                    let dist_sq = u32::from(dx)
+                                        .saturating_mul(u32::from(dx))
+                                        .saturating_add(dy_weighted.saturating_mul(dy_weighted));
+                                    let threshold_cells_sq = 10u64.saturating_mul(10);
+                                    let threshold_time_sq =
+                                        100_000_000u64.saturating_mul(100_000_000);
+                                    let velocity_exceeded = u64::from(dist_sq)
+                                        .saturating_mul(threshold_time_sq)
+                                        > threshold_cells_sq
+                                            .saturating_mul(dt_ns.saturating_mul(dt_ns));
+                                    self.move_floating(
+                                        *key,
+                                        col,
+                                        row,
+                                        *start_x,
+                                        *start_y,
+                                        *initial_x,
+                                        *initial_y,
+                                        velocity_exceeded,
+                                        resistance,
+                                    );
+                                    let dx_total = col.abs_diff(*start_x);
+                                    let dy_total = row.abs_diff(*start_y);
+                                    if dx_total + dy_total > 2 {
+                                        self.update_snap_preview(*key, col, row, detach_coordinate);
+                                    } else {
+                                        self.drag_snap = None;
+                                    }
+                                    // Set detach_coordinate AFTER snap preview runs
+                                    if detach_coordinate.is_none() {
+                                        *detach_coordinate = Some((col, row));
+                                    }
+                                    *prev_col = col;
+                                    *prev_row = row;
+                                    *prev_time_ns = now_ns;
+                                }
+                                (true, true)
+                            }
                         }
-                    }
-                    true
-                }
-                (MouseCaptureState::DraggingWindow { .. }, MouseEventKind::Release(_)) => {
-                    self.cancel_drag_snap_timer();
-                    self.drag_last_event = None;
-                    if let Some(capture) = self.mouse_capture.take()
-                        && let MouseCaptureState::DraggingWindow { key, .. } = capture
-                        && self.drag_snap.is_some()
-                    {
-                        self.apply_snap(key);
-                    }
-                    true
-                }
-                (MouseCaptureState::DraggingWindow { .. }, MouseEventKind::Moved)
-                    if self.drag_snap.is_some() =>
-                {
-                    // Mouse re-entered the terminal after being released outside
-                    // during a header drag (no Release event was delivered).
-                    self.cancel_drag_snap_timer();
-                    self.drag_last_event = None;
-                    if let Some(capture) = self.mouse_capture.take()
-                        && let MouseCaptureState::DraggingWindow { key, .. } = capture
-                    {
-                        self.apply_snap(key);
-                    }
-                    true
-                }
-                (
+                        MouseEventKind::Release(_) => {
+                            self.cancel_drag_snap_timer();
+                            self.drag_last_event = None;
+                            if self.snap_preview == Some(SnapPreviewState::Maximize) {
+                                self.toggle_maximize(*key);
+                                self.drag_snap = None;
+                                self.snap_preview = None;
+                            } else if self.drag_snap.is_some() {
+                                // Snap target found — apply snap (removes from
+                                // tiling tree and inserts at snap position)
+                                self.apply_snap(*key);
+                            } else if !*snap_applied {
+                                // Only detach if the user actually dragged the
+                                // window.
+                                let drag_dist = col.abs_diff(*anchor_x) + row.abs_diff(*anchor_y);
+                                if drag_dist > 0 {
+                                    self.detach_from_tiling_layout(*key);
+                                }
+                            }
+                            // else: snap was already applied by Moved handler — the
+                            // window is correctly positioned in the tiling tree; do
+                            // NOT detach it again.
+                            self.snap_preview = None;
+                            self.snap_projection_cache = None;
+                            self.last_header_click = None;
+                            (true, false)
+                        }
+                        MouseEventKind::Moved if self.drag_snap.is_some() => {
+                            self.cancel_drag_snap_timer();
+                            self.drag_last_event = None;
+                            self.apply_snap(*key);
+                            *snap_applied = true;
+                            self.snap_preview = None;
+                            self.snap_projection_cache = None;
+                            (true, true)
+                        }
+                        _ => (false, true),
+                    },
                     MouseCaptureState::ResizingWindow {
                         key,
                         edge,
-                        start_rect: _,
                         start_col,
                         start_row,
                         start_x,
                         start_y,
                         start_width,
                         start_height,
-                    },
-                    MouseEventKind::Drag(_),
-                ) => {
-                    if self.is_window_floating(key) {
-                        let bounds = LayoutRect {
-                            x: self.managed_area.x,
-                            y: self.managed_area.y,
-                            width: self.managed_area.width,
-                            height: self.managed_area.height,
-                        };
-                        let resized = apply_resize_drag_signed(
-                            start_x,
-                            start_y,
-                            start_width,
-                            start_height,
-                            edge,
-                            col,
-                            row,
-                            start_col,
-                            start_row,
-                            bounds,
-                            self.floating_resize_offscreen,
-                        );
-                        self.set_floating_rect(
-                            key,
-                            Some(crate::window::FloatRectSpec::Absolute(resized)),
-                        );
-                    }
-                    true
-                }
-                (MouseCaptureState::ResizingWindow { .. }, MouseEventKind::Release(_)) => {
-                    self.mouse_capture.take();
-                    true
-                }
-                (MouseCaptureState::ComponentInteraction { key }, _) => {
-                    // Forward Drag/Up/Moved to the captured component.
-                    let focused = *self.focus.current() == key;
-                    let mut ctx = self.component_context_for(focused, key);
-                    if let Some(area) = self.hitbox_registry.component_area(key) {
-                        ctx = ctx.with_screen_area(area);
-                    }
-                    let core_event = Event::Mouse(MouseEvent {
-                        kind: *kind,
-                        column: col,
-                        row,
-                        modifiers: *modifiers,
-                    });
-                    let consumed = if let Some(comp) = self.component_for_key_mut(key) {
-                        let result = comp.handle_events(&core_event, &ctx);
-                        let was_consumed = !result.is_ignored();
-                        if let Some(action) = result.into_action() {
-                            self.process_action(key, action);
+                        ..
+                    } => match kind {
+                        MouseEventKind::Drag(_) => {
+                            if self.is_window_floating(*key) {
+                                let bounds = LayoutRect {
+                                    x: self.managed_area.x,
+                                    y: self.managed_area.y,
+                                    width: self.managed_area.width,
+                                    height: self.managed_area.height,
+                                };
+                                let resized = apply_resize_drag_signed(
+                                    *start_x,
+                                    *start_y,
+                                    *start_width,
+                                    *start_height,
+                                    *edge,
+                                    col,
+                                    row,
+                                    *start_col,
+                                    *start_row,
+                                    bounds,
+                                    self.floating_resize_offscreen,
+                                );
+                                self.set_floating_rect(
+                                    *key,
+                                    Some(crate::window::FloatRectSpec::Absolute(resized)),
+                                );
+                            }
+                            (true, true)
                         }
-                        was_consumed
-                    } else {
-                        false
-                    };
-                    if matches!(kind, MouseEventKind::Release(_)) {
-                        self.mouse_capture = None;
+                        MouseEventKind::Release(_) => (true, false),
+                        _ => (false, true),
+                    },
+                    MouseCaptureState::ComponentInteraction { key } => {
+                        let focused = *self.focus.current() == *key;
+                        let mut ctx = self.component_context_for(focused, *key);
+                        if let Some(area) = self.hitbox_registry.component_area(*key) {
+                            ctx = ctx.with_screen_area(area);
+                        }
+                        let core_event = Event::Mouse(MouseEvent {
+                            kind: *kind,
+                            column: col,
+                            row,
+                            modifiers: *modifiers,
+                        });
+                        let consumed = if let Some(comp) = self.component_for_key_mut(*key) {
+                            let result = comp.handle_events(&core_event, &ctx);
+                            let was_consumed = !result.is_ignored();
+                            if let Some(action) = result.into_action() {
+                                self.process_action(*key, action);
+                            }
+                            was_consumed
+                        } else {
+                            false
+                        };
+                        (consumed, !matches!(kind, MouseEventKind::Release(_)))
                     }
-                    consumed
+                    MouseCaptureState::LayoutHandle => match kind {
+                        MouseEventKind::Drag(_) | MouseEventKind::Release(_) => {
+                            let event = Event::Mouse(MouseEvent {
+                                kind: *kind,
+                                column: col,
+                                row,
+                                modifiers: *modifiers,
+                            });
+                            let handled = self
+                                .managed_layout
+                                .as_mut()
+                                .map(|l| l.handle_event(&event, self.managed_area))
+                                .unwrap_or(false);
+                            (handled, !matches!(kind, MouseEventKind::Release(_)))
+                        }
+                        _ => (false, true),
+                    },
+                };
+                if restore {
+                    self.mouse_capture = Some(capture);
                 }
-                (MouseCaptureState::LayoutHandle, MouseEventKind::Drag(_))
-                | (MouseCaptureState::LayoutHandle, MouseEventKind::Release(_)) => {
-                    let event = Event::Mouse(MouseEvent {
-                        kind: *kind,
-                        column: col,
-                        row,
-                        modifiers: *modifiers,
-                    });
-                    let handled = self
-                        .managed_layout
-                        .as_mut()
-                        .map(|l| l.handle_event(&event, self.managed_area))
-                        .unwrap_or(false);
-                    if matches!(kind, MouseEventKind::Release(_)) {
-                        self.mouse_capture = None;
-                    }
-                    handled
-                }
-                _ => false,
-            };
+                return result;
+            }
         }
 
         // Phase 2 — Scroll events: hover-to-scroll to the window under cursor.
@@ -1163,7 +1352,11 @@ impl WindowManager {
                         if self.is_window_floating(key) {
                             self.bring_floating_to_front_key(key);
                         } else {
-                            let _ = self.detach_to_floating(key, rect);
+                            // Defer floating decoupling until the drag deadzone
+                            // is breached.  Capture the pointer now; the floating
+                            // rect will be installed on the first Drag event that
+                            // exceeds the kinetic threshold (dx + dy > 2).
+                            self.bring_to_front_key(key);
                         }
 
                         let (initial_x, initial_y) =
@@ -1176,10 +1369,21 @@ impl WindowManager {
                             };
                         self.mouse_capture = Some(MouseCaptureState::DraggingWindow {
                             key,
+                            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+                            anchor_x: col,
+                            anchor_y: row,
                             initial_x,
                             initial_y,
                             start_x: col,
                             start_y: row,
+                            prev_col: col,
+                            prev_row: row,
+                            prev_time_ns: std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_nanos() as u64)
+                                .unwrap_or(0),
+                            detach_coordinate: None,
+                            snap_applied: false,
                         });
                         self.drag_last_event = Some(Instant::now());
                         self.arm_drag_snap_timer();
@@ -1290,6 +1494,41 @@ impl WindowManager {
             if let Some(timeout) = self.config.drag_snap_timeout {
                 self.drag_timer_id = Some(handle.schedule_once(timeout, SystemTask::DragSnap));
             }
+        }
+    }
+
+    /// Arm a 50ms single-shot timer for temporal-dwell visual feedback.
+    /// Cancels any previously-armed temporal tick before creating a new one.
+    /// The tick handler (on_temporal_dwell_tick) may re-arm for continuous
+    /// cycling while the cursor remains inside the magnetic zone.
+    fn arm_temporal_dwell_timer(&mut self) {
+        if let Some(handle) = &self.system_task_handle {
+            if let Some(old) = self.temporal_timer_id.take() {
+                handle.cancel(old);
+            }
+            self.temporal_timer_id = Some(handle.schedule_once(
+                std::time::Duration::from_millis(50),
+                SystemTask::TemporalDwellTick,
+            ));
+        }
+    }
+
+    /// Called by the runner on each `SystemTask::TemporalDwellTick`.
+    /// If the cursor is still held stationary inside a magnetic zone,
+    /// triggers a render frame and re-arms the 50ms tick.  Otherwise
+    /// stops the cycle.
+    pub fn on_temporal_dwell_tick(&mut self) {
+        let in_magnetic_zone = matches!(
+            &self.mouse_capture,
+            Some(MouseCaptureState::DraggingWindow { resistance, .. })
+                if resistance.entered_magnetic_x_at.is_some()
+                || resistance.entered_magnetic_y_at.is_some()
+        );
+        if in_magnetic_zone {
+            self.mark_layout_dirty();
+            self.arm_temporal_dwell_timer();
+        } else {
+            self.temporal_timer_id = None;
         }
     }
 
@@ -1810,8 +2049,16 @@ impl WindowManager {
         {
             self.drag_last_event = None;
             self.drag_timer_id = None;
-            self.apply_snap(key);
+            if self.snap_preview == Some(SnapPreviewState::Maximize) {
+                self.toggle_maximize(key);
+            } else if self.drag_snap.is_some() {
+                self.apply_snap(key);
+            }
         }
+        // Unconditional flush — prevents stale ghost previews
+        self.drag_snap = None;
+        self.snap_preview = None;
+        self.snap_projection_cache = None;
     }
 
     pub fn super_passthrough_active(&self) -> bool {
@@ -2022,6 +2269,7 @@ fn map_layout_node(node: &LayoutNode<WindowKey>) -> LayoutNode<WindowKey> {
             constraints: constraints.clone(),
             resizable: *resizable,
         },
+        LayoutNode::Void(id) => LayoutNode::Void(*id),
     }
 }
 
@@ -2774,10 +3022,18 @@ mod tests {
         // Simulate abandoned drag (mouse released outside terminal).
         wm.mouse_capture = Some(MouseCaptureState::DraggingWindow {
             key,
+            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+            anchor_x: 15,
+            anchor_y: 10,
             initial_x: 10,
             initial_y: 5,
             start_x: 15,
             start_y: 10,
+            prev_col: 15,
+            prev_row: 10,
+            prev_time_ns: 0,
+            detach_coordinate: None,
+            snap_applied: false,
         });
         wm.drag_snap = Some((
             None,
@@ -2798,11 +3054,189 @@ mod tests {
         });
         let wm_moved = crate::events::core_event_to_wm(&moved).unwrap();
         assert!(wm.dispatch_mouse(&wm_moved));
-        assert!(wm.mouse_capture.is_none(), "mouse_capture should be taken");
+        // Capture is kept alive so Release can clean up properly
+        assert!(
+            wm.mouse_capture.is_some(),
+            "mouse_capture must survive Moved snap commit"
+        );
         assert!(
             wm.drag_snap.is_none(),
             "drag_snap should be consumed by apply_snap"
         );
+    }
+
+    #[test]
+    fn moved_snap_then_release_does_not_corrupt_layout() {
+        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use crate::layout::{Direction, LayoutNode, TilingLayout};
+        use crate::window::{FloatRect, FloatRectSpec};
+
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        wm.set_panel_visible(false);
+        let keys = make_keys(&mut wm, 100);
+
+        // Two-window horizontal tiling layout.
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[1]), LayoutNode::Leaf(keys[2])],
+            weights: vec![1.0, 1.0],
+            constraints: vec![],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        let leaves_before: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
+        assert_eq!(leaves_before.len(), 2, "must start with 2 tiled windows");
+
+        let dragged_key = keys[1];
+        wm.set_floating_rect(
+            dragged_key,
+            Some(FloatRectSpec::Absolute(FloatRect {
+                x: 5,
+                y: 5,
+                width: 30,
+                height: 12,
+            })),
+        );
+
+        wm.mouse_capture = Some(MouseCaptureState::DraggingWindow {
+            key: dragged_key,
+            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+            anchor_x: 10,
+            anchor_y: 10,
+            initial_x: 5,
+            initial_y: 5,
+            start_x: 10,
+            start_y: 10,
+            prev_col: 10,
+            prev_row: 10,
+            prev_time_ns: 0,
+            detach_coordinate: None,
+            snap_applied: false,
+        });
+
+        // Snap target: insert keys[1] to the RIGHT of keys[2].
+        wm.drag_snap = Some((
+            Some(keys[2]),
+            InsertPosition::Right,
+            Rect {
+                x: 40,
+                y: 0,
+                width: 40,
+                height: 24,
+            },
+        ));
+
+        // Phase 1: Moved event fires — applies snap.
+        let moved = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: 5,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let wm_moved = crate::events::core_event_to_wm(&moved).unwrap();
+        assert!(wm.dispatch_mouse(&wm_moved));
+
+        // Capture must still be alive.
+        assert!(
+            wm.mouse_capture.is_some(),
+            "capture must survive Moved snap commit"
+        );
+
+        // Verify snap was applied.
+        assert!(
+            wm.layout_contains(dragged_key),
+            "dragged window must be in tiling tree after Moved snap"
+        );
+        assert!(
+            wm.drag_snap.is_none(),
+            "drag_snap must be consumed by apply_snap"
+        );
+        assert!(
+            wm.snap_preview.is_none(),
+            "snap_preview must be cleared after Moved snap commit"
+        );
+
+        // Verify snap_applied flag was set.
+        match wm.mouse_capture.as_ref() {
+            Some(MouseCaptureState::DraggingWindow { snap_applied, .. }) => {
+                assert!(
+                    *snap_applied,
+                    "snap_applied must be true after Moved commits snap"
+                );
+            }
+            _ => panic!("expected DraggingWindow capture"),
+        }
+
+        // Phase 2: Release event fires — should NOT double-detach.
+        let release = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Release(MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let wm_release = crate::events::core_event_to_wm(&release).unwrap();
+        assert!(wm.dispatch_mouse(&wm_release));
+
+        assert!(
+            wm.mouse_capture.is_none(),
+            "capture must be cleared after Release"
+        );
+
+        // Verify layout is not corrupted: both windows present.
+        let leaves_after: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
+        assert_eq!(
+            leaves_after.len(),
+            2,
+            "layout must still have exactly 2 windows after Moved+Release"
+        );
+        assert!(
+            leaves_after.contains(&keys[1]),
+            "keys[1] must remain in layout"
+        );
+        assert!(
+            leaves_after.contains(&keys[2]),
+            "keys[2] must remain in layout"
+        );
+
+        // Verify regions can be computed without panic.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        let regions = wm.managed_layout.as_ref().unwrap().root().layout(area);
+        assert_eq!(regions.len(), 2, "layout must produce 2 regions");
+
+        // Verify no overlapping regions.
+        for (i, (_, r1)) in regions.iter().enumerate() {
+            for (j, (_, r2)) in regions.iter().enumerate() {
+                if i != j {
+                    assert!(
+                        !rects_intersect(*r1, *r2),
+                        "regions must not overlap: region {} = {:?}, region {} = {:?}",
+                        i,
+                        r1,
+                        j,
+                        r2,
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -3249,10 +3683,18 @@ mod tests {
         let keys = make_keys(&mut wm, 100);
         wm.mouse_capture = Some(MouseCaptureState::DraggingWindow {
             key: keys[1],
+            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+            anchor_x: 0,
+            anchor_y: 0,
             initial_x: 0,
             initial_y: 0,
             start_x: 0,
             start_y: 0,
+            prev_col: 0,
+            prev_row: 0,
+            prev_time_ns: 0,
+            detach_coordinate: None,
+            snap_applied: false,
         });
         wm.drag_last_event = Some(Instant::now());
         let remaining = wm.drag_snap_remaining();
@@ -3273,10 +3715,42 @@ mod tests {
         let keys = make_keys(&mut wm, 100);
         wm.mouse_capture = Some(MouseCaptureState::DraggingWindow {
             key: keys[1],
+            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+            anchor_x: 0,
+            anchor_y: 0,
             initial_x: 0,
             initial_y: 0,
             start_x: 0,
             start_y: 0,
+            prev_col: 0,
+            prev_row: 0,
+            prev_time_ns: 0,
+            detach_coordinate: None,
+            snap_applied: false,
+        });
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let keys = make_keys(&mut wm, 100);
+        wm.mouse_capture = Some(MouseCaptureState::DraggingWindow {
+            key: keys[1],
+            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+            anchor_x: 0,
+            anchor_y: 0,
+            initial_x: 0,
+            initial_y: 0,
+            start_x: 0,
+            start_y: 0,
+            prev_col: 0,
+            prev_row: 0,
+            prev_time_ns: 0,
+            detach_coordinate: None,
+            snap_applied: false,
         });
         wm.drag_last_event = Some(Instant::now() - STALE_EVENT_OFFSET);
         assert_eq!(wm.drag_snap_remaining(), Some(Duration::ZERO));
@@ -3347,10 +3821,18 @@ mod tests {
 
         wm.mouse_capture = Some(MouseCaptureState::DraggingWindow {
             key,
+            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+            anchor_x: 15,
+            anchor_y: 10,
             initial_x: 10,
             initial_y: 5,
             start_x: 15,
             start_y: 10,
+            prev_col: 15,
+            prev_row: 10,
+            prev_time_ns: 0,
+            detach_coordinate: None,
+            snap_applied: false,
         });
         wm.drag_snap = Some((
             Some(window_key),
@@ -4446,9 +4928,8 @@ mod tests {
         }))
         .unwrap();
         wm.dispatch_mouse(&down);
-        assert_eq!(
-            wm.mouse_capture,
-            Some(MouseCaptureState::LayoutHandle),
+        assert!(
+            matches!(wm.mouse_capture, Some(MouseCaptureState::LayoutHandle)),
             "Down on split handle must set LayoutHandle capture"
         );
     }
@@ -4528,7 +5009,10 @@ mod tests {
         }))
         .unwrap();
         wm.dispatch_mouse(&down);
-        assert_eq!(wm.mouse_capture, Some(MouseCaptureState::LayoutHandle));
+        assert!(matches!(
+            wm.mouse_capture,
+            Some(MouseCaptureState::LayoutHandle)
+        ));
 
         // Up
         let up = crate::events::core_event_to_wm(&Event::Mouse(MouseEvent {

--- a/crates/term-wm-layout-engine/src/hit_test.rs
+++ b/crates/term-wm-layout-engine/src/hit_test.rs
@@ -14,11 +14,14 @@ pub fn hit_test_leaf<Id: Copy + Eq + Ord>(
     None
 }
 
-/// Determine which cardinal quadrant of `target` the cursor falls in.
+/// Determine which diagonal quadrant of `target` the cursor falls in.
 ///
-/// Uses integer cross-product logic (no floating-point) to classify:
-/// East/West when `|dx| > |dy|`, North/South when `|dy| > |dx|`,
-/// with a tie-breaker of East for `dx >= 0`.
+/// Uses dimension-scaled cross-product (no floating-point, no sqrt) to
+/// account for the target's aspect ratio.  The comparison
+/// `|dx| * height > |dy| * width` is equivalent to checking whether the
+/// angle from center to cursor is shallower than the true geometric
+/// diagonal `(±height/±width)`, producing equal-area triangular quadrants
+/// regardless of the rectangle's shape.
 pub fn detect_quadrant(cursor_col: u16, cursor_row: u16, target: &LayoutRect) -> Quadrant {
     let (cx, cy) = target.center();
 
@@ -31,25 +34,23 @@ pub fn detect_quadrant(cursor_col: u16, cursor_row: u16, target: &LayoutRect) ->
 
     let adx = dx.unsigned_abs();
     let ady = dy.unsigned_abs();
+    let w = u32::from(target.width);
+    let h = u32::from(target.height);
 
-    if adx > ady {
-        if dx > 0 {
-            Quadrant::East
-        } else {
-            Quadrant::West
-        }
-    } else if ady > adx {
-        if dy > 0 {
-            Quadrant::South
-        } else {
-            Quadrant::North
-        }
-    } else {
-        // |dx| == |dy| or both zero — East if dx >= 0, West otherwise
+    let scaled_dx = adx.saturating_mul(h);
+    let scaled_dy = ady.saturating_mul(w);
+
+    if scaled_dx > scaled_dy || (scaled_dx == scaled_dy && dx >= 0) {
         if dx >= 0 {
             Quadrant::East
         } else {
             Quadrant::West
+        }
+    } else {
+        if dy < 0 {
+            Quadrant::North
+        } else {
+            Quadrant::South
         }
     }
 }
@@ -129,5 +130,30 @@ mod tests {
     #[test]
     fn quadrant_on_center_defaults_to_east() {
         assert_eq!(detect_quadrant(50, 50, &rect()), Quadrant::East);
+    }
+
+    #[test]
+    fn quadrant_non_square_wide_target() {
+        let wide = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 20,
+        };
+        assert_eq!(detect_quadrant(80, 5, &wide), Quadrant::East);
+        assert_eq!(detect_quadrant(60, 2, &wide), Quadrant::North);
+        assert_eq!(detect_quadrant(55, 0, &wide), Quadrant::North);
+    }
+
+    #[test]
+    fn quadrant_non_square_tall_target() {
+        let tall = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 60,
+        };
+        assert_eq!(detect_quadrant(18, 5, &tall), Quadrant::North);
+        assert_eq!(detect_quadrant(19, 10, &tall), Quadrant::East);
     }
 }

--- a/crates/term-wm-layout-engine/src/lib.rs
+++ b/crates/term-wm-layout-engine/src/lib.rs
@@ -37,8 +37,8 @@ pub use rect::{
 pub use region_map::RegionMap;
 pub use scroll::ScrollState;
 pub use snap::{
-    EdgeResistance, InsertPosition, SnapPreview, SnapTarget, detect_edge_snap, edge_preview_rect,
-    tiled_preview_rect,
+    EdgeResistance, InsertPosition, SnapPreview, SnapTarget, corner_preview_rect,
+    detect_corner_snap, detect_edge_snap, edge_preview_rect, tiled_preview_rect,
 };
 pub use split::{
     build_rects_from_sizes, gap_size, handle_thickness, split_rect_bsp, split_rects_nary,

--- a/crates/term-wm-layout-engine/src/node.rs
+++ b/crates/term-wm-layout-engine/src/node.rs
@@ -117,6 +117,17 @@ impl<Id: Copy + Eq + Ord> BspNode<Id> {
                         Self::leaf(*current),
                         Self::leaf(insert),
                     ),
+                    // Corners: use vertical split (top portion for new window)
+                    InsertPosition::TopLeft | InsertPosition::TopRight => (
+                        Orientation::Vertical,
+                        Self::leaf(insert),
+                        Self::leaf(*current),
+                    ),
+                    InsertPosition::BottomLeft | InsertPosition::BottomRight => (
+                        Orientation::Vertical,
+                        Self::leaf(*current),
+                        Self::leaf(insert),
+                    ),
                 };
                 let half_dim = match orientation {
                     Orientation::Horizontal => area.width / 2,
@@ -484,6 +495,17 @@ impl<Id: Copy + Eq + Ord> NaryNode<Id> {
                         Self::leaf(*current),
                     ),
                     InsertPosition::Bottom => (
+                        Orientation::Vertical,
+                        Self::leaf(*current),
+                        Self::leaf(insert),
+                    ),
+                    // Corners: use vertical split (top portion for new window)
+                    InsertPosition::TopLeft | InsertPosition::TopRight => (
+                        Orientation::Vertical,
+                        Self::leaf(insert),
+                        Self::leaf(*current),
+                    ),
+                    InsertPosition::BottomLeft | InsertPosition::BottomRight => (
                         Orientation::Vertical,
                         Self::leaf(*current),
                         Self::leaf(insert),

--- a/crates/term-wm-layout-engine/src/rect.rs
+++ b/crates/term-wm-layout-engine/src/rect.rs
@@ -154,6 +154,15 @@ pub fn gap_insert<T: Into<u16>>(
     }
 }
 
+/// Which diagonal quadrant of a rectangle a point falls in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Quadrant {
+    North,
+    South,
+    East,
+    West,
+}
+
 /// The direction children are stacked in a split container.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Orientation {
@@ -161,15 +170,6 @@ pub enum Orientation {
     Horizontal,
     /// Children are placed top-to-bottom, sharing the available width.
     Vertical,
-}
-
-/// One of the four cardinal directions, used for drag-and-drop insertion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Quadrant {
-    North,
-    South,
-    East,
-    West,
 }
 
 /// An integer ratio `(p, q)` meaning `p/(p+q)` of the parent's size.

--- a/crates/term-wm-layout-engine/src/snap.rs
+++ b/crates/term-wm-layout-engine/src/snap.rs
@@ -6,6 +6,10 @@ pub enum InsertPosition {
     Right,
     Top,
     Bottom,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
 }
 
 impl InsertPosition {
@@ -13,13 +17,24 @@ impl InsertPosition {
         match self {
             InsertPosition::Left | InsertPosition::Right => Orientation::Horizontal,
             InsertPosition::Top | InsertPosition::Bottom => Orientation::Vertical,
+            // Corners use horizontal orientation for BSP split (vertical divider)
+            InsertPosition::TopLeft
+            | InsertPosition::TopRight
+            | InsertPosition::BottomLeft
+            | InsertPosition::BottomRight => Orientation::Horizontal,
         }
     }
 
     pub fn ratio(&self) -> Ratio {
         match self {
-            InsertPosition::Left | InsertPosition::Top => Ratio(1, 1),
-            InsertPosition::Right | InsertPosition::Bottom => Ratio(1, 1),
+            InsertPosition::Left
+            | InsertPosition::Top
+            | InsertPosition::Right
+            | InsertPosition::Bottom
+            | InsertPosition::TopLeft
+            | InsertPosition::TopRight
+            | InsertPosition::BottomLeft
+            | InsertPosition::BottomRight => Ratio(1, 1),
         }
     }
 }
@@ -43,9 +58,9 @@ pub struct SnapPreview<Id: Copy + Eq + Ord> {
 pub struct EdgeResistanceConfig {
     pub magnetic_zone: u16,
     pub spatial_threshold: u16,
-    // temporal_threshold and velocity tracking planned but not yet wired;
-    // requires frame timestamp plumbing from the runtime.
-    pub _temporal_threshold_ns: Option<u64>,
+    /// Time in nanoseconds the cursor must stay within the magnetic zone
+    /// before the resistance is broken.  None disables temporal resistance.
+    pub temporal_threshold_ns: Option<u64>,
 }
 
 impl EdgeResistanceConfig {
@@ -53,7 +68,7 @@ impl EdgeResistanceConfig {
         Self {
             magnetic_zone: 3,
             spatial_threshold: 8,
-            _temporal_threshold_ns: None,
+            temporal_threshold_ns: Some(500_000_000), // 500ms
         }
     }
 }
@@ -63,6 +78,10 @@ pub struct EdgeResistance {
     pub config: EdgeResistanceConfig,
     pub prev_x: Option<i32>,
     pub prev_y: Option<i32>,
+    /// Wall-clock nanosecond timestamp when the cursor first entered the
+    /// magnetic zone on the current axis.  Pure integer; no `std::time` types.
+    pub entered_magnetic_x_at: Option<u64>,
+    pub entered_magnetic_y_at: Option<u64>,
 }
 
 impl EdgeResistance {
@@ -71,6 +90,8 @@ impl EdgeResistance {
             config,
             prev_x: None,
             prev_y: None,
+            entered_magnetic_x_at: None,
+            entered_magnetic_y_at: None,
         }
     }
 
@@ -78,64 +99,102 @@ impl EdgeResistance {
         Self::new(EdgeResistanceConfig::default_tui())
     }
 
-    pub fn apply_x(&mut self, new_x: i32, bounds: LayoutRect) -> i32 {
+    /// Apply X-axis magnetic resistance.
+    ///
+    /// `now_ns` is a raw nanosecond timestamp (from `Instant::now()`
+    /// converted to nanos-since-epoch in the caller).  The layout engine
+    /// treats it as an opaque integer — no `std::time` types are used.
+    pub fn apply_x(&mut self, new_x: i32, bounds: LayoutRect, now_ns: u64) -> i32 {
         let low = bounds.x;
         let high = bounds
             .x
             .saturating_add(i32::from(bounds.width.saturating_sub(1)));
-        let result = snap_axis(
-            new_x,
+        let result = snap_axis(&SnapAxisParams {
+            new_val: new_x,
             low,
             high,
-            self.config.magnetic_zone,
-            self.config.spatial_threshold,
-            &self.prev_x,
-        );
+            magnetic_zone: self.config.magnetic_zone,
+            spatial_threshold: self.config.spatial_threshold,
+            temporal_threshold_ns: self.config.temporal_threshold_ns,
+            prev: self.prev_x,
+            entered_at: self.entered_magnetic_x_at,
+            now_ns,
+            enable_low_snap: true,
+            enable_high_snap: true,
+        });
+        // Track entry into magnetic zone for temporal threshold
+        let is_snapped = result == low || result == high;
+        if is_snapped && self.entered_magnetic_x_at.is_none() {
+            self.entered_magnetic_x_at = Some(now_ns);
+        } else if !is_snapped {
+            self.entered_magnetic_x_at = None;
+        }
         self.prev_x = Some(new_x);
         result
     }
 
-    pub fn apply_y(&mut self, new_y: i32, bounds: LayoutRect) -> i32 {
+    /// Apply Y-axis magnetic resistance.
+    pub fn apply_y(&mut self, new_y: i32, bounds: LayoutRect, now_ns: u64) -> i32 {
         let low = bounds.y;
         let high = bounds
             .y
             .saturating_add(i32::from(bounds.height.saturating_sub(1)));
-        let result = snap_axis(
-            new_y,
+        let result = snap_axis(&SnapAxisParams {
+            new_val: new_y,
             low,
             high,
-            self.config.magnetic_zone,
-            self.config.spatial_threshold,
-            &self.prev_y,
-        );
+            magnetic_zone: self.config.magnetic_zone,
+            spatial_threshold: self.config.spatial_threshold,
+            temporal_threshold_ns: self.config.temporal_threshold_ns,
+            prev: self.prev_y,
+            entered_at: self.entered_magnetic_y_at,
+            now_ns,
+            enable_low_snap: false,
+            enable_high_snap: true,
+        });
+        let is_snapped = result == low || result == high;
+        if is_snapped && self.entered_magnetic_y_at.is_none() {
+            self.entered_magnetic_y_at = Some(now_ns);
+        } else if !is_snapped {
+            self.entered_magnetic_y_at = None;
+        }
         self.prev_y = Some(new_y);
         result
     }
 
-    pub fn apply(&mut self, new_x: i32, bounds: LayoutRect) -> i32 {
-        self.apply_x(new_x, bounds)
+    pub fn apply(&mut self, new_x: i32, bounds: LayoutRect, now_ns: u64) -> i32 {
+        self.apply_x(new_x, bounds, now_ns)
     }
 }
 
-fn snap_axis(
+struct SnapAxisParams {
     new_val: i32,
     low: i32,
     high: i32,
     magnetic_zone: u16,
     spatial_threshold: u16,
-    prev: &Option<i32>,
-) -> i32 {
-    let zone = i32::from(magnetic_zone);
-    let hysteresis = i32::from(spatial_threshold);
+    temporal_threshold_ns: Option<u64>,
+    prev: Option<i32>,
+    entered_at: Option<u64>,
+    now_ns: u64,
+    enable_low_snap: bool,
+    enable_high_snap: bool,
+}
 
-    let d_low = new_val.saturating_sub(low).unsigned_abs();
-    let d_high = high.saturating_sub(new_val).unsigned_abs();
+fn snap_axis(params: &SnapAxisParams) -> i32 {
+    let zone = i32::from(params.magnetic_zone);
+    let hysteresis = i32::from(params.spatial_threshold);
 
-    let already_snapped = prev
+    let d_low = params.new_val.saturating_sub(params.low).unsigned_abs();
+    let d_high = params.high.saturating_sub(params.new_val).unsigned_abs();
+
+    let already_snapped = params
+        .prev
         .map(|p| {
-            let pd_low = p.saturating_sub(low).unsigned_abs();
-            let pd_high = high.saturating_sub(p).unsigned_abs();
-            pd_low <= zone as u32 || pd_high <= zone as u32
+            let pd_low = p.saturating_sub(params.low).unsigned_abs();
+            let pd_high = params.high.saturating_sub(p).unsigned_abs();
+            (params.enable_low_snap && pd_low <= zone as u32)
+                || (params.enable_high_snap && pd_high <= zone as u32)
         })
         .unwrap_or(false);
 
@@ -144,12 +203,21 @@ fn snap_axis(
     let snap_low = d_low <= threshold as u32;
     let snap_high = d_high <= threshold as u32;
 
-    if snap_low && d_low <= d_high {
-        low
-    } else if snap_high {
-        high
+    // If already snapped and temporal threshold has elapsed, break the lock
+    if already_snapped
+        && let (Some(threshold_ns), Some(entry_ns)) =
+            (params.temporal_threshold_ns, params.entered_at)
+        && params.now_ns.saturating_sub(entry_ns) >= threshold_ns
+    {
+        return params.new_val;
+    }
+
+    if params.enable_low_snap && snap_low && d_low <= d_high {
+        params.low
+    } else if params.enable_high_snap && snap_high {
+        params.high
     } else {
-        new_val
+        params.new_val
     }
 }
 
@@ -213,6 +281,38 @@ pub fn edge_preview_rect(managed_area: LayoutRect, pos: InsertPosition) -> Layou
             height: managed_area.height / 2,
             ..managed_area
         },
+        // Corner previews: quarter-screen (50% × 50%)
+        InsertPosition::TopLeft => LayoutRect {
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+            ..managed_area
+        },
+        InsertPosition::TopRight => LayoutRect {
+            x: managed_area
+                .x
+                .saturating_add(i32::from(managed_area.width / 2)),
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+            ..managed_area
+        },
+        InsertPosition::BottomLeft => LayoutRect {
+            y: managed_area
+                .y
+                .saturating_add(i32::from(managed_area.height / 2)),
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+            ..managed_area
+        },
+        InsertPosition::BottomRight => LayoutRect {
+            x: managed_area
+                .x
+                .saturating_add(i32::from(managed_area.width / 2)),
+            y: managed_area
+                .y
+                .saturating_add(i32::from(managed_area.height / 2)),
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+        },
     }
 }
 
@@ -240,6 +340,112 @@ pub fn tiled_preview_rect(target_rect: LayoutRect, position: InsertPosition) -> 
             height: target_rect.height / 2,
             ..target_rect
         },
+        // Corner tiled previews: quarter of the target pane
+        InsertPosition::TopLeft => LayoutRect {
+            width: target_rect.width / 2,
+            height: target_rect.height / 2,
+            ..target_rect
+        },
+        InsertPosition::TopRight => LayoutRect {
+            x: target_rect
+                .x
+                .saturating_add(i32::from(target_rect.width / 2)),
+            width: target_rect.width / 2,
+            height: target_rect.height / 2,
+            ..target_rect
+        },
+        InsertPosition::BottomLeft => LayoutRect {
+            y: target_rect
+                .y
+                .saturating_add(i32::from(target_rect.height / 2)),
+            width: target_rect.width / 2,
+            height: target_rect.height / 2,
+            ..target_rect
+        },
+        InsertPosition::BottomRight => LayoutRect {
+            x: target_rect
+                .x
+                .saturating_add(i32::from(target_rect.width / 2)),
+            y: target_rect
+                .y
+                .saturating_add(i32::from(target_rect.height / 2)),
+            width: target_rect.width / 2,
+            height: target_rect.height / 2,
+        },
+    }
+}
+
+/// Compute a corner (quarter-screen) preview rect.
+pub fn corner_preview_rect(managed_area: LayoutRect, pos: InsertPosition) -> LayoutRect {
+    match pos {
+        InsertPosition::TopLeft => LayoutRect {
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+            ..managed_area
+        },
+        InsertPosition::TopRight => LayoutRect {
+            x: managed_area
+                .x
+                .saturating_add(i32::from(managed_area.width / 2)),
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+            ..managed_area
+        },
+        InsertPosition::BottomLeft => LayoutRect {
+            y: managed_area
+                .y
+                .saturating_add(i32::from(managed_area.height / 2)),
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+            ..managed_area
+        },
+        InsertPosition::BottomRight => LayoutRect {
+            x: managed_area
+                .x
+                .saturating_add(i32::from(managed_area.width / 2)),
+            y: managed_area
+                .y
+                .saturating_add(i32::from(managed_area.height / 2)),
+            width: managed_area.width / 2,
+            height: managed_area.height / 2,
+        },
+        // Non-corner positions: delegate to edge_preview_rect
+        _ => edge_preview_rect(managed_area, pos),
+    }
+}
+
+/// Detect a corner snap when the cursor is simultaneously within `sensitivity`
+/// of both an X edge and a Y edge. Uses saturating arithmetic exclusively.
+pub fn detect_corner_snap(
+    col: u16,
+    row: u16,
+    managed_area: LayoutRect,
+    sensitivity: u16,
+) -> Option<InsertPosition> {
+    let margin_left = managed_area.x as u16;
+    let margin_right = (managed_area.x as u16)
+        .saturating_add(managed_area.width)
+        .saturating_sub(1);
+    let margin_top = managed_area.y as u16;
+    let margin_bottom = (managed_area.y as u16)
+        .saturating_add(managed_area.height)
+        .saturating_sub(1);
+
+    let near_left = col <= sensitivity.saturating_add(margin_left);
+    let near_right = col >= margin_right.saturating_sub(sensitivity);
+    let near_top = row <= sensitivity.saturating_add(margin_top);
+    let near_bottom = row >= margin_bottom.saturating_sub(sensitivity);
+
+    if near_top && near_left {
+        Some(InsertPosition::TopLeft)
+    } else if near_top && near_right {
+        Some(InsertPosition::TopRight)
+    } else if near_bottom && near_left {
+        Some(InsertPosition::BottomLeft)
+    } else if near_bottom && near_right {
+        Some(InsertPosition::BottomRight)
+    } else {
+        None
     }
 }
 
@@ -302,7 +508,7 @@ mod tests {
             width: 80,
             height: 24,
         };
-        assert_eq!(er.apply_x(2, bounds), 0);
+        assert_eq!(er.apply_x(2, bounds, 0), 0);
     }
 
     #[test]
@@ -314,7 +520,7 @@ mod tests {
             width: 80,
             height: 24,
         };
-        assert_eq!(er.apply_x(78, bounds), 79);
+        assert_eq!(er.apply_x(78, bounds, 0), 79);
     }
 
     #[test]
@@ -326,11 +532,11 @@ mod tests {
             width: 80,
             height: 24,
         };
-        assert_eq!(er.apply_x(40, bounds), 40);
+        assert_eq!(er.apply_x(40, bounds, 0), 40);
     }
 
     #[test]
-    fn edge_resistance_snaps_y_to_top() {
+    fn edge_resistance_does_not_snap_y_to_top() {
         let mut er = EdgeResistance::default_tui();
         let bounds = LayoutRect {
             x: 0,
@@ -338,7 +544,8 @@ mod tests {
             width: 80,
             height: 24,
         };
-        assert_eq!(er.apply_y(2, bounds), 0);
+        // Y-axis low snap (title-bar area) is intentionally disabled
+        assert_eq!(er.apply_y(2, bounds, 0), 2);
     }
 
     #[test]
@@ -350,7 +557,82 @@ mod tests {
             width: 80,
             height: 24,
         };
-        assert_eq!(er.apply_y(22, bounds), 23);
+        assert_eq!(er.apply_y(22, bounds, 0), 23);
+    }
+
+    #[test]
+    fn temporal_resistance_breaks_after_threshold() {
+        let mut er = EdgeResistance::default_tui();
+        let bounds = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        // First call: enters magnetic zone
+        assert_eq!(er.apply_x(2, bounds, 0), 0);
+        // Still within threshold — should stay snapped
+        assert_eq!(er.apply_x(5, bounds, 100_000_000), 0);
+        // After 500ms threshold — should break free
+        assert_eq!(er.apply_x(5, bounds, 600_000_000), 5);
+    }
+
+    #[test]
+    fn corner_snap_top_left() {
+        let a = area();
+        assert_eq!(
+            detect_corner_snap(0, 0, a, 2),
+            Some(InsertPosition::TopLeft)
+        );
+        assert_eq!(
+            detect_corner_snap(1, 0, a, 2),
+            Some(InsertPosition::TopLeft)
+        );
+        assert_eq!(
+            detect_corner_snap(0, 1, a, 2),
+            Some(InsertPosition::TopLeft)
+        );
+    }
+
+    #[test]
+    fn corner_snap_top_right() {
+        let a = area();
+        assert_eq!(
+            detect_corner_snap(79, 0, a, 2),
+            Some(InsertPosition::TopRight)
+        );
+        assert_eq!(
+            detect_corner_snap(78, 0, a, 2),
+            Some(InsertPosition::TopRight)
+        );
+    }
+
+    #[test]
+    fn corner_snap_bottom_left() {
+        let a = area();
+        assert_eq!(
+            detect_corner_snap(0, 23, a, 2),
+            Some(InsertPosition::BottomLeft)
+        );
+        assert_eq!(
+            detect_corner_snap(1, 23, a, 2),
+            Some(InsertPosition::BottomLeft)
+        );
+    }
+
+    #[test]
+    fn corner_snap_bottom_right() {
+        let a = area();
+        assert_eq!(
+            detect_corner_snap(79, 23, a, 2),
+            Some(InsertPosition::BottomRight)
+        );
+    }
+
+    #[test]
+    fn corner_snap_none_when_far() {
+        let a = area();
+        assert_eq!(detect_corner_snap(40, 12, a, 2), None);
     }
 
     #[test]

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -981,6 +981,7 @@ struct TestPane {
     max_sb: usize,
     alt_screen: bool,
     pending_title: Option<String>,
+    kill_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 #[cfg(test)]
@@ -992,7 +993,21 @@ impl TestPane {
             max_sb,
             alt_screen: false,
             pending_title: None,
+            kill_count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
+    }
+
+    fn with_kill_tracker(max_sb: usize) -> (Self, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        let kill_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let pane = Self {
+            parser: std::sync::Arc::new(std::sync::Mutex::new(vt100::Parser::new(24, 80, max_sb))),
+            current_scrollback: 0,
+            max_sb,
+            alt_screen: false,
+            pending_title: None,
+            kill_count: std::sync::Arc::clone(&kill_count),
+        };
+        (pane, kill_count)
     }
 
     fn set_scrollback_value(&mut self, val: usize) {
@@ -1070,6 +1085,8 @@ impl Pane for TestPane {
     }
 
     fn kill_child(&mut self) -> term_wm_pty_engine::PtyResult<()> {
+        self.kill_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 
@@ -1185,6 +1202,19 @@ mod tests {
             &mut term_wm_core::hitbox_registry::HitboxRegistry::new(),
         );
         term.pane_mut().scrollback()
+    }
+
+    // --- Destroy / kill tests ---
+
+    #[test]
+    fn destroy_calls_kill_child() {
+        let (pane, kill_count) = TestPane::with_kill_tracker(200);
+        let mut term = TerminalComponent::from_pane(Box::new(pane));
+        term.destroy();
+        assert!(
+            kill_count.load(std::sync::atomic::Ordering::SeqCst) >= 1,
+            "destroy() must call pane.kill_child()"
+        );
     }
 
     // --- Scroll sync tests ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,19 +157,19 @@ pub fn render_app(
     // This ensures floating windows block clicks to tiling handles beneath them.
     let chrome_entries: Vec<(HitTarget, term_wm_layout_engine::LayoutRect)> = {
         let mut entries = Vec::new();
-        for handle in wm.tiling_handles() {
-            entries.push((HitTarget::LayoutHandle, handle.rect));
-        }
         for region in draw_plan.regions() {
             let k = region.key;
-            // Window content area — blocks clicks to anything beneath
-            entries.push((HitTarget::Window(k), region.bounds));
             for h in wm.resize_handles().iter().filter(|h| h.key == k) {
                 entries.push((HitTarget::ChromeResize(h.key, h.edge), h.rect));
             }
             for h in wm.floating_headers().iter().filter(|h| h.key == k) {
                 entries.push((HitTarget::ChromeHeader(h.key, HeaderAction::Drag), h.rect));
             }
+        }
+        // Tiling split handles last — highest priority at split boundaries,
+        // so they intercept clicks that would otherwise hit a Window region.
+        for handle in wm.tiling_handles() {
+            entries.push((HitTarget::LayoutHandle, handle.rect));
         }
         entries
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ use std::sync::Arc;
 use term_wm_console::RatatuiBackend;
 use term_wm_console::draw_plan_renderer::{
     ColorConvert, DrawPlanRenderer, composite_window, overlay_shadow_data, render_drop_shadow,
-    render_handles_masked, render_overlays, render_panels, render_resize_outline,
+    render_ghost_preview, render_handles_masked, render_overlays, render_panels,
+    render_resize_outline,
 };
 use term_wm_core::hitbox_registry::{HitTarget, HitboxRegistry};
 use term_wm_core::window::decorator::HeaderAction;
@@ -29,6 +30,11 @@ pub fn render_app(
     let Some(ratatui_backend) = backend.as_any_mut().downcast_mut::<RatatuiBackend>() else {
         return;
     };
+
+    // Clear per-frame draw state (regions, floating headers, hitbox registry)
+    // that was populated during the previous frame's render pass.
+    wm.prepare_draw();
+
     let area = term_wm_layout_engine::LayoutRect {
         x: 0,
         y: 0,
@@ -147,19 +153,23 @@ pub fn render_app(
 
     // Register chrome hitboxes (resize handles + header drag zones)
     // Collect data first to avoid simultaneous mutable + immutable borrows on wm.
+    // Order: tiling handles (lowest z), window content (middle), chrome (highest z).
+    // This ensures floating windows block clicks to tiling handles beneath them.
     let chrome_entries: Vec<(HitTarget, term_wm_layout_engine::LayoutRect)> = {
         let mut entries = Vec::new();
+        for handle in wm.tiling_handles() {
+            entries.push((HitTarget::LayoutHandle, handle.rect));
+        }
         for region in draw_plan.regions() {
             let k = region.key;
+            // Window content area — blocks clicks to anything beneath
+            entries.push((HitTarget::Window(k), region.bounds));
             for h in wm.resize_handles().iter().filter(|h| h.key == k) {
                 entries.push((HitTarget::ChromeResize(h.key, h.edge), h.rect));
             }
             for h in wm.floating_headers().iter().filter(|h| h.key == k) {
                 entries.push((HitTarget::ChromeHeader(h.key, HeaderAction::Drag), h.rect));
             }
-        }
-        for handle in wm.tiling_handles() {
-            entries.push((HitTarget::LayoutHandle, handle.rect));
         }
         entries
     };
@@ -243,38 +253,27 @@ pub fn render_app(
                 &wm.config().theme,
             );
 
-            // Snap preview (colored background + countdown text)
+            // Snap preview (dashed border + shade fill + countdown text)
             if let Some((_, _, snap_rect)) = wm.drag_snap_rect_data() {
                 use ratatui::layout::Alignment;
                 use ratatui::style::{Color, Style};
                 use ratatui::widgets::Paragraph;
-                let accent_color = wm.config().theme.accent.to_ratatui();
                 let rat_snap = ratatui::prelude::Rect {
                     x: snap_rect.x.max(0) as u16,
                     y: snap_rect.y.max(0) as u16,
                     width: snap_rect.width,
                     height: snap_rect.height,
                 };
-                let clip = rat_snap.intersection(buf.area);
-                if clip.width > 0 && clip.height > 0 {
-                    for y in clip.y..clip.y.saturating_add(clip.height) {
-                        for x in clip.x..clip.x.saturating_add(clip.width) {
-                            if let Some(cell) = buf.cell_mut((x, y)) {
-                                let mut style = cell.style();
-                                style.bg = Some(accent_color);
-                                cell.set_style(style);
-                            }
-                        }
-                    }
-                }
+                render_ghost_preview(buf, *snap_rect, &wm.config().theme);
                 if let Some(remaining) = wm.drag_snap_remaining() {
                     const GRACE: std::time::Duration = std::time::Duration::from_millis(500);
                     let timeout = wm.config().drag_snap_timeout.unwrap();
                     if timeout.saturating_sub(remaining) >= GRACE {
+                        let action = wm.snap_preview_action_label().unwrap_or("snap");
                         let text = if remaining == std::time::Duration::ZERO {
-                            "Mouse left — snapping...".to_string()
+                            format!("Mouse left — {}...", action)
                         } else {
-                            format!("Mouse left — snapping in {}s", remaining.as_secs().max(1))
+                            format!("Mouse left — {} in {}s", action, remaining.as_secs().max(1))
                         };
                         let text_len = text.len() as u16;
                         let text_x = rat_snap.x + (rat_snap.width.saturating_sub(text_len)) / 2;
@@ -295,6 +294,37 @@ pub fn render_app(
                                 .alignment(Alignment::Center);
                             ratatui::widgets::Widget::render(paragraph, text_area, buf);
                         }
+                    }
+                }
+            }
+
+            // Dim target tile border during tiled-insert snap preview
+            if let Some(target_key) = wm.snap_preview_target_key()
+                && let Some(target_rect) = wm.regions().get(target_key)
+            {
+                let dim = ratatui::style::Modifier::DIM;
+                let rx = target_rect.x.max(0) as u16;
+                let ry = target_rect.y.max(0) as u16;
+                let right = rx.saturating_add(target_rect.width).saturating_sub(1);
+                let bottom = ry.saturating_add(target_rect.height).saturating_sub(1);
+                for x in rx..=right {
+                    if let Some(cell) = buf.cell_mut((x, ry)) {
+                        cell.set_style(cell.style().add_modifier(dim));
+                    }
+                    if bottom != ry
+                        && let Some(cell) = buf.cell_mut((x, bottom))
+                    {
+                        cell.set_style(cell.style().add_modifier(dim));
+                    }
+                }
+                for y in (ry + 1)..bottom {
+                    if let Some(cell) = buf.cell_mut((rx, y)) {
+                        cell.set_style(cell.style().add_modifier(dim));
+                    }
+                    if right != rx
+                        && let Some(cell) = buf.cell_mut((right, y))
+                    {
+                        cell.set_style(cell.style().add_modifier(dim));
                     }
                 }
             }

--- a/tests/integration_tiling.proptest-regressions
+++ b/tests/integration_tiling.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 45e5a967319fe2ce82ae481889ca9f27c47a47f031a4f2364936e32c548baaaf # shrinks to tree = Split { direction: Horizontal, children: [Leaf(1), Leaf(1)], weights: [1.0, 1.0], constraints: [], resizable: true }, area = LayoutRect { x: 0, y: 0, width: 100, height: 40 }

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -1,0 +1,1116 @@
+use std::sync::Arc;
+use term_wm::AppContext;
+use term_wm::layout::Direction;
+use term_wm::layout::tiling::{InsertPosition, LayoutNode, TilingLayout};
+use term_wm::window::{FloatRectSpec, WindowKey, WindowManager};
+use term_wm::wm_config::WmConfig;
+use term_wm_layout_engine::{LayoutRect, detect_corner_snap, detect_edge_snap, edge_preview_rect};
+
+type Rect = term_wm_core::Rect;
+
+const AREA: Rect = Rect {
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 24,
+};
+
+const SNAP_SENSITIVITY: u16 = 3;
+
+fn area_lr() -> LayoutRect {
+    LayoutRect {
+        x: AREA.x,
+        y: AREA.y,
+        width: AREA.width,
+        height: AREA.height,
+    }
+}
+
+fn wm_with_two_windows() -> (WindowManager, [WindowKey; 2]) {
+    let mut config = WmConfig::standalone();
+    config.chrome_enabled = false;
+    let mut wm = WindowManager::with_config(
+        config,
+        Arc::new(AppContext::new("test", "0.0.0")),
+        None,
+        None,
+        None,
+        None,
+    );
+    wm.set_panel_visible(false);
+    let k0 = wm.create_window(Box::new(NoopComponent));
+    let k1 = wm.create_window(Box::new(NoopComponent));
+    let split = LayoutNode::Split {
+        direction: Direction::Horizontal,
+        children: vec![LayoutNode::Leaf(k0), LayoutNode::Leaf(k1)],
+        weights: vec![1.0, 1.0],
+        constraints: vec![],
+        resizable: false,
+    };
+    wm.set_managed_layout(TilingLayout::new(split));
+    wm.register_managed_layout(AREA);
+    (wm, [k0, k1])
+}
+
+fn header_rect(wm: &WindowManager, key: WindowKey) -> Rect {
+    for h in wm.floating_headers() {
+        if h.key == key {
+            return h.rect;
+        }
+    }
+    panic!("no header found for key");
+}
+
+fn make_mouse(
+    kind: term_wm::events::MouseEventKind,
+    col: u16,
+    row: u16,
+) -> term_wm::events::WmEvent {
+    let event = term_wm::events::Event::Mouse(term_wm::events::MouseEvent {
+        kind,
+        column: col,
+        row,
+        modifiers: term_wm::events::KeyModifiers::NONE,
+    });
+    term_wm::events::core_event_to_wm(&event).expect("valid mouse event")
+}
+
+struct NoopComponent;
+impl term_wm::components::Component<term_wm::actions::TermWmAction> for NoopComponent {
+    fn render(
+        &mut self,
+        _backend: &mut dyn term_wm_render::RenderBackend,
+        _area: LayoutRect,
+        _ctx: &term_wm::components::ComponentContext,
+        _registry: &mut term_wm::hitbox_registry::HitboxRegistry,
+    ) {
+    }
+    fn handle_events(
+        &mut self,
+        _event: &term_wm::events::Event,
+        _ctx: &term_wm::components::ComponentContext,
+    ) -> term_wm::actions::EventResult<term_wm::actions::TermWmAction> {
+        term_wm::actions::EventResult::Ignored
+    }
+    fn update(
+        &mut self,
+        _action: term_wm::actions::TermWmAction,
+        _ctx: &term_wm::components::ComponentContext,
+        _queue: &mut std::collections::VecDeque<(WindowKey, term_wm::actions::TermWmAction)>,
+    ) {
+    }
+    fn destroy(&mut self) {}
+}
+
+fn collect_leaf_ids(node: &LayoutNode<usize>) -> Vec<usize> {
+    node.collect_leaves()
+}
+
+fn has_void(node: &LayoutNode<usize>) -> bool {
+    match node {
+        LayoutNode::Void(_) => true,
+        LayoutNode::Leaf(_) => false,
+        LayoutNode::Split { children, .. } => children.iter().any(has_void),
+    }
+}
+
+fn rects_overlap(a: Rect, b: Rect) -> bool {
+    if a.width == 0 || a.height == 0 || b.width == 0 || b.height == 0 {
+        return false;
+    }
+    let a_right = a.x + i32::from(a.width);
+    let a_bottom = a.y + i32::from(a.height);
+    let b_right = b.x + i32::from(b.width);
+    let b_bottom = b.y + i32::from(b.height);
+    a.x < b_right && a_right > b.x && a.y < b_bottom && a_bottom > b.y
+}
+
+// ─── Module 1: Snap Detection ────────────────────────────────────────
+
+#[cfg(test)]
+mod snap_detection {
+    use super::*;
+
+    #[test]
+    fn top_edge_y0_is_sacred() {
+        let pos = detect_edge_snap(40, 0, area_lr(), SNAP_SENSITIVITY);
+        assert_eq!(
+            pos,
+            Some(InsertPosition::Top),
+            "detection returns Top; the WM treats y=0 as maximize"
+        );
+    }
+
+    #[test]
+    fn left_edge_bisects() {
+        let pos = detect_edge_snap(1, 12, area_lr(), SNAP_SENSITIVITY);
+        assert_eq!(pos, Some(InsertPosition::Left));
+        let preview = edge_preview_rect(area_lr(), InsertPosition::Left);
+        assert_eq!(preview.width, AREA.width / 2);
+        assert_eq!(preview.x, AREA.x);
+    }
+
+    #[test]
+    fn right_edge_bisects() {
+        let pos = detect_edge_snap(AREA.width - 1, 12, area_lr(), SNAP_SENSITIVITY);
+        assert_eq!(pos, Some(InsertPosition::Right));
+        let preview = edge_preview_rect(area_lr(), InsertPosition::Right);
+        assert_eq!(preview.width, AREA.width / 2);
+        assert_eq!(preview.x, AREA.x + i32::from(AREA.width / 2));
+    }
+
+    #[test]
+    fn corner_snap_quadrants() {
+        let a = area_lr();
+        let cases = [
+            (0u16, 0u16, InsertPosition::TopLeft),
+            (AREA.width - 1, 0, InsertPosition::TopRight),
+            (0, AREA.height - 1, InsertPosition::BottomLeft),
+            (AREA.width - 1, AREA.height - 1, InsertPosition::BottomRight),
+        ];
+        for (col, row, expected) in cases {
+            let pos = detect_corner_snap(col, row, a, SNAP_SENSITIVITY);
+            assert_eq!(pos, Some(expected), "corner at ({col}, {row})");
+        }
+        let tl = edge_preview_rect(a, InsertPosition::TopLeft);
+        assert_eq!(tl.width, AREA.width / 2);
+        assert_eq!(tl.height, AREA.height / 2);
+    }
+
+    #[test]
+    fn corner_over_edge_priority() {
+        let pos = detect_corner_snap(1, 1, area_lr(), SNAP_SENSITIVITY);
+        assert_eq!(pos, Some(InsertPosition::TopLeft));
+    }
+}
+
+// ─── Module 2: Multi-Window Tiling ───────────────────────────────────
+
+#[cfg(test)]
+mod multi_window_tiling {
+    use super::*;
+
+    #[test]
+    fn three_windows_horizontal() {
+        let root = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1usize),
+                LayoutNode::leaf(2),
+                LayoutNode::leaf(3),
+            ],
+            weights: vec![1.0, 1.0, 1.0],
+            constraints: vec![],
+            resizable: false,
+        };
+        let regions = root.layout(AREA);
+        assert_eq!(regions.len(), 3);
+        let total_w: u16 = regions.iter().map(|(_, r)| r.width).sum();
+        assert_eq!(total_w, AREA.width);
+        for (i, (_, r1)) in regions.iter().enumerate() {
+            for (j, (_, r2)) in regions.iter().enumerate() {
+                if i != j {
+                    assert!(!rects_overlap(*r1, *r2));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn nested_mixed_orientation() {
+        let root = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1usize),
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![LayoutNode::leaf(2), LayoutNode::leaf(3)],
+                    weights: vec![1.0, 1.0],
+                    constraints: vec![],
+                    resizable: false,
+                },
+            ],
+            weights: vec![1.0, 1.0],
+            constraints: vec![],
+            resizable: false,
+        };
+        let regions = root.layout(AREA);
+        assert_eq!(regions.len(), 3);
+        let total_area: u32 = regions
+            .iter()
+            .map(|(_, r)| r.width as u32 * r.height as u32)
+            .sum();
+        assert_eq!(total_area, AREA.width as u32 * AREA.height as u32);
+    }
+
+    #[test]
+    fn insert_leaf_splits_target() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        let regions = root.layout(AREA);
+        assert_eq!(regions.len(), 2);
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        let r2 = regions.iter().find(|(id, _)| *id == 2).unwrap().1;
+        assert!(r1.x <= r2.x, "window 1 should be left of window 2");
+    }
+
+    #[test]
+    fn remove_leaf_collapses() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.remove_leaf(2);
+        root.cleanup_after_removal();
+        let regions = root.layout(AREA);
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].1.width, AREA.width);
+        assert_eq!(regions[0].1.height, AREA.height);
+    }
+
+    #[test]
+    fn remove_all_collapses_to_single_leaf() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.remove_leaf(1);
+        root.cleanup_after_removal();
+        let regions = root.layout(AREA);
+        assert_eq!(regions.len(), 1, "after removing 1 of 2, one leaf remains");
+        root.remove_leaf(2);
+        root.cleanup_after_removal();
+        assert!(
+            matches!(root, LayoutNode::Leaf(2)),
+            "removing last leaf from collapsed tree"
+        );
+    }
+
+    #[test]
+    fn normalize_weights_equalizes() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.normalize_weights();
+        let regions = root.layout(AREA);
+        assert_eq!(regions.len(), 2);
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        let r2 = regions.iter().find(|(id, _)| *id == 2).unwrap().1;
+        let diff = (r1.width as i32 - r2.width as i32).abs();
+        assert!(
+            diff <= 1,
+            "widths should be within 1px: {} vs {}",
+            r1.width,
+            r2.width
+        );
+    }
+
+    /// Verify that corner insert puts the dragged window in the correct
+    /// quadrant and the first sibling in the adjacent quadrant.
+    /// Regression guard against insert/first ordering swaps.
+    #[test]
+    fn corner_insert_window_ordering() {
+        // Start with 3 windows side by side: [1, 2, 3]
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.insert_leaf(2, 3, InsertPosition::Right);
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 80,
+        };
+        let mid_y: i32 = (area.height / 2).into();
+
+        // Insert 4 into BottomLeft quadrant
+        // Expected: 4 in bottom-left, 1 in bottom-right, others in top strip
+        root.insert_leaf(1, 4, InsertPosition::BottomLeft);
+        let regions = root.layout(area);
+        let r4 = regions.iter().find(|(id, _)| *id == 4).unwrap().1;
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        assert!(
+            r4.x < r1.x,
+            "BottomLeft: insert must be left of first sibling"
+        );
+        assert!(r4.y >= mid_y, "BottomLeft: insert must be in bottom half");
+
+        // Reset and test BottomRight
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.insert_leaf(2, 3, InsertPosition::Right);
+        root.insert_leaf(1, 4, InsertPosition::BottomRight);
+        let regions = root.layout(area);
+        let r4 = regions.iter().find(|(id, _)| *id == 4).unwrap().1;
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        assert!(
+            r4.x > r1.x,
+            "BottomRight: insert must be right of first sibling"
+        );
+        assert!(r4.y >= mid_y, "BottomRight: insert must be in bottom half");
+
+        // Reset and test TopLeft
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.insert_leaf(2, 3, InsertPosition::Right);
+        root.insert_leaf(1, 4, InsertPosition::TopLeft);
+        let regions = root.layout(area);
+        let r4 = regions.iter().find(|(id, _)| *id == 4).unwrap().1;
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        assert!(r4.x < r1.x, "TopLeft: insert must be left of first sibling");
+        assert!(r4.y < mid_y, "TopLeft: insert must be in top half");
+
+        // Reset and test TopRight
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.insert_leaf(2, 3, InsertPosition::Right);
+        root.insert_leaf(1, 4, InsertPosition::TopRight);
+        let regions = root.layout(area);
+        let r4 = regions.iter().find(|(id, _)| *id == 4).unwrap().1;
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        assert!(
+            r4.x > r1.x,
+            "TopRight: insert must be right of first sibling"
+        );
+        assert!(r4.y < mid_y, "TopRight: insert must be in top half");
+    }
+}
+
+// ─── Module 3: Void Node Lifecycle ───────────────────────────────────
+
+#[cfg(test)]
+mod void_node_lifecycle {
+    use super::*;
+
+    #[test]
+    fn corner_insert_creates_void() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::TopLeft);
+        assert!(has_void(&root), "corner insert must create a Void node");
+    }
+
+    #[test]
+    fn replace_void_by_id() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::TopLeft);
+        let void_id = match &root {
+            LayoutNode::Split { children, .. } => match &children[0] {
+                LayoutNode::Split {
+                    children: inner, ..
+                } => match &inner[1] {
+                    LayoutNode::Void(id) => *id,
+                    _ => panic!("expected Void in inner split"),
+                },
+                _ => panic!("expected inner Split"),
+            },
+            _ => panic!("expected outer Split"),
+        };
+        let replaced = root.replace_void_by_id(void_id, LayoutNode::leaf(99));
+        assert!(replaced);
+        assert!(!has_void(&root), "Void should be replaced");
+        let ids = collect_leaf_ids(&root);
+        assert!(ids.contains(&99));
+    }
+
+    #[test]
+    fn cleanup_removes_voids() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::TopLeft);
+        root.cleanup_after_removal();
+        assert!(!has_void(&root), "cleanup should remove all Void nodes");
+    }
+
+    #[test]
+    fn void_skipped_in_layout() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::TopLeft);
+        root.cleanup_after_removal();
+        let regions = root.layout(AREA);
+        for (_, r) in &regions {
+            assert!(r.width > 0);
+            assert!(r.height > 0);
+        }
+        assert_eq!(regions.len(), 2);
+    }
+}
+
+// ─── Module 4: Spatial Isolation ─────────────────────────────────────
+
+#[cfg(test)]
+mod spatial_isolation {
+    use super::*;
+
+    #[test]
+    fn snap_right_preserves_left_sibling() {
+        let mut config = WmConfig::standalone();
+        config.chrome_enabled = false;
+        let mut wm = WindowManager::with_config(
+            config,
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        wm.set_panel_visible(false);
+        let k0 = wm.create_window(Box::new(NoopComponent));
+        let k1 = wm.create_window(Box::new(NoopComponent));
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(k0), LayoutNode::Leaf(k1)],
+            weights: vec![1.0, 1.0],
+            constraints: vec![],
+            resizable: false,
+        };
+        wm.set_managed_layout(TilingLayout::new(split));
+        wm.register_managed_layout(AREA);
+
+        let rect_before_left = wm.region(k0);
+
+        let new_root = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::Leaf(k0),
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![LayoutNode::Leaf(k1), LayoutNode::Void(0)],
+                    weights: vec![1.0, 1.0],
+                    constraints: vec![],
+                    resizable: false,
+                },
+            ],
+            weights: vec![1.0, 1.0],
+            constraints: vec![],
+            resizable: false,
+        };
+        wm.set_managed_layout(TilingLayout::new(new_root));
+        wm.register_managed_layout(AREA);
+
+        let rect_after_left = wm.region(k0);
+        assert_eq!(
+            rect_after_left.x, rect_before_left.x,
+            "left sibling x must not change"
+        );
+        assert_eq!(
+            rect_after_left.y, rect_before_left.y,
+            "left sibling y must not change"
+        );
+        assert_eq!(
+            rect_after_left.width, rect_before_left.width,
+            "left sibling width must not change"
+        );
+        assert_eq!(
+            rect_after_left.height, rect_before_left.height,
+            "left sibling height must not change"
+        );
+    }
+
+    #[test]
+    fn snap_quadrant_preserves_sibling_orientation() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.insert_leaf(2, 3, InsertPosition::Bottom);
+        let root_dir = match &root {
+            LayoutNode::Split { direction, .. } => *direction,
+            _ => panic!("expected root Split"),
+        };
+        assert_eq!(
+            root_dir,
+            Direction::Horizontal,
+            "root must remain Horizontal"
+        );
+
+        root.insert_leaf(3, 4, InsertPosition::BottomRight);
+        let root_dir_after = match &root {
+            LayoutNode::Split { direction, .. } => *direction,
+            _ => panic!("expected root Split"),
+        };
+        assert_eq!(
+            root_dir_after,
+            Direction::Horizontal,
+            "root direction must not change after quadrant insert"
+        );
+    }
+
+    #[test]
+    fn insert_does_not_mutate_unrelated_splits() {
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.insert_leaf(2, 3, InsertPosition::Bottom);
+
+        let regions_before = root.layout(AREA);
+        let r3_before = *regions_before.iter().find(|(id, _)| *id == 3).unwrap();
+
+        root.insert_leaf(2, 4, InsertPosition::Right);
+
+        let regions_after = root.layout(AREA);
+        let r3_after = *regions_after.iter().find(|(id, _)| *id == 3).unwrap();
+        assert_eq!(
+            r3_before.1.x, r3_after.1.x,
+            "unrelated sibling x must not change"
+        );
+        assert_eq!(
+            r3_before.1.y, r3_after.1.y,
+            "unrelated sibling y must not change"
+        );
+        assert_eq!(
+            r3_before.1.width, r3_after.1.width,
+            "unrelated sibling width must not change"
+        );
+        assert_eq!(
+            r3_before.1.height, r3_after.1.height,
+            "unrelated sibling height must not change"
+        );
+    }
+}
+
+// ─── Module 5: Drag-Snap Pipeline ────────────────────────────────────
+//
+// These tests verify the full interaction flow through `dispatch_mouse`
+// using the production render pipeline to populate HitboxRegistry.
+// Snap detection geometry is tested in Module 1 (pure math).
+// These tests verify that the state machine correctly handles
+// Press→Drag→Release sequences without panics or state corruption.
+
+#[cfg(test)]
+mod drag_snap_pipeline {
+    use super::*;
+
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect as RatatuiRect;
+    use term_wm::events::{MouseButton, MouseEventKind};
+    use term_wm::render_app;
+    use term_wm_console::RatatuiBackend;
+    use term_wm_console::draw_plan_renderer::DrawPlanRenderer;
+    use term_wm_core::engine::CoreEngine;
+
+    fn setup() -> (WindowManager, CoreEngine, DrawPlanRenderer, [WindowKey; 2]) {
+        let (wm, keys) = wm_with_two_windows();
+        (wm, CoreEngine::new(), DrawPlanRenderer::new(), keys)
+    }
+
+    fn advance_frame(
+        wm: &mut WindowManager,
+        engine: &mut CoreEngine,
+        renderer: &mut DrawPlanRenderer,
+    ) {
+        let area = RatatuiRect {
+            x: 0,
+            y: 0,
+            width: AREA.width,
+            height: AREA.height,
+        };
+        let buf = Buffer::empty(area);
+        let mut backend = RatatuiBackend::new(buf, area);
+        render_app(&mut backend, wm, engine, renderer);
+    }
+
+    #[test]
+    fn drag_to_right_edge_snaps() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        let header = header_rect(&wm, keys[0]);
+        let down = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header.x as u16,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&down);
+
+        // Use y=12 (middle of screen) to avoid corner detection zone (y <= 6)
+        let mid_y = 12u16;
+        let right_edge = (AREA.x + i32::from(AREA.width) - 1) as u16;
+        let drag = make_mouse(MouseEventKind::Drag(MouseButton::Left), right_edge, mid_y);
+        wm.dispatch_mouse(&drag);
+
+        // Verify exact ghost geometry: right half (40, 0, 40, 24)
+        let snap_rect = wm
+            .drag_snap_rect()
+            .expect("drag_snap must be set after Drag");
+        assert_eq!(snap_rect.x, AREA.x + i32::from(AREA.width / 2), "ghost x");
+        assert_eq!(snap_rect.y, AREA.y, "ghost y");
+        assert_eq!(snap_rect.width, AREA.width / 2, "ghost width");
+        assert_eq!(snap_rect.height, AREA.height, "ghost height");
+
+        let up = make_mouse(
+            MouseEventKind::Release(MouseButton::Left),
+            right_edge,
+            mid_y,
+        );
+        wm.dispatch_mouse(&up);
+
+        // Re-render to recompute regions after apply_snap modified the layout tree
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let r = wm.region(keys[0]);
+        assert_eq!(
+            r.x,
+            AREA.x + i32::from(AREA.width / 2),
+            "right-snapped window x"
+        );
+        assert_eq!(r.y, AREA.y, "right-snapped window y");
+        assert_eq!(r.width, AREA.width / 2, "right-snapped window width");
+        assert_eq!(r.height, AREA.height, "right-snapped window height");
+    }
+
+    #[test]
+    fn press_preserves_tiled_state() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        assert!(!wm.is_window_floating(keys[0]), "starts tiled");
+
+        let header = header_rect(&wm, keys[0]);
+        let down = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header.x as u16,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&down);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // Press alone must NOT decouple — deadzone drag requirement
+        assert!(
+            !wm.is_window_floating(keys[0]),
+            "press must not make window floating"
+        );
+
+        // Drag that breaches the kinetic deadzone (dx+dy > 2 cells)
+        let drag_x = (header.x + 5) as u16;
+        let drag = make_mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            drag_x,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&drag);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        assert!(
+            wm.is_window_floating(keys[0]),
+            "must be floating after drag breaches deadzone"
+        );
+    }
+
+    #[test]
+    fn drag_to_top_maximizes() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        let header = header_rect(&wm, keys[0]);
+        let down = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header.x as u16,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&down);
+
+        // Use center column to avoid corner-snap collision at left edge
+        let mid_x = AREA.width / 2;
+        let drag = make_mouse(MouseEventKind::Drag(MouseButton::Left), mid_x, 0);
+        wm.dispatch_mouse(&drag);
+
+        // Verify ghost preview is maximize (full area)
+        let snap_rect = wm
+            .drag_snap_rect()
+            .expect("drag_snap must be set after Drag to top edge");
+        assert_eq!(snap_rect.x, AREA.x, "maximize ghost x");
+        assert_eq!(snap_rect.y, AREA.y, "maximize ghost y");
+        assert_eq!(snap_rect.width, AREA.width, "maximize ghost width");
+        assert_eq!(snap_rect.height, AREA.height, "maximize ghost height");
+
+        let up = make_mouse(MouseEventKind::Release(MouseButton::Left), mid_x, 0);
+        wm.dispatch_mouse(&up);
+
+        // Ghost overlay must be cleared immediately after maximize applies
+        assert!(
+            wm.drag_snap_rect().is_none(),
+            "drag_snap must be None after maximize release"
+        );
+
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let r = wm.region(keys[0]);
+        assert_eq!(r.x, AREA.x, "maximized x");
+        assert_eq!(r.y, AREA.y, "maximized y");
+        assert_eq!(r.width, AREA.width, "maximized width");
+        assert_eq!(r.height, AREA.height, "maximized height");
+    }
+
+    #[test]
+    fn drag_to_corner_quadrant() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        let header = header_rect(&wm, keys[0]);
+        let down = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header.x as u16,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&down);
+
+        let corner_x = (AREA.x + i32::from(AREA.width) - 1) as u16;
+        let corner_y = (AREA.y + i32::from(AREA.height) - 1) as u16;
+        let drag = make_mouse(MouseEventKind::Drag(MouseButton::Left), corner_x, corner_y);
+        wm.dispatch_mouse(&drag);
+
+        // Verify exact ghost geometry: bottom-right quadrant (40, 12, 40, 12)
+        let snap_rect = wm
+            .drag_snap_rect()
+            .expect("drag_snap must be set after Drag to corner");
+        assert_eq!(snap_rect.x, AREA.x + i32::from(AREA.width / 2), "ghost x");
+        assert_eq!(snap_rect.y, AREA.y + i32::from(AREA.height / 2), "ghost y");
+        assert_eq!(snap_rect.width, AREA.width / 2, "ghost width");
+        assert_eq!(snap_rect.height, AREA.height / 2, "ghost height");
+
+        let up = make_mouse(
+            MouseEventKind::Release(MouseButton::Left),
+            corner_x,
+            corner_y,
+        );
+        wm.dispatch_mouse(&up);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let r = wm.region(keys[0]);
+        assert_eq!(r.x, AREA.x + i32::from(AREA.width / 2), "corner x");
+        assert_eq!(r.y, AREA.y + i32::from(AREA.height / 2), "corner y");
+        assert_eq!(r.width, AREA.width / 2, "corner width");
+        assert_eq!(r.height, AREA.height / 2, "corner height");
+    }
+
+    #[test]
+    fn drag_away_restores_float_geometry() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        let header = header_rect(&wm, keys[0]);
+
+        let down = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header.x as u16,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&down);
+
+        // Use y=12 (middle of screen) to avoid corner detection zone
+        let mid_y = 12u16;
+        let right_edge = (AREA.x + i32::from(AREA.width) - 1) as u16;
+        let drag = make_mouse(MouseEventKind::Drag(MouseButton::Left), right_edge, mid_y);
+        wm.dispatch_mouse(&drag);
+
+        // Verify exact ghost geometry for the right-edge snap
+        let snap_rect = wm
+            .drag_snap_rect()
+            .expect("drag_snap must be set after Drag to right edge");
+        assert_eq!(snap_rect.x, AREA.x + i32::from(AREA.width / 2), "ghost x");
+        assert_eq!(snap_rect.y, AREA.y, "ghost y");
+        assert_eq!(snap_rect.width, AREA.width / 2, "ghost width");
+        assert_eq!(snap_rect.height, AREA.height, "ghost height");
+
+        let up = make_mouse(
+            MouseEventKind::Release(MouseButton::Left),
+            right_edge,
+            mid_y,
+        );
+        wm.dispatch_mouse(&up);
+
+        // Re-render to refresh hitboxes after layout mutation
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let snapped = wm.region(keys[0]);
+        let pre_w = snapped.width;
+        let pre_h = snapped.height;
+
+        let header2 = header_rect(&wm, keys[0]);
+        let cursor_x = header2.x as u16;
+        let cursor_y = header2.y as u16;
+        let cursor_offset_x = cursor_x as i32 - snapped.x;
+        let cursor_offset_y = cursor_y as i32 - snapped.y;
+
+        let down2 = make_mouse(MouseEventKind::Press(MouseButton::Left), cursor_x, cursor_y);
+        wm.dispatch_mouse(&down2);
+
+        let away_x = (AREA.x + 10) as u16;
+        let away_y = (AREA.y + 5) as u16;
+        let drag2 = make_mouse(MouseEventKind::Drag(MouseButton::Left), away_x, away_y);
+        wm.dispatch_mouse(&drag2);
+
+        let up2 = make_mouse(MouseEventKind::Release(MouseButton::Left), away_x, away_y);
+        wm.dispatch_mouse(&up2);
+
+        let float_panes = wm.floating_panes();
+        let (_, float_spec) = float_panes
+            .iter()
+            .find(|(k, _)| *k == keys[0])
+            .expect("window should be floating");
+        if let FloatRectSpec::Absolute(fr) = float_spec {
+            assert_eq!(fr.width, pre_w, "restored width must match pre-snap");
+            assert_eq!(fr.height, pre_h, "restored height must match pre-snap");
+            let new_cursor_offset_x = away_x as i32 - fr.x;
+            let new_cursor_offset_y = away_y as i32 - fr.y;
+            assert_eq!(
+                new_cursor_offset_x, cursor_offset_x,
+                "cursor offset x must match"
+            );
+            assert_eq!(
+                new_cursor_offset_y, cursor_offset_y,
+                "cursor offset y must match"
+            );
+        } else {
+            panic!("expected absolute float rect");
+        }
+    }
+
+    #[test]
+    fn double_snap_converges() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        let header = header_rect(&wm, keys[0]);
+
+        // Phase 1: snap right
+        let down = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header.x as u16,
+            header.y as u16,
+        );
+        wm.dispatch_mouse(&down);
+        let right_edge = (AREA.x + i32::from(AREA.width) - 1) as u16;
+        let drag = make_mouse(MouseEventKind::Drag(MouseButton::Left), right_edge, 12);
+        wm.dispatch_mouse(&drag);
+
+        // Verify ghost geometry for Phase 1
+        let snap_rect = wm
+            .drag_snap_rect()
+            .expect("phase 1: drag_snap must be set after Drag");
+        assert_eq!(
+            snap_rect.x,
+            AREA.x + i32::from(AREA.width / 2),
+            "phase 1: ghost x"
+        );
+        assert_eq!(snap_rect.y, AREA.y, "phase 1: ghost y");
+        assert_eq!(snap_rect.width, AREA.width / 2, "phase 1: ghost width");
+        assert_eq!(snap_rect.height, AREA.height, "phase 1: ghost height");
+
+        let up = make_mouse(MouseEventKind::Release(MouseButton::Left), right_edge, 12);
+        wm.dispatch_mouse(&up);
+
+        // Re-render for phase 2
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let r1 = wm.region(keys[0]);
+        assert_eq!(
+            r1.x,
+            AREA.x + i32::from(AREA.width / 2),
+            "phase 1: right-snapped x"
+        );
+        assert_eq!(r1.width, AREA.width / 2, "phase 1: right-snapped width");
+
+        // Phase 2: drag away from edge
+        let header2 = header_rect(&wm, keys[0]);
+        let cursor_x = header2.x as u16;
+        let cursor_y = header2.y as u16;
+        let cursor_offset_x = cursor_x as i32 - r1.x;
+        let cursor_offset_y = cursor_y as i32 - r1.y;
+
+        let down2 = make_mouse(MouseEventKind::Press(MouseButton::Left), cursor_x, cursor_y);
+        wm.dispatch_mouse(&down2);
+        let away_x = (AREA.x + 10) as u16;
+        let away_y = 12u16;
+        let drag2 = make_mouse(MouseEventKind::Drag(MouseButton::Left), away_x, away_y);
+        wm.dispatch_mouse(&drag2);
+        let up2 = make_mouse(MouseEventKind::Release(MouseButton::Left), away_x, away_y);
+        wm.dispatch_mouse(&up2);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // Phase 2: window must be floating with preserved dimensions and cursor offset
+        let float_panes = wm.floating_panes();
+        let (_, float_spec) = float_panes
+            .iter()
+            .find(|(k, _)| *k == keys[0])
+            .expect("phase 2: window should be floating after drag-away");
+        if let FloatRectSpec::Absolute(fr) = float_spec {
+            assert_eq!(
+                fr.width,
+                AREA.width / 2,
+                "phase 2: floating width must match snapped width"
+            );
+            assert_eq!(
+                fr.height, AREA.height,
+                "phase 2: floating height must match snapped height"
+            );
+            let new_cursor_offset_x = away_x as i32 - fr.x;
+            let new_cursor_offset_y = away_y as i32 - fr.y;
+            assert_eq!(
+                new_cursor_offset_x, cursor_offset_x,
+                "phase 2: cursor offset x must be preserved"
+            );
+            assert_eq!(
+                new_cursor_offset_y, cursor_offset_y,
+                "phase 2: cursor offset y must be preserved"
+            );
+        } else {
+            panic!("phase 2: expected absolute float rect");
+        }
+
+        // Phase 3: snap left
+        let header3 = header_rect(&wm, keys[0]);
+        let down3 = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            header3.x as u16,
+            header3.y as u16,
+        );
+        wm.dispatch_mouse(&down3);
+        let left_edge = AREA.x as u16;
+        let drag3 = make_mouse(MouseEventKind::Drag(MouseButton::Left), left_edge, 12);
+        wm.dispatch_mouse(&drag3);
+        let up3 = make_mouse(MouseEventKind::Release(MouseButton::Left), left_edge, 12);
+        wm.dispatch_mouse(&up3);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let r3 = wm.region(keys[0]);
+        let total_w = r3.width.saturating_add(wm.region(keys[1]).width);
+        assert_eq!(r3.x, AREA.x, "phase 3: left-snapped x");
+        assert_eq!(r3.y, AREA.y, "phase 3: left-snapped y");
+        assert_eq!(
+            r3.width,
+            total_w / 2,
+            "phase 3: left-snapped width = total/2"
+        );
+        assert_eq!(r3.height, AREA.height, "phase 3: left-snapped height");
+        // Sibling must stay constrained to its lane — not expanded across full width
+        let r_sibling = wm.region(keys[1]);
+        assert!(
+            r_sibling.x > r3.x,
+            "phase 3: sibling must be to the right of keys[0]"
+        );
+        assert!(
+            !rects_overlap(r3, r_sibling),
+            "phase 3: windows must not overlap"
+        );
+    }
+}
+
+// ─── Module 6: Property Tests ────────────────────────────────────────
+
+#[cfg(test)]
+mod property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn area_strategy() -> impl Strategy<Value = Rect> {
+        (100u16..200, 40u16..80).prop_map(|(w, h)| Rect {
+            x: 0,
+            y: 0,
+            width: w,
+            height: h,
+        })
+    }
+
+    fn leaf_id_strategy() -> impl Strategy<Value = usize> {
+        1usize..1000
+    }
+
+    fn tree_strategy() -> impl Strategy<Value = LayoutNode<usize>> {
+        leaf_id_strategy().prop_flat_map(|first_id| {
+            let insert_pos = prop_oneof![
+                Just(InsertPosition::Left),
+                Just(InsertPosition::Right),
+                Just(InsertPosition::Top),
+                Just(InsertPosition::Bottom),
+            ];
+            (
+                Just(first_id),
+                prop::collection::vec((leaf_id_strategy(), insert_pos), 0..7),
+            )
+                .prop_map(move |(_, ops)| {
+                    let mut tree = LayoutNode::leaf(first_id);
+                    for (new_id, pos) in ops {
+                        let target = *collect_leaf_ids(&tree).last().unwrap_or(&first_id);
+                        tree.insert_leaf(target, new_id, pos);
+                    }
+                    tree
+                })
+        })
+    }
+
+    /// Build a non-resizable version of a tree (all splits have resizable: false).
+    fn make_non_resizable(node: &LayoutNode<usize>) -> LayoutNode<usize> {
+        match node {
+            LayoutNode::Leaf(id) => LayoutNode::leaf(*id),
+            LayoutNode::Void(id) => LayoutNode::Void(*id),
+            LayoutNode::Split {
+                direction,
+                children,
+                weights,
+                constraints,
+                ..
+            } => LayoutNode::Split {
+                direction: *direction,
+                children: children.iter().map(make_non_resizable).collect(),
+                weights: weights.clone(),
+                constraints: constraints.clone(),
+                resizable: false,
+            },
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn insert_never_shrinks_leaf_set(
+            mut tree in tree_strategy(),
+            new_id in leaf_id_strategy(),
+            pos in prop_oneof![
+                Just(InsertPosition::Left),
+                Just(InsertPosition::Right),
+                Just(InsertPosition::Top),
+                Just(InsertPosition::Bottom),
+            ],
+        ) {
+            let before = collect_leaf_ids(&tree);
+            let insert_target = *before.last().unwrap_or(&1);
+            tree.insert_leaf(insert_target, new_id, pos);
+            let after = collect_leaf_ids(&tree);
+            prop_assert!(after.len() >= before.len(),
+                "leaf count must not shrink: {} -> {}", before.len(), after.len());
+            prop_assert!(after.contains(&new_id),
+                "new leaf {} must be present after insert", new_id);
+        }
+
+        #[test]
+        fn no_overlapping_regions(
+            tree in tree_strategy(),
+            area in area_strategy(),
+        ) {
+            let regions = tree.layout(area);
+            for (i, (_, r1)) in regions.iter().enumerate() {
+                for (j, (_, r2)) in regions.iter().enumerate() {
+                    if i < j {
+                        prop_assert!(!rects_overlap(*r1, *r2),
+                            "regions overlap: {:?} and {:?}", r1, r2);
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn non_void_area_covers_full(
+            tree in tree_strategy(),
+            area in area_strategy(),
+        ) {
+            let non_resizable = make_non_resizable(&tree);
+            let regions = non_resizable.layout(area);
+            let leaf_area: u32 = regions.iter()
+                .map(|(_, r)| r.width as u32 * r.height as u32)
+                .sum();
+            let total_area = area.width as u32 * area.height as u32;
+            prop_assert_eq!(leaf_area, total_area,
+                "non-resizable tree must cover full area");
+        }
+
+        #[test]
+        fn weights_stay_positive(
+            mut tree in tree_strategy(),
+        ) {
+            tree.normalize_weights();
+            fn check(node: &LayoutNode<usize>) -> bool {
+                match node {
+                    LayoutNode::Split { weights, children, .. } => {
+                        weights.iter().all(|w| *w > 0.0) && children.iter().all(check)
+                    }
+                    _ => true,
+                }
+            }
+            prop_assert!(check(&tree), "all weights must be positive");
+        }
+    }
+}

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -426,6 +426,42 @@ mod void_node_lifecycle {
         }
         assert_eq!(regions.len(), 2);
     }
+
+    #[test]
+    fn clear_leaf_converts_single_leaf_to_void() {
+        let mut root = LayoutNode::leaf(42usize);
+        assert!(
+            root.clear_leaf(42),
+            "clear_leaf must return true when id matches"
+        );
+        assert!(has_void(&root), "Leaf must become Void after clear_leaf");
+        let regions = root.layout(AREA);
+        assert!(regions.is_empty(), "Void produces no regions");
+
+        // Non-matching id must be a no-op
+        let mut root2 = LayoutNode::leaf(99usize);
+        assert!(
+            !root2.clear_leaf(42),
+            "clear_leaf must return false when id does not match"
+        );
+        assert!(
+            matches!(root2, LayoutNode::Leaf(99)),
+            "Leaf must be preserved when id does not match"
+        );
+    }
+
+    #[test]
+    fn remove_leaf_on_split_then_clear_leaf_on_remaining() {
+        // Simulate: two side-by-side windows [1, 2], remove one,
+        // then clear_leaf the remaining before re-inserting the removed one.
+        let mut root = LayoutNode::leaf(1usize);
+        root.insert_leaf(1, 2, InsertPosition::Right);
+        root.remove_leaf(1);
+        root.cleanup_after_removal();
+        // Tree is now Leaf(2)
+        assert!(root.clear_leaf(2), "clear_leaf on remaining leaf");
+        assert!(has_void(&root), "tree is now Void");
+    }
 }
 
 // ─── Module 4: Spatial Isolation ─────────────────────────────────────
@@ -1012,6 +1048,94 @@ mod drag_snap_pipeline {
         assert!(
             !rects_overlap(r3, r_sibling),
             "phase 3: windows must not overlap"
+        );
+    }
+
+    #[test]
+    fn regr_sole_leaf_maximize_cycle_shows_ghost_on_right_side() {
+        // https://github.com/anomalyco/term-wm/issues/NNN
+        //
+        // 1. start with two side-by-side panes
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // 2. double-click the right pane to maximize it, then double-click it
+        //    again to restore it — the right pane becomes floating and the left
+        //    pane becomes the sole leaf in the tiling tree.
+        let right_header = header_rect(&wm, keys[1]);
+        let col = right_header.x as u16;
+        let row = right_header.y as u16;
+
+        let press1 = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&press1);
+        let release1 = make_mouse(MouseEventKind::Release(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&release1);
+        let press2 = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&press2);
+
+        let panes = wm.floating_panes();
+        let (_, spec) = panes
+            .iter()
+            .find(|(k, _)| *k == keys[1])
+            .expect("right pane maximized");
+        if let FloatRectSpec::Absolute(rect) = spec {
+            assert_eq!(rect.width, AREA.width, "maximized: full width");
+            assert_eq!(rect.height, AREA.height, "maximized: full height");
+        } else {
+            panic!("expected absolute float rect");
+        }
+
+        let release2 = make_mouse(MouseEventKind::Release(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&release2);
+        let press3 = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&press3);
+        let release3 = make_mouse(MouseEventKind::Release(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&release3);
+        assert!(
+            wm.floating_panes().iter().any(|(k, _)| *k == keys[1]),
+            "right pane must be floating after restore"
+        );
+
+        // Re-render to refresh hitboxes
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // 3. drag the left pane to the right side of the screen.
+        //    The ghost overlay must appear on the RIGHT half — not the left
+        //    (which was the bug: split_root created duplicate entries from a
+        //    sole leaf, and project_insert returned the first match).
+        let left_header = header_rect(&wm, keys[0]);
+        let press_left = make_mouse(
+            MouseEventKind::Press(MouseButton::Left),
+            left_header.x as u16,
+            left_header.y as u16,
+        );
+        wm.dispatch_mouse(&press_left);
+
+        let right_edge = (AREA.x + i32::from(AREA.width) - 1) as u16;
+        let mid_y = 12u16;
+        let drag = make_mouse(MouseEventKind::Drag(MouseButton::Left), right_edge, mid_y);
+        wm.dispatch_mouse(&drag);
+
+        let snap_rect = wm.drag_snap_rect().expect("drag snap must be set");
+        assert!(
+            snap_rect.x >= AREA.x + i32::from(AREA.width / 2),
+            "ghost x={} must be on right half",
+            snap_rect.x
+        );
+
+        let release_left = make_mouse(
+            MouseEventKind::Release(MouseButton::Left),
+            right_edge,
+            mid_y,
+        );
+        wm.dispatch_mouse(&release_left);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let r0 = wm.region(keys[0]);
+        assert!(
+            r0.x >= AREA.x + i32::from(AREA.width / 2),
+            "pane must land on right half, got x={}",
+            r0.x
         );
     }
 }

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -619,6 +619,33 @@ mod drag_snap_pipeline {
         (wm, CoreEngine::new(), DrawPlanRenderer::new(), keys)
     }
 
+    /// Like `setup` but with `resizable: true` so split handles are produced.
+    fn setup_with_resizable() -> (WindowManager, CoreEngine, DrawPlanRenderer, [WindowKey; 2]) {
+        let mut config = WmConfig::standalone();
+        config.chrome_enabled = false;
+        let mut wm = WindowManager::with_config(
+            config,
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        wm.set_panel_visible(false);
+        let k0 = wm.create_window(Box::new(NoopComponent));
+        let k1 = wm.create_window(Box::new(NoopComponent));
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(k0), LayoutNode::Leaf(k1)],
+            weights: vec![1.0, 1.0],
+            constraints: vec![],
+            resizable: true,
+        };
+        wm.set_managed_layout(TilingLayout::new(split));
+        wm.register_managed_layout(AREA);
+        (wm, CoreEngine::new(), DrawPlanRenderer::new(), [k0, k1])
+    }
+
     fn advance_frame(
         wm: &mut WindowManager,
         engine: &mut CoreEngine,
@@ -1136,6 +1163,60 @@ mod drag_snap_pipeline {
             r0.x >= AREA.x + i32::from(AREA.width / 2),
             "pane must land on right half, got x={}",
             r0.x
+        );
+    }
+
+    #[test]
+    fn split_handle_drag_works_after_render_pipeline_populates_hitboxes() {
+        // Regression: render_app registered Window hitboxes with region.bounds
+        // (full chrome-inclusive rect) AFTER LayoutHandle, causing the Window
+        // to override the handle at the split boundary.  LayoutHandle must
+        // take priority so mouse events route to the layout engine, not the
+        // terminal component.
+        //
+        // Uses resizable: true so that split handles are produced.
+        let (mut wm, mut engine, mut renderer, keys) = setup_with_resizable();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // Find the gap position from the WM state
+        let gap = &wm.tiling_handles()[0].rect;
+        let gap_col = (gap.x + i32::from(gap.width) / 2) as u16;
+        let gap_row = (gap.y + i32::from(gap.height) / 2) as u16;
+
+        // Press on the handle — must set LayoutHandle capture (dispatch returns true)
+        let down = make_mouse(MouseEventKind::Press(MouseButton::Left), gap_col, gap_row);
+        assert!(
+            wm.dispatch_mouse(&down),
+            "Press on split handle must be consumed"
+        );
+
+        // Drag right by 5 columns — layout must adjust
+        let drag = make_mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            gap_col + 5,
+            gap_row,
+        );
+        assert!(
+            wm.dispatch_mouse(&drag),
+            "Drag on split handle must be consumed"
+        );
+
+        // Release
+        let up = make_mouse(
+            MouseEventKind::Release(MouseButton::Left),
+            gap_col + 5,
+            gap_row,
+        );
+        wm.dispatch_mouse(&up);
+
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // The left window must have grown wider
+        let r0 = wm.region(keys[0]);
+        let r1 = wm.region(keys[1]);
+        assert!(
+            r0.width > r1.width,
+            "left window must be wider after dragging handle right"
         );
     }
 

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -1138,6 +1138,47 @@ mod drag_snap_pipeline {
             r0.x
         );
     }
+
+    #[test]
+    fn close_all_windows_then_tile_new_does_not_phantom() {
+        // Regression: closing all windows left a Void in the tree.
+        // Opening a new window via tile_window would call split_root on Void,
+        // creating Horizontal[Void, leaf] with a resize handle (the phantom).
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // Close both windows
+        wm.close_window(keys[0]);
+        wm.close_window(keys[1]);
+
+        // Open two new windows via tile_window (production path)
+        let k0 = wm.create_window(Box::new(NoopComponent));
+        assert!(wm.tile_window(k0), "first new window must tile");
+        let k1 = wm.create_window(Box::new(NoopComponent));
+        assert!(wm.tile_window(k1), "second new window must tile");
+
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // Both new windows must have valid regions, no phantom split handles
+        let r0 = wm.region(k0);
+        let r1 = wm.region(k1);
+        assert!(
+            r0.width > 0 && r0.height > 0,
+            "window 0 must have valid region"
+        );
+        assert!(
+            r1.width > 0 && r1.height > 0,
+            "window 1 must have valid region"
+        );
+        assert!(!rects_overlap(r0, r1), "windows must not overlap");
+        let total_w = r0.width.saturating_add(r1.width);
+        assert!(
+            total_w == AREA.width || total_w == AREA.width.wrapping_sub(1),
+            "windows must fill width: {} vs {}",
+            total_w,
+            AREA.width
+        );
+    }
 }
 
 // ─── Module 6: Property Tests ────────────────────────────────────────

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -729,6 +729,42 @@ mod drag_snap_pipeline {
     }
 
     #[test]
+    fn double_click_header_toggles_maximize() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        assert!(!wm.is_window_floating(keys[0]), "starts tiled");
+
+        let header = header_rect(&wm, keys[0]);
+        let col = header.x as u16;
+        let row = header.y as u16;
+
+        // First click: Press + Release at same position (no drag)
+        let down = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&down);
+        let up = make_mouse(MouseEventKind::Release(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&up);
+
+        // Second click within the 500ms double-click window
+        let down2 = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&down2);
+
+        // Double-click must trigger toggle_maximize on a tiled window.
+        // Maximized windows have floating_rect set but is_maximized flag true,
+        // so is_window_floating returns false — check via floating_panes + is_maximized.
+        let panes = wm.floating_panes();
+        let (_, spec) = panes
+            .iter()
+            .find(|(k, _)| *k == keys[0])
+            .expect("window in floating panes");
+        if let FloatRectSpec::Absolute(rect) = spec {
+            assert_eq!(rect.width, AREA.width, "maximized width");
+            assert_eq!(rect.height, AREA.height, "maximized height");
+        } else {
+            panic!("expected absolute float rect");
+        }
+    }
+
+    #[test]
     fn drag_to_corner_quadrant() {
         let (mut wm, mut engine, mut renderer, keys) = setup();
         advance_frame(&mut wm, &mut engine, &mut renderer);


### PR DESCRIPTION
- Add Void node type to BSP tree as placeholder for future window insertion
- Implement collect_leaves, build_flat, replace_void_by_id, void_regions
- Implement split_root for all 6 InsertPosition variants (Left, Right, Top,
  Bottom, TopLeft, TopRight, BottomLeft, BottomRight)
- Add project_insert and project_insert_void for snap preview projection
- Refactor snap detection into separate module with corner/edge detection
- Implement drag-snap pipeline through dispatch_mouse → update_snap_preview
- Add Retained-mode CoreEngine + DrawPlanRenderer lifecycle in tests
- Defer floating rect installation until drag deadzone breach
- Clear drag_snap ghost on maximize release to prevent stale overlay
- Add full integration test suite: snap detection, multi-window tiling,
  void lifecycle, spatial isolation, drag-snap pipeline, property tests
- Register drag-snap timer for deferred snap commit