### PR TITLE
core: Fix power profile calculation loop and resolve idle CPU burn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2523,14 +2523,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2543,11 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.14-alpha"
+version = "0.8.15-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -52,14 +52,14 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm = { path = ".", version = "0.8.14-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.8.14-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.14-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.14-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.14-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.8.14-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.14-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.14-alpha" }
+term-wm = { path = ".", version = "0.8.15-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.8.15-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.15-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.15-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.15-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.8.15-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.15-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.15-alpha" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,33 @@ _The benchmark reports frame pacing, render times (avg/1% lows), and cell-update
 - **Streaming** (~60 fps, 16ms interval) — active when PTY data is flowing (dirty windows pending render) or input was received within the last 500ms.
 - **PowerSaver** (blocks on channel, 3600s interval, default) — no input and no dirty windows; the event loop blocks on the channel with no CPU burn.
 
-The active profile is derived by `UnifiedEventSource::current_profile()` which calls `profile_from_activity(last_event_at, has_dirty_windows)`. The runner detects changes via `PowerProfileTracker` and propagates the new profile to `WindowManager` each frame. Developers can hook into `BottomPanelTrait::set_power_profile` for custom indicators or override `current_profile()` on custom `EventSource` implementations.
+The active profile is derived by `UnifiedEventSource::current_profile()` which calls `profile_from_activity(last_event_at, has_dirty_windows)`. The runner detects changes via `PowerProfileTracker` and propagates the new profile to `WindowManager` each frame. The bottom panel receives profile changes via `ComponentAction::SetPowerProfile`. Developers can override `current_profile()` on custom `EventSource` implementations.
+
+#### Low-Level Kernel Sleep & Hardware Interrupt Mechanics
+
+When the system satisfies the criteria for `PowerSaver` mode, user-space execution code ceases entirely, shifting execution weight directly down to the operating system kernel and physical hardware interrupts via a highly coordinated multi-layered synchronization layer:
+
+1. **User-Space Thread Parking (`futex`):** When the main thread calls `self.rx.recv_timeout()` inside `UnifiedEventSource::poll`, it delegates to the concurrency primitives of the crossbeam channel selector. Following a brief spin-lock phase to catch high-frequency back-to-back entries without context switching, the thread invokes an operating system thread-parking mechanic. On Linux, this resolves to a `futex` system call: `syscall(SYS_futex, &lock_address, FUTEX_WAIT_PRIVATE, expected_val, &timeout)`.
+
+2. **Kernel Suspension (0% CPU Burn):** The Linux kernel scheduler takes the main thread out of the CPU core's active execution run-queue and parks it in a passive wait-queue tied to that lock memory address, shifting the task state to `TASK_INTERRUPTIBLE`. At this point, the application consumes exactly 0% CPU cycles and is completely bypassed during standard scheduler cycles.
+
+3. **Hardware Interrupt & PTY Cascade:** When a user initiates hardware input (e.g., striking a key or moving a mouse), the device asserts a physical interrupt request line on the Advanced Programmable Interrupt Controller (APIC), forcing the CPU to branch to the kernel's Interrupt Descriptor Table (IDT). The kernel's input driver processes the raw device packets and pipes the character bytes into the target pseudoterminal (`PTY`) master/slave ring buffer.
+
+4. **Asynchronous Unblock:** The presence of new data in the PTY buffer triggers an active wake signal on the file descriptor being monitored via `epoll_wait`/`poll` by the background `crossterm-input` thread. This background thread awakens, parses the ANSI escape bytes into a core event structure, and drops it into the crossbeam channel via `input_tx.send()`. Recognizing that the primary event loop thread is parked, the channel primitive executes a `FUTEX_WAKE_PRIVATE` system call, shifting the main loop thread's task state back to `TASK_RUNNING` to resume instruction execution.
+
+Additionally, the runner bridges the scheduler's task deadlines into the event source via `set_max_sleep_duration()`. When a background task (e.g. a `SuperPassthrough` timeout, `DragSnap` timer) is scheduled, the runner pushes the task deadline from the `TaskScheduler` into the event source, which clamps its `poll_interval()` against it. This ensures PowerSaver's 3600s interval never blocks past a pending task deadline — the event loop wakes at exactly the right moment without busy-waiting.
+
+#### The Immediate-Mode Visual Phase Lag Illusion
+
+Due to the constraints of an immediate-mode rendering architecture, monitoring the power state via on-screen indicators (such as the status panel or debug log window) reveals a constant "Streaming" text pattern during complete idleness. This is an expected artifact of loop phase ordering, not a failure of the power manager:
+
+1. **Render Pass Execution:** The runner executes an active frame cycle and invokes `output.draw()`. The layout components query the window manager's text configurations while the global profile variable still evaluates to `Streaming`, rasterizing the yellow status indicator text bytes into the cell character grid matrix.
+
+2. **State Consumption & Calibration:** Immediately *after* the frame buffer is successfully drawn and committed, `flush_state_changes()` triggers. It executes `driver.take_dirty_windows()` to flush update vectors and evaluates `current_profile()`. Finding the inactivity thresholds crossed, it mutates the authoritative profile variable down to `PowerSaver`.
+
+3. **Instant Suspension:** The loop boundary yields control back to `EventLoop::run`, which immediately queries `self.driver.poll(poll_interval)`. Since the profile was just scaled down to `PowerSaver`, the main execution thread immediately executes its futex system wait call and drops into deep kernel sleep *before another drawing frame can render*.
+
+Consequently, the terminal cell matrix safely preserves the visual text painted during Step 1. The CPU is completely asleep at 0% utilization, but the display remains frozen on the word "Streaming". When hardware input unblocks the thread, event routing instantly elevates the engine to `Interactive` or `Streaming` *before* the subsequent frame pass, causing the on-screen status to jump from "Streaming" straight to "Interactive"—entirely skipping the visible display of the intermediate `PowerSaver` phase.
 
 ## License
 

--- a/crates/term-wm-core/src/io/event_source.rs
+++ b/crates/term-wm-core/src/io/event_source.rs
@@ -40,9 +40,29 @@ pub trait EventSource {
     /// [`current_profile()`]: Self::current_profile
     fn set_pending_work(&mut self, _pending: bool) {}
 
+    /// Inform the event source of the maximum duration it is allowed to block
+    /// before the next scheduled background task expires.
+    ///
+    /// The runner calls this at the end of each cycle with the shortest
+    /// deadline from the task scheduler.  When `None` there are no upcoming
+    /// tasks and the source may use its full profile-based poll interval.
+    ///
+    /// The default is a no-op for sources that don't need deadline awareness.
+    fn set_max_sleep_duration(&mut self, _duration: Option<std::time::Duration>) {}
+
     /// Take accumulated window exit notifications. Default returns empty.
     fn take_exited_windows(&mut self) -> Vec<crate::window::WindowKey> {
         Vec::new()
+    }
+
+    /// Take accumulated dirty-window keys and reset the set.
+    ///
+    /// After a successful render the runner calls this to signal that all
+    /// pending PTY output has been displayed and the power profile may
+    /// drop back to `PowerSaver`.  The default returns an empty set for
+    /// event sources that do not track dirty windows.
+    fn take_dirty_windows(&mut self) -> std::collections::HashSet<crate::window::WindowKey> {
+        std::collections::HashSet::new()
     }
 }
 
@@ -71,6 +91,10 @@ impl<T: EventSource + ?Sized> EventSource for &mut T {
         (**self).set_pending_work(pending)
     }
 
+    fn set_max_sleep_duration(&mut self, duration: Option<std::time::Duration>) {
+        (**self).set_max_sleep_duration(duration)
+    }
+
     fn poll_interval(&self) -> Duration {
         (**self).poll_interval()
     }
@@ -81,6 +105,10 @@ impl<T: EventSource + ?Sized> EventSource for &mut T {
 
     fn take_exited_windows(&mut self) -> Vec<crate::window::WindowKey> {
         (**self).take_exited_windows()
+    }
+
+    fn take_dirty_windows(&mut self) -> std::collections::HashSet<crate::window::WindowKey> {
+        (**self).take_dirty_windows()
     }
 }
 
@@ -128,5 +156,74 @@ mod tests {
         } else {
             panic!("expected key");
         }
+    }
+
+    #[test]
+    fn take_dirty_windows_default_returns_empty() {
+        let mut d = Dummy;
+        let set = EventSource::take_dirty_windows(&mut d);
+        assert!(set.is_empty(), "default impl must return empty set");
+    }
+
+    #[test]
+    fn take_dirty_windows_via_mut_ref_forwards_to_inner() {
+        struct TrackingSource {
+            dirty: std::collections::HashSet<crate::window::WindowKey>,
+        }
+
+        impl EventSource for TrackingSource {
+            fn poll(&mut self, _: Duration) -> io::Result<bool> {
+                Ok(false)
+            }
+            fn read(&mut self) -> io::Result<Event> {
+                unreachable!()
+            }
+            fn next_key(&mut self) -> io::Result<KeyEvent> {
+                unreachable!()
+            }
+            fn next_mouse(&mut self) -> io::Result<MouseEvent> {
+                unreachable!()
+            }
+            fn take_dirty_windows(
+                &mut self,
+            ) -> std::collections::HashSet<crate::window::WindowKey> {
+                std::mem::take(&mut self.dirty)
+            }
+        }
+
+        let mut inner = TrackingSource {
+            dirty: std::collections::HashSet::from([crate::window::WindowKey::default()]),
+        };
+        let mut reference = &mut inner;
+
+        // Call through the blanket impl — must forward to TrackingSource, not the default.
+        let taken = EventSource::take_dirty_windows(&mut reference);
+        assert_eq!(taken.len(), 1, "must forward to concrete impl");
+        assert!(
+            reference.dirty.is_empty(),
+            "concrete impl must have cleared its dirty set"
+        );
+    }
+
+    #[test]
+    fn set_max_sleep_duration_default_does_not_panic() {
+        struct Stub;
+        impl EventSource for Stub {
+            fn poll(&mut self, _: Duration) -> io::Result<bool> {
+                Ok(false)
+            }
+            fn read(&mut self) -> io::Result<Event> {
+                unreachable!()
+            }
+            fn next_key(&mut self) -> io::Result<KeyEvent> {
+                unreachable!()
+            }
+            fn next_mouse(&mut self) -> io::Result<MouseEvent> {
+                Err(io::Error::other("no"))
+            }
+        }
+        let mut s = Stub;
+        EventSource::set_max_sleep_duration(&mut s, Some(Duration::from_secs(1)));
+        EventSource::set_max_sleep_duration(&mut s, None);
     }
 }

