### PR TITLE
Fix linux process titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2531,14 +2531,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.17-alpha"
+version = "0.8.18-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -52,14 +52,14 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm = { path = ".", version = "0.8.17-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.8.17-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.17-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.17-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.17-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.8.17-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.17-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.17-alpha" }
+term-wm = { path = ".", version = "0.8.18-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.8.18-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.18-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.18-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.18-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.8.18-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.18-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.18-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -245,14 +245,16 @@ impl Pty {
     }
 
     pub fn take_pending_title(&self) -> Option<String> {
-        let fg = self.foreground_title
+        let fg = self
+            .foreground_title
             .lock()
             .unwrap_or_else(|err| err.into_inner())
             .clone();
 
         if fg.is_some() {
             // Process name is authoritative. Purge any stale OSC titles.
-            let _ = self.pending_title
+            let _ = self
+                .pending_title
                 .lock()
                 .unwrap_or_else(|err| err.into_inner())
                 .take();
@@ -1273,5 +1275,99 @@ mod tests {
         let e = wrap_err("spawn_command", 42);
         let s = format!("{}", e);
         assert!(s.contains("pty spawn_command failed: 42"));
+    }
+
+    #[test]
+    fn take_pending_title_clones_foreground_not_consumes() {
+        let cmd = CommandBuilder::new("cat");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn");
+
+        *pty.foreground_title.lock().unwrap() = Some("vim".to_string());
+
+        assert_eq!(pty.take_pending_title(), Some("vim".to_string()));
+        assert_eq!(pty.take_pending_title(), Some("vim".to_string()));
+
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn take_pending_title_purges_stale_osc_when_fg_present() {
+        let cmd = CommandBuilder::new("cat");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn");
+
+        *pty.foreground_title.lock().unwrap() = Some("vim".to_string());
+        *pty.pending_title.lock().unwrap() = Some("user@host".to_string());
+
+        assert_eq!(pty.take_pending_title(), Some("vim".to_string()));
+        assert_eq!(
+            *pty.pending_title.lock().unwrap(),
+            None,
+            "stale OSC title must be purged"
+        );
+
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn take_pending_title_falls_back_to_osc_when_no_fg() {
+        let cmd = CommandBuilder::new("cat");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn");
+
+        *pty.foreground_title.lock().unwrap() = None;
+        *pty.pending_title.lock().unwrap() = Some("user@host".to_string());
+
+        assert_eq!(pty.take_pending_title(), Some("user@host".to_string()));
+        assert_eq!(
+            *pty.pending_title.lock().unwrap(),
+            None,
+            "OSC title must be consumed"
+        );
+
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn take_pending_title_returns_none_when_both_empty() {
+        let cmd = CommandBuilder::new("cat");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn");
+
+        *pty.foreground_title.lock().unwrap() = None;
+        *pty.pending_title.lock().unwrap() = None;
+
+        assert_eq!(pty.take_pending_title(), None);
+
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
     }
 }

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -245,16 +245,24 @@ impl Pty {
     }
 
     pub fn take_pending_title(&self) -> Option<String> {
-        self.foreground_title
+        let fg = self.foreground_title
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .take();
+
+        if fg.is_some() {
+            // Purge the stale OSC title to prevent it from bleeding through on the next query
+            let _ = self.pending_title
+                .lock()
+                .unwrap_or_else(|err| err.into_inner())
+                .take();
+            return fg;
+        }
+
+        self.pending_title
             .lock()
             .unwrap_or_else(|err| err.into_inner())
             .take()
-            .or_else(|| {
-                self.pending_title
-                    .lock()
-                    .unwrap_or_else(|err| err.into_inner())
-                    .take()
-            })
     }
 
     fn poll_foreground(&mut self) {

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -248,10 +248,10 @@ impl Pty {
         let fg = self.foreground_title
             .lock()
             .unwrap_or_else(|err| err.into_inner())
-            .take();
+            .clone();
 
         if fg.is_some() {
-            // Purge the stale OSC title to prevent it from bleeding through on the next query
+            // Process name is authoritative. Purge any stale OSC titles.
             let _ = self.pending_title
                 .lock()
                 .unwrap_or_else(|err| err.into_inner())
@@ -272,12 +272,11 @@ impl Pty {
                 && fg_pid != self.last_fg_pid
             {
                 self.last_fg_pid = fg_pid;
-                if let Some(name) = get_process_name(fg_pid) {
-                    *self
-                        .foreground_title
-                        .lock()
-                        .unwrap_or_else(|err| err.into_inner()) = Some(name);
-                }
+                let name = get_process_name(fg_pid);
+                *self
+                    .foreground_title
+                    .lock()
+                    .unwrap_or_else(|err| err.into_inner()) = name;
             }
         }
     }


### PR DESCRIPTION
The title state machine had two bugs:

1. take_pending_title() consumed foreground_title via .take(), leaving
   it as None. When SIGWINCH triggered a shell redraw that emitted an
   OSC title sequence, pending_title overwrote the empty foreground and
   hijacked the window title.

2. poll_foreground() only assigned to foreground_title on Some, leaving
   a stale value when the process exited.

Fix by cloning (not consuming) foreground_title on read, purging
pending_title when foreground is present, and unconditionally assigning
the get_process_name result in poll_foreground.

Adds 4 regression tests covering all take_pending_title branches.