### PR TITLE
feat(core): Exhaustive semantic mouse dispatch in Component trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2523,14 +2523,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2543,11 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.11-alpha"
+version = "0.8.12-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -52,14 +52,14 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm = { path = ".", version = "0.8.11-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.8.11-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.11-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.11-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.11-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.8.11-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.11-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.11-alpha" }
+term-wm = { path = ".", version = "0.8.12-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.8.12-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.12-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.12-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.12-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.8.12-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.12-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.12-alpha" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"

--- a/crates/term-wm-core/src/components/mod.rs
+++ b/crates/term-wm-core/src/components/mod.rs
@@ -7,7 +7,7 @@ use term_wm_layout_engine::LayoutRect;
 pub use crate::actions::EventResult;
 use crate::actions::TermWmAction;
 pub use crate::component_context::ComponentContext;
-use crate::events::Event;
+use crate::events::{Event, KeyModifiers, MouseButton, MouseEventKind};
 use crate::power_profile::PowerProfile;
 use crate::window::WindowKey;
 use crate::wm_config::HintVisibility;
@@ -40,33 +40,87 @@ pub trait Component<Msg>: std::any::Any {
 
     /// Phase 2: Evaluate raw events, return EventResult.
     /// Does NOT mutate state.
+    /// Dispatches mouse events to semantic handlers by MouseEventKind.
     fn handle_events(&mut self, event: &Event, ctx: &ComponentContext) -> EventResult<Msg> {
         if let Event::Mouse(mouse) = event {
             if let Some(screen_area) = ctx.screen_area() {
-                let is_inside = i32::from(mouse.column) >= screen_area.x
-                    && i32::from(mouse.column)
-                        < screen_area.x.saturating_add(i32::from(screen_area.width))
-                    && i32::from(mouse.row) >= screen_area.y
-                    && i32::from(mouse.row)
-                        < screen_area.y.saturating_add(i32::from(screen_area.height));
-                if is_inside {
-                    let local = crate::events::LocalMouseEvent {
-                        col: mouse.column.saturating_sub(screen_area.x.max(0) as u16),
-                        row: mouse.row.saturating_sub(screen_area.y.max(0) as u16),
-                        kind: mouse.kind,
-                        modifiers: mouse.modifiers,
-                    };
-                    return self.on_mouse(&local, ctx);
-                }
+                let local_x = (i32::from(mouse.column) - screen_area.x).max(0) as u16;
+                let local_y = (i32::from(mouse.row) - screen_area.y).max(0) as u16;
+                return match mouse.kind {
+                    MouseEventKind::Press(btn) => {
+                        self.on_mouse_press(local_x, local_y, btn, mouse.modifiers, ctx)
+                    }
+                    MouseEventKind::Release(btn) => {
+                        self.on_mouse_release(local_x, local_y, btn, mouse.modifiers, ctx)
+                    }
+                    MouseEventKind::Drag(btn) => {
+                        self.on_mouse_drag(local_x, local_y, btn, mouse.modifiers, ctx)
+                    }
+                    MouseEventKind::ScrollUp
+                    | MouseEventKind::ScrollDown
+                    | MouseEventKind::ScrollLeft
+                    | MouseEventKind::ScrollRight => {
+                        self.on_mouse_scroll(local_x, local_y, mouse.kind, mouse.modifiers, ctx)
+                    }
+                    MouseEventKind::Moved => {
+                        self.on_mouse_move(local_x, local_y, mouse.modifiers, ctx)
+                    }
+                };
             }
             return EventResult::Ignored;
         }
         self.on_key(event, ctx)
     }
 
-    fn on_mouse(
+    fn on_mouse_press(
         &mut self,
-        _mouse: &crate::events::LocalMouseEvent,
+        _local_x: u16,
+        _local_y: u16,
+        _button: MouseButton,
+        _modifiers: KeyModifiers,
+        _ctx: &ComponentContext,
+    ) -> EventResult<Msg> {
+        EventResult::Ignored
+    }
+
+    fn on_mouse_release(
+        &mut self,
+        _local_x: u16,
+        _local_y: u16,
+        _button: MouseButton,
+        _modifiers: KeyModifiers,
+        _ctx: &ComponentContext,
+    ) -> EventResult<Msg> {
+        EventResult::Ignored
+    }
+
+    fn on_mouse_drag(
+        &mut self,
+        _local_x: u16,
+        _local_y: u16,
+        _button: MouseButton,
+        _modifiers: KeyModifiers,
+        _ctx: &ComponentContext,
+    ) -> EventResult<Msg> {
+        EventResult::Ignored
+    }
+
+    fn on_mouse_scroll(
+        &mut self,
+        _local_x: u16,
+        _local_y: u16,
+        _kind: MouseEventKind,
+        _modifiers: KeyModifiers,
+        _ctx: &ComponentContext,
+    ) -> EventResult<Msg> {
+        EventResult::Ignored
+    }
+
+    fn on_mouse_move(
+        &mut self,
+        _local_x: u16,
+        _local_y: u16,
+        _modifiers: KeyModifiers,
         _ctx: &ComponentContext,
     ) -> EventResult<Msg> {
         EventResult::Ignored

--- a/crates/term-wm-core/src/components/mod.rs
+++ b/crates/term-wm-core/src/components/mod.rs
@@ -382,4 +382,394 @@ mod tests {
             .is_ignored()
         );
     }
+
+    #[test]
+    fn mouse_outside_screen_area_returns_ignored() {
+        use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut d = DummyComp;
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            column: 5,
+            row: 5,
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(d.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn mouse_no_screen_area_returns_ignored() {
+        use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut d = DummyComp;
+        let ctx = ComponentContext::new(true);
+        let event = Event::Mouse(MouseEvent {
+            column: 0,
+            row: 0,
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+        });
+        assert!(d.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn dispatch_press_calls_on_mouse_press() {
+        use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        struct PressRecorder {
+            received: std::cell::Cell<bool>,
+        }
+        impl Component<()> for PressRecorder {
+            fn on_mouse_press(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<()> {
+                self.received.set(true);
+                assert_eq!(local_x, 5);
+                assert_eq!(local_y, 3);
+                assert_eq!(button, MouseButton::Left);
+                EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: (),
+                _: &ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, ())>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+
+        let mut comp = PressRecorder {
+            received: std::cell::Cell::new(false),
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            column: 15,
+            row: 13,
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+        });
+        let result = comp.handle_events(&event, &ctx);
+        assert!(matches!(result, EventResult::Consumed));
+        assert!(comp.received.get());
+    }
+
+    #[test]
+    fn dispatch_release_calls_on_mouse_release() {
+        use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        struct ReleaseRecorder {
+            received: std::cell::Cell<bool>,
+        }
+        impl Component<()> for ReleaseRecorder {
+            fn on_mouse_release(
+                &mut self,
+                local_x: u16,
+                _local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<()> {
+                self.received.set(true);
+                assert_eq!(local_x, 5);
+                EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: (),
+                _: &ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, ())>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+
+        let mut comp = ReleaseRecorder {
+            received: std::cell::Cell::new(false),
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            column: 15,
+            row: 13,
+            kind: MouseEventKind::Release(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+        });
+        comp.handle_events(&event, &ctx);
+        assert!(comp.received.get());
+    }
+
+    #[test]
+    fn dispatch_drag_calls_on_mouse_drag() {
+        use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        struct DragRecorder {
+            received: std::cell::Cell<bool>,
+        }
+        impl Component<()> for DragRecorder {
+            fn on_mouse_drag(
+                &mut self,
+                local_x: u16,
+                _local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<()> {
+                self.received.set(true);
+                assert_eq!(local_x, 0);
+                EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: (),
+                _: &ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, ())>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+
+        let mut comp = DragRecorder {
+            received: std::cell::Cell::new(false),
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            column: 8,
+            row: 15,
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+        });
+        comp.handle_events(&event, &ctx);
+        assert!(comp.received.get());
+    }
+
+    #[test]
+    fn dispatch_scroll_variants_calls_on_mouse_scroll() {
+        use crate::events::{KeyModifiers, MouseEvent, MouseEventKind};
+
+        struct ScrollRecorder {
+            received: std::cell::Cell<bool>,
+        }
+        impl Component<()> for ScrollRecorder {
+            fn on_mouse_scroll(
+                &mut self,
+                _local_x: u16,
+                _local_y: u16,
+                kind: MouseEventKind,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<()> {
+                self.received.set(true);
+                assert!(matches!(
+                    kind,
+                    MouseEventKind::ScrollUp
+                        | MouseEventKind::ScrollDown
+                        | MouseEventKind::ScrollLeft
+                        | MouseEventKind::ScrollRight
+                ));
+                EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: (),
+                _: &ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, ())>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        for kind in [
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollDown,
+            MouseEventKind::ScrollLeft,
+            MouseEventKind::ScrollRight,
+        ] {
+            let mut comp = ScrollRecorder {
+                received: std::cell::Cell::new(false),
+            };
+            let event = Event::Mouse(MouseEvent {
+                column: 40,
+                row: 12,
+                kind,
+                modifiers: KeyModifiers::NONE,
+            });
+            comp.handle_events(&event, &ctx);
+            assert!(
+                comp.received.get(),
+                "scroll variant {:?} not dispatched",
+                kind
+            );
+        }
+    }
+
+    #[test]
+    fn dispatch_move_calls_on_mouse_move() {
+        use crate::events::{KeyModifiers, MouseEvent, MouseEventKind};
+
+        struct MoveRecorder {
+            received: std::cell::Cell<bool>,
+        }
+        impl Component<()> for MoveRecorder {
+            fn on_mouse_move(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<()> {
+                self.received.set(true);
+                assert_eq!(local_x, 40);
+                assert_eq!(local_y, 12);
+                EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: (),
+                _: &ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, ())>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+
+        let mut comp = MoveRecorder {
+            received: std::cell::Cell::new(false),
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        let event = Event::Mouse(MouseEvent {
+            column: 40,
+            row: 12,
+            kind: MouseEventKind::Moved,
+            modifiers: KeyModifiers::NONE,
+        });
+        comp.handle_events(&event, &ctx);
+        assert!(comp.received.get());
+    }
+
+    #[test]
+    fn mouse_coordinate_clamping_at_negative_area_origin() {
+        use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        struct CoordRecorder {
+            coords: std::cell::Cell<(u16, u16)>,
+        }
+        impl Component<()> for CoordRecorder {
+            fn on_mouse_press(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<()> {
+                self.coords.set((local_x, local_y));
+                EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: (),
+                _: &ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, ())>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+
+        let mut comp = CoordRecorder {
+            coords: std::cell::Cell::new((0, 0)),
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 10,
+            y: 10,
+            width: 20,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            column: 5,
+            row: 5,
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+        });
+        comp.handle_events(&event, &ctx);
+        assert_eq!(comp.coords.get(), (0, 0));
+    }
 }

--- a/crates/term-wm-core/src/window/decorator.rs
+++ b/crates/term-wm-core/src/window/decorator.rs
@@ -43,7 +43,6 @@ pub enum HeaderAction {
     Close,
     Drag,
     ToggleDirectMode,
-    None,
 }
 
 pub struct WindowRenderCtx<'a> {
@@ -89,14 +88,13 @@ pub trait WindowDecorator: std::fmt::Debug + Send + Sync {
         ctx: WindowRenderCtx<'_>,
     );
 
-    fn hit_test(&self, window_rect: LayoutRect, x: u16, y: u16) -> HeaderAction;
-
     /// Returns the content area inside the decorations, relative to `window_rect`.
     fn content_area(&self, window_rect: LayoutRect) -> LayoutRect;
 }
 
 #[derive(Debug)]
 pub struct DefaultDecorator {
+    #[expect(dead_code)]
     show_buttons: bool,
 }
 
@@ -132,32 +130,6 @@ pub fn header_buttons(outer_right: u16) -> [(u16, HeaderAction, &'static str); 4
 }
 
 impl WindowDecorator for DefaultDecorator {
-    fn hit_test(&self, rect: LayoutRect, x: u16, y: u16) -> HeaderAction {
-        if !self.show_buttons {
-            return HeaderAction::Drag;
-        }
-
-        let outer_left = rect.x as u16;
-        let outer_right = (rect.x as u16)
-            .saturating_add(rect.width)
-            .saturating_sub(EDGE_INDEX_ADJUST);
-        let header_y = (rect.y as u16).saturating_add(TOP_BORDER_HEIGHT);
-
-        if y != header_y {
-            return HeaderAction::None;
-        }
-        if x <= outer_left || x >= outer_right {
-            return HeaderAction::None;
-        }
-
-        for (bx, action, _) in header_buttons(outer_right) {
-            if x == bx {
-                return action;
-            }
-        }
-        HeaderAction::Drag
-    }
-
     fn render_window(
         &self,
         _backend: &mut dyn term_wm_render::RenderBackend,
@@ -187,46 +159,5 @@ mod tests {
         let dec = DefaultDecorator::new();
         let s = format!("{:?}", dec);
         assert!(s.contains("DefaultDecorator"));
-    }
-
-    #[test]
-    fn hit_test_returns_expected_actions() {
-        let dec = DefaultDecorator::new();
-        let rect = LayoutRect {
-            x: 10,
-            y: 5,
-            width: 10,
-            height: 6,
-        };
-        // header_y = y + 1 = 6
-        let header_y = 6;
-
-        // outside header row
-        assert_eq!(dec.hit_test(rect, 11, 5), HeaderAction::None);
-
-        // left/right edges
-        assert_eq!(dec.hit_test(rect, 10, header_y), HeaderAction::None);
-        assert_eq!(dec.hit_test(rect, 19, header_y), HeaderAction::None);
-
-        // buttons: compute positions (right-to-left: close, maximize, minimize, direct)
-        let outer_right = (rect.x as u16) + rect.width - 1;
-        let close_x = outer_right.saturating_sub(HEADER_BUTTON_GAP);
-        let max_x = close_x.saturating_sub(HEADER_BUTTON_GAP);
-        let min_x = max_x.saturating_sub(HEADER_BUTTON_GAP);
-        let kb_x = min_x.saturating_sub(HEADER_BUTTON_GAP);
-
-        assert_eq!(dec.hit_test(rect, close_x, header_y), HeaderAction::Close);
-        assert_eq!(dec.hit_test(rect, max_x, header_y), HeaderAction::Maximize);
-        assert_eq!(dec.hit_test(rect, min_x, header_y), HeaderAction::Minimize);
-        assert_eq!(
-            dec.hit_test(rect, kb_x, header_y),
-            HeaderAction::ToggleDirectMode
-        );
-
-        // area between buttons -> drag
-        assert_eq!(
-            dec.hit_test(rect, (rect.x as u16) + 2, header_y),
-            HeaderAction::Drag
-        );
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/command_menu.rs
+++ b/crates/term-wm-core/src/window/window_manager/command_menu.rs
@@ -56,7 +56,10 @@ impl WindowManager {
             }
         }
 
-        let ctx = self.component_context(false).with_overlay(true);
+        let ctx = self
+            .component_context(false)
+            .with_overlay(true)
+            .with_screen_area(self.managed_area());
         let Some(menu) = &mut self.command_menu_component else {
             return None;
         };

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2298,6 +2298,7 @@ fn make_keys(wm: &mut WindowManager, n: usize) -> Vec<WindowKey> {
 mod tests {
     use super::*;
     use crate::layout::{Constraint, Direction};
+    use std::collections::VecDeque;
     use term_wm_layout_engine::LayoutRect;
 
     /// Test fixture: how far back to set `drag_last_event` to simulate
@@ -5181,5 +5182,457 @@ mod tests {
             )),
             "registry must contain LayoutHandle at split gap"
         );
+    }
+
+    #[test]
+    fn header_close_action_closes_window() {
+        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use crate::layout::{LayoutNode, TilingLayout};
+
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let keys = make_keys(&mut wm, 100);
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        wm.managed_draw_order = vec![keys[1]];
+        wm.z_order = vec![keys[1]];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(keys[1]);
+        wm.transition_window(keys[1], crate::window::entry::WindowState::Mapped);
+
+        let win_key = keys[1];
+        let full_rect = wm.full_region_for_key(win_key);
+        let outer_right = full_rect
+            .x
+            .saturating_add(i32::from(full_rect.width))
+            .saturating_sub(1);
+        let close_x = outer_right as u16;
+        let close_y = full_rect.y.saturating_add(1) as u16;
+
+        wm.hitbox_registry.register(
+            HitTarget::ChromeHeader(win_key, crate::window::decorator::HeaderAction::Close),
+            LayoutRect {
+                x: i32::from(close_x),
+                y: i32::from(close_y),
+                width: 1,
+                height: 1,
+            },
+        );
+
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            column: close_x,
+            row: close_y,
+            modifiers: KeyModifiers::NONE,
+        });
+        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
+        assert!(wm.dispatch_mouse(&wm_click));
+    }
+
+    #[test]
+    fn header_maximize_action_toggles_maximize() {
+        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use crate::layout::{LayoutNode, TilingLayout};
+
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let keys = make_keys(&mut wm, 100);
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        wm.managed_draw_order = vec![keys[1]];
+        wm.z_order = vec![keys[1]];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(keys[1]);
+        wm.transition_window(keys[1], crate::window::entry::WindowState::Mapped);
+
+        let win_key = keys[1];
+        let full_rect = wm.full_region_for_key(win_key);
+        let outer_right = full_rect
+            .x
+            .saturating_add(i32::from(full_rect.width))
+            .saturating_sub(1);
+        let close_x = outer_right.saturating_sub(2);
+        let max_x = close_x as u16;
+        let max_y = full_rect.y.saturating_add(1) as u16;
+
+        wm.hitbox_registry.register(
+            HitTarget::ChromeHeader(win_key, crate::window::decorator::HeaderAction::Maximize),
+            LayoutRect {
+                x: i32::from(max_x),
+                y: i32::from(max_y),
+                width: 1,
+                height: 1,
+            },
+        );
+
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            column: max_x,
+            row: max_y,
+            modifiers: KeyModifiers::NONE,
+        });
+        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
+        assert!(wm.dispatch_mouse(&wm_click));
+    }
+
+    #[test]
+    fn header_minimize_action_minimizes_window() {
+        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use crate::layout::{LayoutNode, TilingLayout};
+
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let keys = make_keys(&mut wm, 100);
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        wm.managed_draw_order = vec![keys[1]];
+        wm.z_order = vec![keys[1]];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(keys[1]);
+        wm.transition_window(keys[1], crate::window::entry::WindowState::Mapped);
+
+        let win_key = keys[1];
+        let full_rect = wm.full_region_for_key(win_key);
+        let outer_right = full_rect
+            .x
+            .saturating_add(i32::from(full_rect.width))
+            .saturating_sub(1);
+        let close_x = outer_right.saturating_sub(2);
+        let max_x = close_x.saturating_sub(2);
+        let min_x = max_x as u16;
+        let min_y = full_rect.y.saturating_add(1) as u16;
+
+        wm.hitbox_registry.register(
+            HitTarget::ChromeHeader(win_key, crate::window::decorator::HeaderAction::Minimize),
+            LayoutRect {
+                x: i32::from(min_x),
+                y: i32::from(min_y),
+                width: 1,
+                height: 1,
+            },
+        );
+
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            column: min_x,
+            row: min_y,
+            modifiers: KeyModifiers::NONE,
+        });
+        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
+        assert!(wm.dispatch_mouse(&wm_click));
+    }
+
+    #[test]
+    fn overlay_dispatch_passes_screen_area_to_context() {
+        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use crate::layout::{LayoutNode, TilingLayout};
+
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let keys = make_keys(&mut wm, 100);
+        wm.set_panel_visible(false);
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        wm.managed_draw_order = vec![keys[1]];
+        wm.z_order = vec![keys[1]];
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_app_window(keys[1]);
+
+        let overlay_rect = LayoutRect {
+            x: 10,
+            y: 5,
+            width: 30,
+            height: 15,
+        };
+
+        struct TestOverlay {
+            got_screen_area: std::cell::Cell<bool>,
+        }
+        impl crate::components::Component<TermWmAction> for TestOverlay {
+            fn handle_events(
+                &mut self,
+                _event: &Event,
+                ctx: &crate::components::ComponentContext,
+            ) -> crate::actions::EventResult<TermWmAction> {
+                if ctx.screen_area().is_some() {
+                    self.got_screen_area.set(true);
+                }
+                crate::actions::EventResult::Consumed
+            }
+            fn update(
+                &mut self,
+                _: TermWmAction,
+                _: &crate::components::ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, TermWmAction)>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &crate::components::ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+        impl crate::components::Overlay<TermWmAction> for TestOverlay {}
+
+        wm.open_overlay(
+            OverlayId::Help,
+            Some(Box::new(TestOverlay {
+                got_screen_area: std::cell::Cell::new(false),
+            })),
+        );
+
+        wm.hitbox_registry
+            .register(HitTarget::Overlay(OverlayId::Help), overlay_rect);
+
+        let click = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            column: 15,
+            row: 8,
+            modifiers: KeyModifiers::NONE,
+        });
+        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
+        assert!(wm.dispatch_mouse(&wm_click));
+    }
+
+    #[test]
+    fn overlay_close_exit_confirm_removes_overlay() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(!wm.exit_confirm_visible());
+
+        struct StubOverlay;
+        impl crate::components::Component<TermWmAction> for StubOverlay {
+            fn update(
+                &mut self,
+                _: TermWmAction,
+                _: &crate::components::ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, TermWmAction)>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &crate::components::ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+        impl crate::components::Overlay<TermWmAction> for StubOverlay {}
+
+        wm.open_overlay(OverlayId::ExitConfirm, Some(Box::new(StubOverlay)));
+        assert!(wm.exit_confirm_visible());
+        wm.close_exit_confirm();
+        assert!(!wm.exit_confirm_visible());
+    }
+
+    #[test]
+    fn overlay_help_visible_and_close() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(!wm.help_overlay_visible());
+
+        struct StubOverlay;
+        impl crate::components::Component<TermWmAction> for StubOverlay {
+            fn update(
+                &mut self,
+                _: TermWmAction,
+                _: &crate::components::ComponentContext,
+                _: &mut VecDeque<(crate::window::WindowKey, TermWmAction)>,
+            ) {
+            }
+            fn render(
+                &mut self,
+                _: &mut dyn term_wm_render::RenderBackend,
+                _: LayoutRect,
+                _: &crate::components::ComponentContext,
+                _: &mut crate::hitbox_registry::HitboxRegistry,
+            ) {
+            }
+        }
+        impl crate::components::Overlay<TermWmAction> for StubOverlay {}
+
+        wm.open_overlay(OverlayId::Help, Some(Box::new(StubOverlay)));
+        assert!(wm.help_overlay_visible());
+        wm.close_help_overlay();
+        assert!(!wm.help_overlay_visible());
+    }
+
+    #[test]
+    fn handle_exit_confirm_event_returns_none_without_overlay() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let event = Event::Key(crate::events::KeyEvent {
+            code: crate::events::KeyCode::Esc,
+            modifiers: crate::events::KeyModifiers::NONE,
+            kind: crate::events::KeyKind::Press,
+        });
+        assert!(wm.handle_exit_confirm_event(&event).is_none());
+    }
+
+    #[test]
+    fn fold_menu_is_noop_without_component() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        wm.fold_menu();
+    }
+
+    #[test]
+    fn command_menu_open_close_visibility() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(!wm.command_menu_visible());
+        wm.open_command_menu();
+        assert!(wm.command_menu_visible());
+        wm.close_command_menu();
+        assert!(!wm.command_menu_visible());
+    }
+
+    #[test]
+    fn command_menu_open_no_passthrough_sets_opened_at_none() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        wm.open_command_menu_no_passthrough();
+        assert!(wm.command_menu_visible());
+        wm.close_command_menu();
+    }
+
+    #[test]
+    fn handle_wm_menu_event_returns_none_when_not_visible() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let event = Event::Key(crate::events::KeyEvent {
+            code: crate::events::KeyCode::Esc,
+            modifiers: crate::events::KeyModifiers::NONE,
+            kind: crate::events::KeyKind::Press,
+        });
+        assert!(wm.handle_wm_menu_event(&event).is_none());
+    }
+
+    #[test]
+    fn wm_menu_consumes_event_returns_false_when_not_visible() {
+        let wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        let event = Event::Key(crate::events::KeyEvent {
+            code: crate::events::KeyCode::Esc,
+            modifiers: crate::events::KeyModifiers::NONE,
+            kind: crate::events::KeyKind::Press,
+        });
+        assert!(!wm.wm_menu_consumes_event(&event));
+    }
+
+    #[test]
+    fn wm_menu_consumes_event_returns_false_for_mouse_event() {
+        let mut wm = WindowManager::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            None,
+            None,
+            None,
+        );
+        wm.open_command_menu();
+        let event = Event::Mouse(crate::events::MouseEvent {
+            column: 0,
+            row: 0,
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        assert!(!wm.wm_menu_consumes_event(&event));
+        wm.close_command_menu();
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -1321,84 +1321,77 @@ impl WindowManager {
                 self.mouse_capture = Some(MouseCaptureState::ComponentInteraction { key });
                 consumed
             }
-            HitTarget::ChromeHeader(key, _) => {
-                let rect = self.visible_region_for_key(key);
-                match self.decorator().hit_test(rect, col, row) {
-                    HeaderAction::Close => {
-                        self.close_window(key);
-                        self.last_header_click = None;
-                        true
-                    }
-                    HeaderAction::Maximize => {
+            HitTarget::ChromeHeader(key, action) => match action {
+                HeaderAction::Close => {
+                    self.close_window(key);
+                    self.last_header_click = None;
+                    true
+                }
+                HeaderAction::Maximize => {
+                    self.toggle_maximize(key);
+                    self.last_header_click = None;
+                    true
+                }
+                HeaderAction::Minimize => {
+                    self.minimize_window(key);
+                    self.last_header_click = None;
+                    true
+                }
+                HeaderAction::ToggleDirectMode => {
+                    self.toggle_direct_mode(key);
+                    self.last_header_click = None;
+                    true
+                }
+                HeaderAction::Drag => {
+                    let now = Instant::now();
+                    if let Some((prev_key, prev)) = self.last_header_click
+                        && prev_key == key
+                        && now.duration_since(prev) <= Duration::from_millis(500)
+                    {
                         self.toggle_maximize(key);
                         self.last_header_click = None;
-                        true
+                        return true;
                     }
-                    HeaderAction::Minimize => {
-                        self.minimize_window(key);
-                        self.last_header_click = None;
-                        true
+                    self.last_header_click = Some((key, now));
+
+                    if self.is_window_floating(key) {
+                        self.bring_floating_to_front_key(key);
+                    } else {
+                        self.bring_to_front_key(key);
                     }
-                    HeaderAction::ToggleDirectMode => {
-                        self.toggle_direct_mode(key);
-                        self.last_header_click = None;
-                        true
-                    }
-                    HeaderAction::Drag => {
-                        let now = Instant::now();
-                        if let Some((prev_key, prev)) = self.last_header_click
-                            && prev_key == key
-                            && now.duration_since(prev) <= Duration::from_millis(500)
+
+                    let rect = self.visible_region_for_key(key);
+                    let (initial_x, initial_y) =
+                        if let Some(crate::window::FloatRectSpec::Absolute(fr)) =
+                            self.floating_rect(key)
                         {
-                            self.toggle_maximize(key);
-                            self.last_header_click = None;
-                            return true;
-                        }
-                        self.last_header_click = Some((key, now));
-
-                        if self.is_window_floating(key) {
-                            self.bring_floating_to_front_key(key);
+                            (fr.x, fr.y)
                         } else {
-                            // Defer floating decoupling until the drag deadzone
-                            // is breached.  Capture the pointer now; the floating
-                            // rect will be installed on the first Drag event that
-                            // exceeds the kinetic threshold (dx + dy > 2).
-                            self.bring_to_front_key(key);
-                        }
-
-                        let (initial_x, initial_y) =
-                            if let Some(crate::window::FloatRectSpec::Absolute(fr)) =
-                                self.floating_rect(key)
-                            {
-                                (fr.x, fr.y)
-                            } else {
-                                (rect.x, rect.y)
-                            };
-                        self.mouse_capture = Some(MouseCaptureState::DraggingWindow {
-                            key,
-                            resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
-                            anchor_x: col,
-                            anchor_y: row,
-                            initial_x,
-                            initial_y,
-                            start_x: col,
-                            start_y: row,
-                            prev_col: col,
-                            prev_row: row,
-                            prev_time_ns: std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_nanos() as u64)
-                                .unwrap_or(0),
-                            detach_coordinate: None,
-                            snap_applied: false,
-                        });
-                        self.drag_last_event = Some(Instant::now());
-                        self.arm_drag_snap_timer();
-                        true
-                    }
-                    HeaderAction::None => false,
+                            (rect.x, rect.y)
+                        };
+                    self.mouse_capture = Some(MouseCaptureState::DraggingWindow {
+                        key,
+                        resistance: term_wm_layout_engine::EdgeResistance::default_tui(),
+                        anchor_x: col,
+                        anchor_y: row,
+                        initial_x,
+                        initial_y,
+                        start_x: col,
+                        start_y: row,
+                        prev_col: col,
+                        prev_row: row,
+                        prev_time_ns: std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_nanos() as u64)
+                            .unwrap_or(0),
+                        detach_coordinate: None,
+                        snap_applied: false,
+                    });
+                    self.drag_last_event = Some(Instant::now());
+                    self.arm_drag_snap_timer();
+                    true
                 }
-            }
+            },
             HitTarget::ChromeResize(key, edge) => {
                 if !self.config.floating_windows_enabled || !self.is_window_floating(key) {
                     return false;
@@ -1455,7 +1448,9 @@ impl WindowManager {
                 false
             }
             HitTarget::Overlay(id) => {
-                let ctx = self.component_context_for(false, slotmap::DefaultKey::default());
+                let ctx = self
+                    .component_context_for(false, slotmap::DefaultKey::default())
+                    .with_screen_area(hit_rect);
                 if let Some(overlay) = self.overlays.get_mut(&id) {
                     let result = overlay.handle_events(&core_event, &ctx);
                     !result.is_ignored()
@@ -3543,20 +3538,26 @@ mod tests {
         let min_x = max_x.saturating_sub(2);
         let kb_x = min_x.saturating_sub(2) as u16;
         let kb_y = full_rect.y.saturating_add(1) as u16; // header row
-        assert_eq!(
-            wm.decorator().hit_test(full_rect, kb_x, kb_y),
-            crate::window::decorator::HeaderAction::ToggleDirectMode,
-            "hit_test should detect D button at ({},{}) on {:?}",
-            kb_x,
-            kb_y,
-            full_rect
-        );
-
         assert!(!wm.direct_mode(win_key), "starts off");
 
+        // Register header hitboxes matching the render-pass arrangement:
+        // Drag zone for the full header, per-button hitbox for "D".
         wm.hitbox_registry.register(
             HitTarget::ChromeHeader(win_key, crate::window::decorator::HeaderAction::Drag),
             full_rect,
+        );
+        let button_rect = term_wm_layout_engine::LayoutRect {
+            x: i32::from(kb_x),
+            y: full_rect.y.saturating_add(1),
+            width: 1,
+            height: 1,
+        };
+        wm.hitbox_registry.register(
+            HitTarget::ChromeHeader(
+                win_key,
+                crate::window::decorator::HeaderAction::ToggleDirectMode,
+            ),
+            button_rect,
         );
 
         let click = Event::Mouse(MouseEvent {
@@ -3964,14 +3965,22 @@ mod tests {
         let min_x = max_x.saturating_sub(2);
         let kb_x = min_x.saturating_sub(2) as u16;
         let kb_y = full_rect.y.saturating_add(1) as u16; // header row
-        assert_eq!(
-            wm.decorator().hit_test(full_rect, kb_x, kb_y),
-            crate::window::decorator::HeaderAction::ToggleDirectMode,
-        );
-
         wm.hitbox_registry.register(
             HitTarget::ChromeHeader(win_key, crate::window::decorator::HeaderAction::Drag),
             full_rect,
+        );
+        let button_rect = term_wm_layout_engine::LayoutRect {
+            x: i32::from(kb_x),
+            y: full_rect.y.saturating_add(1),
+            width: 1,
+            height: 1,
+        };
+        wm.hitbox_registry.register(
+            HitTarget::ChromeHeader(
+                win_key,
+                crate::window::decorator::HeaderAction::ToggleDirectMode,
+            ),
+            button_rect,
         );
 
         assert!(wm.direct_mode(win_key), "direct mode enabled before click");
@@ -4599,15 +4608,15 @@ mod tests {
                 _registry: &mut crate::hitbox_registry::HitboxRegistry,
             ) {
             }
-            fn on_mouse(
+            fn on_mouse_press(
                 &mut self,
-                mouse: &crate::events::LocalMouseEvent,
+                _local_x: u16,
+                _local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
                 ctx: &ComponentContext,
             ) -> EventResult<TermWmAction> {
-                if !ctx.direct_mode()
-                    && self.enabled
-                    && matches!(mouse.kind, MouseEventKind::Press(_))
-                {
+                if !ctx.direct_mode() && self.enabled {
                     self.received_down = true;
                     return EventResult::Consumed;
                 }
@@ -4691,14 +4700,43 @@ mod tests {
                 _registry: &mut crate::hitbox_registry::HitboxRegistry,
             ) {
             }
-            fn on_mouse(
+            fn on_mouse_press(
                 &mut self,
-                mouse: &crate::events::LocalMouseEvent,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
                 _ctx: &ComponentContext,
             ) -> EventResult<TermWmAction> {
                 EventResult::Action(TermWmAction::MouseToBytes(vec![
-                    mouse.col as u8,
-                    mouse.row as u8,
+                    local_x as u8,
+                    local_y as u8,
+                ]))
+            }
+            fn on_mouse_release(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<TermWmAction> {
+                EventResult::Action(TermWmAction::MouseToBytes(vec![
+                    local_x as u8,
+                    local_y as u8,
+                ]))
+            }
+            fn on_mouse_drag(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<TermWmAction> {
+                EventResult::Action(TermWmAction::MouseToBytes(vec![
+                    local_x as u8,
+                    local_y as u8,
                 ]))
             }
             fn on_key(
@@ -4781,7 +4819,7 @@ mod tests {
     fn phase3_moved_dispatches_mouse_action_to_update() {
         use crate::actions::EventResult;
         use crate::components::{Component, ComponentContext};
-        use crate::events::{Event, KeyModifiers, MouseEvent, MouseEventKind};
+        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
         use std::collections::VecDeque;
 
         struct ActionRecorder {
@@ -4796,14 +4834,55 @@ mod tests {
                 _registry: &mut crate::hitbox_registry::HitboxRegistry,
             ) {
             }
-            fn on_mouse(
+            fn on_mouse_press(
                 &mut self,
-                mouse: &crate::events::LocalMouseEvent,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
                 _ctx: &ComponentContext,
             ) -> EventResult<TermWmAction> {
                 EventResult::Action(TermWmAction::MouseToBytes(vec![
-                    mouse.col as u8,
-                    mouse.row as u8,
+                    local_x as u8,
+                    local_y as u8,
+                ]))
+            }
+            fn on_mouse_release(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<TermWmAction> {
+                EventResult::Action(TermWmAction::MouseToBytes(vec![
+                    local_x as u8,
+                    local_y as u8,
+                ]))
+            }
+            fn on_mouse_drag(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _button: MouseButton,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<TermWmAction> {
+                EventResult::Action(TermWmAction::MouseToBytes(vec![
+                    local_x as u8,
+                    local_y as u8,
+                ]))
+            }
+            fn on_mouse_move(
+                &mut self,
+                local_x: u16,
+                local_y: u16,
+                _modifiers: KeyModifiers,
+                _ctx: &ComponentContext,
+            ) -> EventResult<TermWmAction> {
+                EventResult::Action(TermWmAction::MouseToBytes(vec![
+                    local_x as u8,
+                    local_y as u8,
                 ]))
             }
             fn on_key(

--- a/crates/term-wm-core/src/window/window_manager/overlays.rs
+++ b/crates/term-wm-core/src/window/window_manager/overlays.rs
@@ -22,7 +22,10 @@ impl WindowManager {
     }
 
     pub fn handle_help_event(&mut self, event: &Event) -> bool {
-        let ctx = self.component_context(true).with_overlay(true);
+        let ctx = self
+            .component_context(true)
+            .with_overlay(true)
+            .with_screen_area(self.managed_area());
         let Some(boxed) = self.overlays.get_mut(&super::OverlayId::Help) else {
             return false;
         };

--- a/crates/term-wm-ui-components/src/list.rs
+++ b/crates/term-wm-ui-components/src/list.rs
@@ -2,13 +2,12 @@ use std::collections::VecDeque;
 
 use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders, List, ListItem};
-use term_wm_core::events::{Event, MouseButton, MouseEventKind};
+use term_wm_core::events::{Event, KeyModifiers, MouseButton};
 
 use crate::helpers::{color_to_ratatui, layout_rect_to_rect};
 use ratatui::widgets::Widget;
 use term_wm_core::actions::{EventResult, TermWmAction};
 use term_wm_core::components::{Component, ComponentContext};
-use term_wm_core::events::LocalMouseEvent;
 use term_wm_core::window::WindowKey;
 use term_wm_layout_engine::LayoutRect;
 
@@ -82,18 +81,18 @@ impl Component<TermWmAction> for ListComponent {
         list.render(inner, &mut backend.buffer);
     }
 
-    fn on_mouse(
+    fn on_mouse_press(
         &mut self,
-        mouse: &LocalMouseEvent,
+        _local_x: u16,
+        local_y: u16,
+        button: MouseButton,
+        _modifiers: KeyModifiers,
         ctx: &ComponentContext,
     ) -> EventResult<TermWmAction> {
-        if matches!(mouse.kind, MouseEventKind::Press(MouseButton::Left))
-            && ctx.focused()
-            && !self.items.is_empty()
-        {
+        if button == MouseButton::Left && ctx.focused() && !self.items.is_empty() {
             let vp = ctx.viewport();
             let skip_n = vp.offset_y.saturating_sub(1);
-            let visible_row = mouse.row.saturating_sub(1) as usize;
+            let visible_row = local_y.saturating_sub(1) as usize;
             let index = skip_n + visible_row;
             if index < self.items.len() {
                 self.selected = index;
@@ -393,15 +392,13 @@ mod tests {
         let mut list = ListComponent::new("t");
         list.set_items(vec!["a".into(), "b".into(), "c".into()]);
         let ctx = ComponentContext::new(true);
-        let mouse = term_wm_core::events::LocalMouseEvent {
-            col: 5,
-            row: 2,
-            kind: term_wm_core::events::MouseEventKind::Press(
-                term_wm_core::events::MouseButton::Left,
-            ),
-            modifiers: term_wm_core::events::KeyModifiers::NONE,
-        };
-        let result = list.on_mouse(&mouse, &ctx);
+        let result = list.on_mouse_press(
+            5,
+            2,
+            term_wm_core::events::MouseButton::Left,
+            term_wm_core::events::KeyModifiers::NONE,
+            &ctx,
+        );
         assert!(matches!(result, EventResult::Consumed));
         assert_eq!(list.selected(), 1);
     }
@@ -411,15 +408,13 @@ mod tests {
         let mut list = ListComponent::new("t");
         list.set_items(vec!["a".into(), "b".into()]);
         let ctx = ComponentContext::new(true);
-        let mouse = term_wm_core::events::LocalMouseEvent {
-            col: 5,
-            row: 10,
-            kind: term_wm_core::events::MouseEventKind::Press(
-                term_wm_core::events::MouseButton::Left,
-            ),
-            modifiers: term_wm_core::events::KeyModifiers::NONE,
-        };
-        let result = list.on_mouse(&mouse, &ctx);
+        let result = list.on_mouse_press(
+            5,
+            10,
+            term_wm_core::events::MouseButton::Left,
+            term_wm_core::events::KeyModifiers::NONE,
+            &ctx,
+        );
         assert!(matches!(result, EventResult::Ignored));
     }
 

--- a/crates/term-wm-ui-components/src/text_renderer.rs
+++ b/crates/term-wm-ui-components/src/text_renderer.rs
@@ -931,6 +931,112 @@ mod tests {
                 .is_dragging()
         );
     }
+
+    #[test]
+    fn on_mouse_press_delegates_to_handle_local_mouse() {
+        use ratatui::text::Line;
+        let mut renderer = TextRendererComponent::new();
+        renderer.set_selection_enabled(true);
+        renderer.set_wrap(false);
+        let lines: Vec<Line<'static>> = (0..5)
+            .map(|idx| Line::from(format!("line {idx}")))
+            .collect();
+        renderer.set_text(Text::from(lines));
+
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(area);
+        let result = renderer.on_mouse_press(5, 2, MouseButton::Left, KeyModifiers::NONE, &ctx);
+        assert!(result.is_ignored());
+    }
+
+    #[test]
+    fn on_mouse_release_delegates_to_handle_local_mouse() {
+        use ratatui::text::Line;
+        let mut renderer = TextRendererComponent::new();
+        renderer.set_selection_enabled(true);
+        renderer.set_wrap(false);
+        let lines: Vec<Line<'static>> = (0..5)
+            .map(|idx| Line::from(format!("line {idx}")))
+            .collect();
+        renderer.set_text(Text::from(lines));
+
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(area);
+        let result = renderer.on_mouse_release(5, 2, MouseButton::Left, KeyModifiers::NONE, &ctx);
+        assert!(result.is_ignored());
+    }
+
+    #[test]
+    fn on_mouse_drag_delegates_to_handle_local_mouse() {
+        use ratatui::text::Line;
+        let mut renderer = TextRendererComponent::new();
+        renderer.set_selection_enabled(true);
+        renderer.set_wrap(false);
+        let lines: Vec<Line<'static>> = (0..5)
+            .map(|idx| Line::from(format!("line {idx}")))
+            .collect();
+        renderer.set_text(Text::from(lines));
+
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(area);
+        let result = renderer.on_mouse_drag(5, 2, MouseButton::Left, KeyModifiers::NONE, &ctx);
+        assert!(result.is_ignored());
+    }
+
+    #[test]
+    fn on_mouse_move_delegates_to_handle_local_mouse() {
+        use ratatui::text::Line;
+        let mut renderer = TextRendererComponent::new();
+        renderer.set_selection_enabled(true);
+        renderer.set_wrap(false);
+        let lines: Vec<Line<'static>> = (0..5)
+            .map(|idx| Line::from(format!("line {idx}")))
+            .collect();
+        renderer.set_text(Text::from(lines));
+
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(area);
+        let result = renderer.on_mouse_move(5, 2, KeyModifiers::NONE, &ctx);
+        assert!(result.is_ignored());
+    }
+
+    #[test]
+    fn handle_local_mouse_with_zero_area_falls_back() {
+        let mut renderer = TextRendererComponent::new();
+        renderer.set_selection_enabled(true);
+        let lines: Vec<Line<'static>> = vec![Line::from("hello")];
+        renderer.set_text(Text::from(lines));
+
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        };
+        let ctx = ComponentContext::new(true).with_screen_area(area);
+        let result = renderer.on_mouse_press(0, 0, MouseButton::Left, KeyModifiers::NONE, &ctx);
+        assert!(result.is_ignored());
+    }
 }
 
 #[derive(Debug)]

--- a/crates/term-wm-ui-components/src/text_renderer.rs
+++ b/crates/term-wm-ui-components/src/text_renderer.rs
@@ -8,13 +8,12 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
-use term_wm_core::events::MouseEvent;
+use term_wm_core::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
 use crate::helpers::{color_to_ratatui, layout_rect_to_rect, linkified_to_text};
 use term_wm_core::actions::{EventResult, TermWmAction};
 use term_wm_core::component_context::{ScrollHandle, ScrollViewport};
 use term_wm_core::components::{Component, ComponentContext, SelectionStatus};
-use term_wm_core::events::LocalMouseEvent;
 use term_wm_core::utils::linkifier::LinkifiedText;
 use term_wm_core::utils::selectable_text::{
     LogicalPosition, SelectionController, SelectionHost, SelectionRange, SelectionViewport,
@@ -178,37 +177,65 @@ impl Component<TermWmAction> for TextRendererComponent {
         self.render_selection_overlay(&mut backend.buffer, screen_area, &ctx.config().theme);
     }
 
-    fn on_mouse(
+    fn on_mouse_press(
         &mut self,
-        mouse: &LocalMouseEvent,
+        local_x: u16,
+        local_y: u16,
+        button: MouseButton,
+        modifiers: KeyModifiers,
         ctx: &ComponentContext,
     ) -> EventResult<TermWmAction> {
-        self.viewport_cache.set(ctx.viewport());
-        if let Some(handle) = ctx.scroll_handle() {
-            self.scroll_handle.replace(Some(handle));
-        }
-        // Reconstruct screen-space MouseEvent for handle_selection_mouse
-        let screen_area = ctx
-            .screen_area()
-            .map(layout_rect_to_rect)
-            .unwrap_or_default();
-        let screen_mouse = MouseEvent {
-            column: mouse.col.saturating_add(screen_area.x),
-            row: mouse.row.saturating_add(screen_area.y),
-            kind: mouse.kind,
-            modifiers: mouse.modifiers,
-        };
-        let screen_area_lr = LayoutRect {
-            x: screen_area.x as i32,
-            y: screen_area.y as i32,
-            width: screen_area.width,
-            height: screen_area.height,
-        };
-        if handle_selection_mouse(self, self.selection_enabled, &screen_mouse, screen_area_lr) {
-            EventResult::Consumed
-        } else {
-            EventResult::Ignored
-        }
+        self.handle_local_mouse(
+            local_x,
+            local_y,
+            MouseEventKind::Press(button),
+            modifiers,
+            ctx,
+        )
+    }
+
+    fn on_mouse_release(
+        &mut self,
+        local_x: u16,
+        local_y: u16,
+        button: MouseButton,
+        modifiers: KeyModifiers,
+        ctx: &ComponentContext,
+    ) -> EventResult<TermWmAction> {
+        self.handle_local_mouse(
+            local_x,
+            local_y,
+            MouseEventKind::Release(button),
+            modifiers,
+            ctx,
+        )
+    }
+
+    fn on_mouse_drag(
+        &mut self,
+        local_x: u16,
+        local_y: u16,
+        button: MouseButton,
+        modifiers: KeyModifiers,
+        ctx: &ComponentContext,
+    ) -> EventResult<TermWmAction> {
+        self.handle_local_mouse(
+            local_x,
+            local_y,
+            MouseEventKind::Drag(button),
+            modifiers,
+            ctx,
+        )
+    }
+
+    fn on_mouse_move(
+        &mut self,
+        local_x: u16,
+        local_y: u16,
+        modifiers: KeyModifiers,
+        ctx: &ComponentContext,
+    ) -> EventResult<TermWmAction> {
+        self.handle_local_mouse(local_x, local_y, MouseEventKind::Moved, modifiers, ctx)
     }
 
     fn on_key(
@@ -624,6 +651,37 @@ impl TextRendererComponent {
         if let Some(handle) = self.scroll_handle.borrow().as_ref() {
             handle.scroll_vertical_to(0);
             handle.scroll_horizontal_to(0);
+        }
+    }
+
+    fn handle_local_mouse(
+        &mut self,
+        local_x: u16,
+        local_y: u16,
+        kind: MouseEventKind,
+        modifiers: KeyModifiers,
+        ctx: &ComponentContext,
+    ) -> EventResult<TermWmAction> {
+        self.viewport_cache.set(ctx.viewport());
+        if let Some(handle) = ctx.scroll_handle() {
+            self.scroll_handle.replace(Some(handle));
+        }
+        let raw_area = ctx.screen_area().unwrap_or(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        });
+        let screen_mouse = MouseEvent {
+            column: (i32::from(local_x) + raw_area.x).max(0) as u16,
+            row: (i32::from(local_y) + raw_area.y).max(0) as u16,
+            kind,
+            modifiers,
+        };
+        if handle_selection_mouse(self, self.selection_enabled, &screen_mouse, raw_area) {
+            EventResult::Consumed
+        } else {
+            EventResult::Ignored
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use term_wm_console::draw_plan_renderer::{
     render_resize_outline,
 };
 use term_wm_core::hitbox_registry::{HitTarget, HitboxRegistry};
-use term_wm_core::window::decorator::HeaderAction;
+use term_wm_core::window::decorator::{HeaderAction, header_buttons};
 use term_wm_core::window::{WindowManager, WindowSurface};
 
 /// Default rendering implementation for the window manager.
@@ -163,7 +163,19 @@ pub fn render_app(
                 entries.push((HitTarget::ChromeResize(h.key, h.edge), h.rect));
             }
             for h in wm.floating_headers().iter().filter(|h| h.key == k) {
+                // Drag zone (full header width) — lower priority in reverse scan
                 entries.push((HitTarget::ChromeHeader(h.key, HeaderAction::Drag), h.rect));
+                // Per-button 1x1 hitboxes at exact button positions — higher priority
+                let outer_right = (h.rect.x.saturating_add(i32::from(h.rect.width))).max(0) as u16;
+                for (bx, action, _) in header_buttons(outer_right) {
+                    let button_rect = term_wm_layout_engine::LayoutRect {
+                        x: i32::from(bx),
+                        y: h.rect.y,
+                        width: 1,
+                        height: 1,
+                    };
+                    entries.push((HitTarget::ChromeHeader(h.key, action), button_rect));
+                }
             }
         }
         // Tiling split handles last — highest priority at split boundaries,


### PR DESCRIPTION
Replace the monolithic on_mouse(&LocalMouseEvent) with 5 typed trait methods — on_mouse_press/release/drag/scroll/move — and make handle_events default dispatch exhaustively by MouseEventKind.

Remove the deprecated decorator.hit_test() pattern; header button actions now resolve directly from HitboxRegistry via the ChromeHeader(key, action) match in dispatch_mouse. Register per-button 1×1 hitboxes in render_app instead.

Inject screen_area into overlay, command_menu, and overlay dispatch contexts for correct coordinate conversion. Fix coordinate math to use i32 saturating arithmetic for off-screen windows.

Migrate all on_mouse overrides:
  - ListComponent -> on_mouse_press
  - TextRendererComponent -> on_mouse_press/release/drag/move
  - SelComponent, ActionRecorder test stubs -> semantic methods