--- a/crates/term-wm-core/src/power_profile.rs
+++ b/crates/term-wm-core/src/power_profile.rs
@@ -128,7 +128,7 @@ impl PowerProfile {
     }
 
     pub fn report_change(&self) {
-        tracing::info!(target: "power", "profile: {}", self.name());
+        tracing::trace!(target: "power", "profile: {}", self.name());
     }
 }
 

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -200,7 +200,7 @@ where
             for key in driver.take_exited_windows() {
                 app.wm().close_window(key);
             }
-            let mut flush_state_changes = |app: &mut A, flow: ControlFlow| {
+            let mut flush_state_changes = |app: &mut A, flow: ControlFlow, consume_dirty: bool| {
                 if let Some(enabled) = app.wm().take_mouse_capture_change() {
                     let _ = driver.set_mouse_capture(enabled);
                 }
@@ -210,11 +210,23 @@ where
                 if let Some(sel_enabled) = app.wm().take_window_selection_change() {
                     app.set_window_selection_enabled(sel_enabled);
                 }
+                if consume_dirty {
+                    // Consume accumulated dirty-window keys so the power
+                    // profile can drop back to PowerSaver when idle.  Only
+                    // call after a successful render — on panics the dirty
+                    // set is preserved so the next frame picks it up.
+                    driver.take_dirty_windows();
+                }
+                // Clamp the driver's sleep duration to the next scheduler
+                // deadline so PowerSaver's 3600s interval doesn't block
+                // past a pending task timeout (e.g. SuperPassthrough).
+                driver.set_max_sleep_duration(system_handle.time_until_next());
                 if let Some(profile) = profile_tracker.poll(driver.current_profile()) {
                     app.wm().set_power_profile(profile);
                 }
                 Ok(flow)
             };
+            let mut did_panic = false;
             if let Some(evt) = event {
                 // Synthesized key event from bottom-panel hint click takes priority
                 let evt = app.wm().take_synthetic_event().unwrap_or(evt);
@@ -240,13 +252,13 @@ where
                         }
                     }
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
 
                 if app.wm().help_overlay_visible() {
                     let _ = app.wm().handle_help_event(&evt);
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
 
                 // If keyboard capture is disabled for the focused window, key events
@@ -269,19 +281,19 @@ where
                             crate::window::SuperPressResult::DoubleSuper => {
                                 app.wm().open_command_menu_no_passthrough();
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             crate::window::SuperPressResult::Pending => {
                                 // First Super of a pair — deferred. Panel shows countdown.
                                 // Timeout forwarding happens in the idle path below.
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             crate::window::SuperPressResult::Forward => {
                                 // Non-wm-toggle key → forward to terminal immediately.
                                 let _ = handle_focused_app_event(&evt, app);
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                         }
                     }
@@ -290,7 +302,7 @@ where
                 // Layer 2a: App-level event handler (before WM actions, after overlays)
                 if app.handle_app_event(&evt) {
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
 
                 // Layer 2b: Global-layer actions (only WmToggleOverlay is Global;
@@ -329,7 +341,7 @@ where
                         app.wm().open_command_menu();
                     }
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
                 if wm_mode && app.wm().command_menu_visible() {
                     if let Some(action) = app.wm().handle_wm_menu_event(&evt) {
@@ -383,16 +395,16 @@ where
                                 app.wm().close_command_menu();
                                 app.open_exit_confirm();
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             _ => {}
                         }
                         update_selection_snapshot(app);
-                        return flush_state_changes(app, ControlFlow::Continue);
+                        return flush_state_changes(app, ControlFlow::Continue, false);
                     }
                     if app.wm().wm_menu_consumes_event(&evt) {
                         update_selection_snapshot(app);
-                        return flush_state_changes(app, ControlFlow::Continue);
+                        return flush_state_changes(app, ControlFlow::Continue, false);
                     }
                     // Focus routing in WM mode (Tab/Shift+Tab)
                     // Fold menu to outline so user can see the window they focused.
@@ -403,7 +415,7 @@ where
                             app.wm().close_command_menu();
                         }
                         update_selection_snapshot(app);
-                        return flush_state_changes(app, ControlFlow::Continue);
+                        return flush_state_changes(app, ControlFlow::Continue, false);
                     }
                     // Dispatch remaining WmMode actions (Quit, OpenHelp, etc.)
                     // while the WM overlay is open.
@@ -412,29 +424,29 @@ where
                             TermWmAction::Quit => {
                                 app.open_exit_confirm();
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             TermWmAction::OpenHelp => {
                                 app.open_help_overlay();
                                 app.wm().close_command_menu();
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             TermWmAction::OpenKeybindings => {
                                 app.open_keybindings_overlay();
                                 app.wm().close_command_menu();
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             TermWmAction::CycleNextWindow => {
                                 app.wm().advance_focus(true);
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             TermWmAction::CyclePrevWindow => {
                                 app.wm().advance_focus(false);
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             TermWmAction::HintToggle => {
                                 let current = app.wm().hint_visibility();
@@ -451,20 +463,20 @@ where
                                 };
                                 app.wm().set_hint_visibility(next);
                                 update_selection_snapshot(app);
-                                return flush_state_changes(app, ControlFlow::Continue);
+                                return flush_state_changes(app, ControlFlow::Continue, false);
                             }
                             _ => {}
                         }
                     }
                     if let Event::Key(_) = &evt {
                         update_selection_snapshot(app);
-                        return flush_state_changes(app, ControlFlow::Continue);
+                        return flush_state_changes(app, ControlFlow::Continue, false);
                     }
                 }
 
                 if matches!(evt, Event::Mouse(_)) && !app.wm().mouse_capture_enabled() {
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
                 // Direct focus switching for mouse clicks.  Uses the live window
                 // set from managed_draw_order (repopulated every draw) instead of
@@ -496,11 +508,11 @@ where
                 {
                     app.open_exit_confirm();
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
                 if !wm_mode && matches!(evt, Event::Key(_)) && app.wm().handle_focus_event(&evt) {
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Continue);
+                    return flush_state_changes(app, ControlFlow::Continue, false);
                 }
 
                 // Layer 3: Pass-through to focused component
@@ -518,7 +530,7 @@ where
             } else {
                 if app.quit_requested() || app.wm().quit_requested() {
                     update_selection_snapshot(app);
-                    return flush_state_changes(app, ControlFlow::Quit);
+                    return flush_state_changes(app, ControlFlow::Quit, false);
                 }
                 update_selection_snapshot(app);
                 app.wm().begin_frame();
@@ -530,7 +542,7 @@ where
                 // After a panic, repair the terminal so the next draw starts
                 // from a clean slate (partial escape sequences, wrong cursor
                 // position, etc. are reset).
-                let did_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                did_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     output.draw(|frame| {
                         // TODO: Get area from DrawPlan or terminal size, not from frame
                         draw(frame, app)
@@ -541,13 +553,13 @@ where
                     output.repair()?;
                 }
             }
-            flush_state_changes(app, ControlFlow::Continue)
+            flush_state_changes(app, ControlFlow::Continue, !did_panic)
         };
 
         let handler_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(handler));
 
         system_handle.set_keep_awake(app.wm().visible_overlay_count() > 0);
-        driver.set_pending_work(system_handle.has_pending());
+        driver.set_pending_work(system_handle.is_keep_awake_active());
         match handler_result {
             Ok(result) => result,
             Err(_) => {
@@ -1189,4 +1201,74 @@ mod tests {
         }
     }
     impl crate::components::WmComponent for TestMenu {}
+}
+
+#[cfg(test)]
+mod power_calibration_tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::time::Duration;
+
+    struct SpyEventSource {
+        captured_max_sleep: Option<Option<Duration>>,
+        mock_dirty_windows: HashSet<WindowKey>,
+    }
+
+    impl EventSource for SpyEventSource {
+        fn poll(&mut self, _: Duration) -> io::Result<bool> {
+            Ok(false)
+        }
+        fn read(&mut self) -> io::Result<Event> {
+            unreachable!()
+        }
+        fn next_key(&mut self) -> io::Result<crate::events::KeyEvent> {
+            unreachable!()
+        }
+        fn next_mouse(&mut self) -> io::Result<crate::events::MouseEvent> {
+            unreachable!()
+        }
+        fn set_max_sleep_duration(&mut self, d: Option<Duration>) {
+            self.captured_max_sleep = Some(d);
+        }
+        fn take_dirty_windows(&mut self) -> HashSet<WindowKey> {
+            std::mem::take(&mut self.mock_dirty_windows)
+        }
+    }
+
+    #[test]
+    fn scheduler_deadline_propagates_to_driver() {
+        let mut driver = SpyEventSource {
+            captured_max_sleep: None,
+            mock_dirty_windows: HashSet::new(),
+        };
+        let sched = crate::task_scheduler::TaskScheduler::<crate::actions::SystemTask>::new();
+        let handle = sched.handle();
+        handle.schedule_once(
+            Duration::from_millis(250),
+            crate::actions::SystemTask::DragSnap,
+        );
+
+        let time_left = handle.time_until_next();
+        driver.set_max_sleep_duration(time_left);
+
+        let captured = driver.captured_max_sleep.unwrap().unwrap();
+        assert!(captured <= Duration::from_millis(250));
+        assert!(captured > Duration::from_millis(200));
+    }
+
+    #[test]
+    fn dirty_keys_are_drained_cleanly_on_frame_completion() {
+        let mut key_set = HashSet::new();
+        key_set.insert(WindowKey::default());
+        let mut driver = SpyEventSource {
+            captured_max_sleep: None,
+            mock_dirty_windows: key_set,
+        };
+
+        let first = EventSource::take_dirty_windows(&mut driver);
+        assert_eq!(first.len(), 1);
+
+        let second = EventSource::take_dirty_windows(&mut driver);
+        assert!(second.is_empty(), "dirty keys must drain between cycles");
+    }
 }

--- a/crates/term-wm-core/src/task_scheduler.rs
+++ b/crates/term-wm-core/src/task_scheduler.rs
@@ -150,6 +150,12 @@ impl<T> TaskHandle<T> {
         self.inner.borrow_mut().keep_awake = active;
     }
 
+    /// Returns `true` if the scheduler has been explicitly requested to keep
+    /// the loop awake for high-frequency transient UI updates or animations.
+    pub fn is_keep_awake_active(&self) -> bool {
+        self.inner.borrow().keep_awake
+    }
+
     /// Returns the duration until the next deadline, or [`None`] when the
     /// scheduler is empty.
     pub fn time_until_next(&self) -> Option<Duration> {
@@ -359,5 +365,15 @@ mod tests {
         h1.schedule_once(Duration::from_millis(1), "shared");
         std::thread::sleep(Duration::from_millis(10));
         assert_eq!(h2.drain_expired_once().len(), 1);
+    }
+
+    #[test]
+    fn is_keep_awake_active_default_false() {
+        let sched = TaskScheduler::<String>::new();
+        assert!(!sched.handle().is_keep_awake_active());
+        sched.handle().set_keep_awake(true);
+        assert!(sched.handle().is_keep_awake_active());
+        sched.handle().set_keep_awake(false);
+        assert!(!sched.handle().is_keep_awake_active());
     }
 }

--- a/src/unified_event_source.rs
+++ b/src/unified_event_source.rs
@@ -73,6 +73,13 @@ pub struct UnifiedEventSource {
     /// pending work (e.g. countdown timer) that requires frequent polling
     /// regardless of PTY dirty-window state.
     pending_work: bool,
+    /// Maximum duration the next [`poll`] call is allowed to block.
+    /// Set by the runner via [`EventSource::set_max_sleep_duration`] to
+    /// clamp the PowerSaver poll interval to the next scheduler deadline.
+    ///
+    /// [`poll`]: EventSource::poll
+    /// [`set_max_sleep_duration`]: EventSource::set_max_sleep_duration
+    max_sleep_duration: Option<Duration>,
 }
 
 impl UnifiedEventSource {
@@ -129,6 +136,7 @@ impl UnifiedEventSource {
             last_event_at: None,
             frame_pacer: FramePacer::new(),
             pending_work: false,
+            max_sleep_duration: None,
         })
     }
 
@@ -172,11 +180,6 @@ impl UnifiedEventSource {
         let sig = self.signal_received;
         self.signal_received = false;
         sig
-    }
-
-    /// Take accumulated dirty windows and reset.
-    pub fn take_dirty_windows(&mut self) -> HashSet<WindowKey> {
-        std::mem::take(&mut self.dirty_windows)
     }
 }
 
@@ -355,7 +358,6 @@ impl EventSource for UnifiedEventSource {
         }
 
         self.frame_pacer.reset();
-        self.dirty_windows.clear();
         Ok(false)
     }
 
@@ -471,8 +473,16 @@ impl EventSource for UnifiedEventSource {
         self.pending_work = pending;
     }
 
+    fn set_max_sleep_duration(&mut self, duration: Option<Duration>) {
+        self.max_sleep_duration = duration;
+    }
+
     fn poll_interval(&self) -> Duration {
-        self.current_profile().poll_interval()
+        let base = self.current_profile().poll_interval();
+        match self.max_sleep_duration {
+            Some(max_sleep) => base.min(max_sleep),
+            None => base,
+        }
     }
 
     fn current_profile(&self) -> PowerProfile {
@@ -484,6 +494,10 @@ impl EventSource for UnifiedEventSource {
 
     fn take_exited_windows(&mut self) -> Vec<WindowKey> {
         std::mem::take(&mut self.exited_windows)
+    }
+
+    fn take_dirty_windows(&mut self) -> HashSet<WindowKey> {
+        std::mem::take(&mut self.dirty_windows)
     }
 }
 
@@ -517,6 +531,7 @@ mod tests {
             last_event_at: None,
             frame_pacer: FramePacer::new(),
             pending_work: false,
+            max_sleep_duration: None,
         };
         // Prevent the no-op handle from panicking on join in drop
         let dummy_handle = std::thread::spawn(|| {});
@@ -606,6 +621,7 @@ mod tests {
             last_event_at: None,
             frame_pacer: FramePacer::new(),
             pending_work: false,
+            max_sleep_duration: None,
         };
         // Prevent the no-op handle from panicking on drop
         let dummy_handle = std::thread::spawn(|| {});
@@ -662,6 +678,7 @@ mod tests {
             last_event_at: None,
             frame_pacer: FramePacer::new(),
             pending_work: false,
+            max_sleep_duration: None,
         };
         assert_eq!(
             source.current_profile(),
@@ -687,6 +704,7 @@ mod tests {
             last_event_at: None,
             frame_pacer: FramePacer::new(),
             pending_work: true,
+            max_sleep_duration: None,
         };
         assert_eq!(
             source.current_profile(),
@@ -710,6 +728,7 @@ mod tests {
             last_event_at: stale,
             frame_pacer: FramePacer::new(),
             pending_work: true,
+            max_sleep_duration: None,
         };
         assert_eq!(
             source2.current_profile(),
@@ -743,6 +762,7 @@ mod tests {
             last_event_at: None,
             frame_pacer: FramePacer::new(),
             pending_work: false,
+            max_sleep_duration: None,
         };
         let dummy_handle = std::thread::spawn(|| {});
         source._input_handle = dummy_handle;
@@ -754,5 +774,83 @@ mod tests {
 
         let again = EventSource::take_exited_windows(&mut source);
         assert!(again.is_empty(), "second call must drain");
+    }
+
+    /// Regression: `take_dirty_windows` must be reachable through the
+    /// `EventSource` trait so that generic runner code (`D: EventSource`)
+    /// actually consumes accumulated dirty keys.  Without the trait
+    /// override the default no-op impl would silently return an empty
+    /// set, leaving dirty_windows accumulated forever.
+    #[test]
+    fn take_dirty_windows_returns_accumulated_keys_through_trait() {
+        use super::EventSource;
+        let (_tx, rx) = bounded(EVENT_CHANNEL_CAPACITY);
+        let key = WindowKey::default();
+        let mut set = HashSet::new();
+        set.insert(key);
+        let mut source = UnifiedEventSource {
+            rx,
+            tx: _tx,
+            _input_handle: std::thread::spawn(|| {}),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            dirty_windows: set,
+            exited_windows: Vec::new(),
+            pending_event: None,
+            input_buffer: VecDeque::new(),
+            signal_received: false,
+            normalizer: KeyboardNormalizer::new(),
+            last_event_at: None,
+            frame_pacer: FramePacer::new(),
+            pending_work: false,
+            max_sleep_duration: None,
+        };
+        let dummy_handle = std::thread::spawn(|| {});
+        source._input_handle = dummy_handle;
+
+        // Call through the trait, not an inherent method. Would return
+        // an empty set if the trait override were missing.
+        let taken = EventSource::take_dirty_windows(&mut source);
+        assert_eq!(taken.len(), 1, "must return the pre-populated key");
+        assert!(taken.contains(&key), "must contain the dirty key");
+
+        let again = EventSource::take_dirty_windows(&mut source);
+        assert!(again.is_empty(), "second call must drain");
+    }
+
+    #[test]
+    fn poll_interval_clamped_by_max_sleep_duration() {
+        let (_tx, rx) = bounded(EVENT_CHANNEL_CAPACITY);
+        let mut source = UnifiedEventSource {
+            rx,
+            tx: _tx,
+            _input_handle: std::thread::spawn(|| {}),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            dirty_windows: HashSet::new(),
+            exited_windows: Vec::new(),
+            pending_event: None,
+            input_buffer: VecDeque::new(),
+            signal_received: false,
+            normalizer: KeyboardNormalizer::new(),
+            last_event_at: None,
+            frame_pacer: FramePacer::new(),
+            pending_work: false,
+            max_sleep_duration: None,
+        };
+        let dummy = std::thread::spawn(|| {});
+        source._input_handle = dummy;
+
+        assert_eq!(
+            source.poll_interval(),
+            PowerProfile::PowerSaver.poll_interval()
+        );
+
+        source.set_max_sleep_duration(Some(Duration::from_millis(100)));
+        assert_eq!(source.poll_interval(), Duration::from_millis(100));
+
+        source.set_max_sleep_duration(None);
+        assert_eq!(
+            source.poll_interval(),
+            PowerProfile::PowerSaver.poll_interval()
+        );
     }
 }


### PR DESCRIPTION
Remediates three architectural defects pinning the event loop to continuous
16ms polling windows regardless of user or pseudoterminal inactivity.

1. Trait State Consumption: Implements take_dirty_windows() across the EventSource trait to flush accumulated background PTY update tokens at the end of each idle rendering pass. This permits current_profile() to accurately register quiesced windows.
2. Instrumentation Loop Break: Demotes power profile transition logs from INFO to TRACE level. This prevents diagnostic messages from contaminating the active debug log component and triggering self-dirtying redraw cascades.
3. Scheduler Deadline Clamping: Replaced generic heap residency wake overrides with targeted is_keep_awake_active() validation. Introduces the set_max_sleep_duration() trait contract to bridge pending background deadlines directly into the driver's polling timeout calculation, averting loop deadlocks.

Note: Due to immediate-mode rendering phase execution, the on-screen status
indicator remains invariant at "Streaming" during deep sleep cycles. The thread
enters kernel suspension immediately after profile calibration and transitions back
to active modes upon hardware interrupt before the next visible draw pass runs.