### PR TITLE
feat: Windows platform hardening, cross-platform test coverage, and regression safeguards 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2531,14 +2531,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2551,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 dependencies = [
  "crossterm",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.18-alpha"
+version = "0.8.19-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -52,14 +52,14 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm = { path = ".", version = "0.8.18-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.8.18-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.18-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.18-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.18-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.8.18-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.18-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.18-alpha" }
+term-wm = { path = ".", version = "0.8.19-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.8.19-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.19-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.19-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.19-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.8.19-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.19-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.19-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/term-wm-core/src/power_profile.rs
+++ b/crates/term-wm-core/src/power_profile.rs
@@ -19,6 +19,10 @@ const STREAMING_POLL_INTERVAL: Duration = Duration::from_millis(16);
 /// Poll interval when idle (blocks on channel, no CPU burn).
 const POWERSAVER_POLL_INTERVAL: Duration = Duration::from_secs(3600);
 
+/// Maximum poll interval on Windows to prevent ConPTY thread starvation.
+#[cfg(target_os = "windows")]
+pub const WINDOWS_MAX_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
 /// Fixed-behavior power profile variant.
 ///
 /// Each variant has a single, predictable `poll_interval`. The active
@@ -232,6 +236,20 @@ mod tests {
         assert_eq!(
             PowerProfile::PowerSaver.poll_interval(),
             POWERSAVER_POLL_INTERVAL
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_max_poll_interval_value() {
+        assert_eq!(
+            WINDOWS_MAX_POLL_INTERVAL,
+            Duration::from_millis(50),
+            "Windows max poll interval must be 50ms to prevent ConPTY starvation"
+        );
+        assert!(
+            WINDOWS_MAX_POLL_INTERVAL < POWERSAVER_POLL_INTERVAL,
+            "Windows max must be less than powersaver interval"
         );
     }
 }

--- a/crates/term-wm-core/src/utils/keyboard_normalizer.rs
+++ b/crates/term-wm-core/src/utils/keyboard_normalizer.rs
@@ -7,13 +7,11 @@
 use crate::events::{Event, KeyCode, KeyKind};
 
 #[derive(Default)]
-pub struct KeyboardNormalizer {
-    esc_down: bool,
-}
+pub struct KeyboardNormalizer;
 
 impl KeyboardNormalizer {
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 
     pub fn normalize(&mut self, evt: Event) -> Option<Event> {
@@ -27,22 +25,9 @@ impl KeyboardNormalizer {
                 }
                 if cfg!(windows) {
                     match key.kind {
-                        KeyKind::Release => {
-                            if key.code == KeyCode::Esc {
-                                self.esc_down = false;
-                            }
-                            return None;
-                        }
+                        KeyKind::Release => return None,
                         KeyKind::Repeat => return None,
                         KeyKind::Press => {}
-                    }
-                    if key.code == KeyCode::Esc {
-                        if self.esc_down {
-                            return None;
-                        }
-                        self.esc_down = true;
-                    } else {
-                        self.esc_down = false;
                     }
                 } else if key.kind == KeyKind::Release {
                     return None;
@@ -119,6 +104,28 @@ mod tests {
             assert!(!k.modifiers.shift);
         } else {
             panic!("expected key event");
+        }
+    }
+
+    #[test]
+    fn repeat_key_passes_through_on_unix() {
+        let mut norm = KeyboardNormalizer::new();
+        let evt = Event::Key(crate::events::KeyEvent {
+            code: KeyCode::Char('a'),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyKind::Repeat,
+        });
+        // On non-Windows, Repeat passes through (only Release is filtered)
+        #[cfg(not(target_os = "windows"))]
+        {
+            let out = norm.normalize(evt);
+            assert!(out.is_some(), "Repeat must pass through on Unix");
+        }
+        // On Windows, Repeat is filtered
+        #[cfg(target_os = "windows")]
+        {
+            let out = norm.normalize(evt);
+            assert!(out.is_none(), "Repeat must be filtered on Windows");
         }
     }
 }

--- a/crates/term-wm-core/src/window/decorator.rs
+++ b/crates/term-wm-core/src/window/decorator.rs
@@ -122,7 +122,7 @@ pub fn header_buttons(outer_right: u16) -> [(u16, HeaderAction, &'static str); 4
     let min_x = max_x.saturating_sub(HEADER_BUTTON_GAP);
     let kb_x = min_x.saturating_sub(HEADER_BUTTON_GAP);
     [
-        (close_x, HeaderAction::Close, "✖"),
+        (close_x, HeaderAction::Close, "X"),
         (max_x, HeaderAction::Maximize, "▢"),
         (min_x, HeaderAction::Minimize, "_"),
         (kb_x, HeaderAction::ToggleDirectMode, "D"),
@@ -159,5 +159,33 @@ mod tests {
         let dec = DefaultDecorator::new();
         let s = format!("{:?}", dec);
         assert!(s.contains("DefaultDecorator"));
+    }
+
+    #[test]
+    fn header_buttons_returns_four_buttons() {
+        let buttons = header_buttons(80);
+        assert_eq!(buttons.len(), 4);
+        assert!(matches!(buttons[0].1, HeaderAction::Close));
+        assert!(matches!(buttons[1].1, HeaderAction::Maximize));
+        assert!(matches!(buttons[2].1, HeaderAction::Minimize));
+        assert!(matches!(buttons[3].1, HeaderAction::ToggleDirectMode));
+    }
+
+    #[test]
+    fn header_buttons_close_glyph_is_x() {
+        let buttons = header_buttons(80);
+        assert_eq!(buttons[0].2, "X");
+    }
+
+    #[test]
+    fn header_buttons_saturates_at_zero() {
+        let buttons = header_buttons(0);
+        assert_eq!(buttons.len(), 4);
+        for (x, _, _) in &buttons {
+            assert_eq!(
+                *x, 0,
+                "all positions must saturate to 0 when outer_right is 0"
+            );
+        }
     }
 }

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -290,10 +290,8 @@ impl Pty {
 
     #[cfg(windows)]
     fn foreground_pid(&self) -> Option<u32> {
-        // TODO: re-enable when find_foreground_process_windows is implemented
-        // let shell_pid = self.child.as_ref().and_then(|c| c.process_id())?;
-        // find_foreground_process_windows(shell_pid)
-        None
+        let shell_pid = self.child.as_ref().and_then(|c| c.process_id())?;
+        find_foreground_process_windows(shell_pid)
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -332,6 +330,17 @@ impl Pty {
                 self.exited = true;
                 self.exit_status = Some(status);
                 self.child = None;
+
+                // ConPTY pipes on Windows frequently swallow EOF, leaving the
+                // reader thread blocked forever. Since this method is polled
+                // every frame, we manually synthesize the exit callback here
+                // when we detect the child process has died.
+                if let Ok(guard) = self.status_cb.lock()
+                    && let Some(ref cb) = *guard
+                {
+                    cb(crate::PtyStatus::Exited);
+                }
+
                 true
             }
             Ok(None) => false,
@@ -662,84 +671,107 @@ fn get_process_name(pid: u32) -> Option<String> {
 }
 
 #[cfg(windows)]
-fn get_process_name(_pid: u32) -> Option<String> {
-    // TODO: re-enable when Windows foreground process tracking is implemented
-    // use std::ffi::OsString;
-    // use std::os::windows::ffi::OsStringExt;
-    //
-    // const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
-    // let handle = unsafe { kernel32::OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    // if handle.is_null() { return None; }
-    // let mut buf = [0u16; 260];
-    // let mut size = buf.len() as u32;
-    // let result = unsafe {
-    //     kernel32::QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut size)
-    // };
-    // unsafe { kernel32::CloseHandle(handle); }
-    // if result == 0 { return None; }
-    // let path = OsString::from_wide(&buf[..size as usize]);
-    // std::path::Path::new(&path).file_stem().map(|s| s.to_string_lossy().into_owned())
-    None
+fn get_process_name(pid: u32) -> Option<String> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+    let handle = unsafe { kernel32::OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle == 0 {
+        return None;
+    }
+
+    let mut buf = [0u16; 260];
+    let mut size = buf.len() as u32;
+    let result =
+        unsafe { kernel32::QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut size) };
+    unsafe {
+        kernel32::CloseHandle(handle);
+    }
+
+    if result == 0 {
+        return None;
+    }
+    let path = OsString::from_wide(&buf[..size as usize]);
+    std::path::Path::new(&path)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
 }
 
-// TODO: Windows foreground process tracking — implement find_foreground_process_windows
-// using CreateToolhelp32Snapshot to walk the process tree from the shell PID:
-//
-// #[cfg(windows)]
-// fn find_foreground_process_windows(shell_pid: u32) -> Option<u32> {
-//     let snapshot = unsafe { kernel32::CreateToolhelp32Snapshot(0x00000002, 0) };
-//     if snapshot == kernel32::INVALID_HANDLE_VALUE { return None; }
-//     let mut children: Vec<(u32, u32)> = Vec::new();
-//     let mut entry = std::mem::MaybeUninit::<kernel32::PROCESSENTRY32W>::zeroed();
-//     unsafe {
-//         (*entry.as_mut_ptr()).dwSize = std::mem::size_of::<kernel32::PROCESSENTRY32W>() as u32;
-//         if kernel32::Process32FirstW(snapshot, entry.as_mut_ptr()) != 0 {
-//             loop {
-//                 let e = entry.assume_init();
-//                 children.push((e.th32ProcessID, e.th32ParentProcessID));
-//                 if kernel32::Process32NextW(snapshot, entry.as_mut_ptr()) == 0 { break; }
-//             }
-//         }
-//         kernel32::CloseHandle(snapshot);
-//     }
-//     let mut current = shell_pid;
-//     loop {
-//         let next = children.iter()
-//             .find(|&&(pid, parent)| parent == current && pid != current)
-//             .map(|&(pid, _)| pid);
-//         match next { Some(next) => current = next, None => break }
-//     }
-//     if current != shell_pid { Some(current) } else { None }
-// }
+#[cfg(windows)]
+fn find_foreground_process_windows(shell_pid: u32) -> Option<u32> {
+    let snapshot = unsafe { kernel32::CreateToolhelp32Snapshot(0x00000002, 0) };
+    if snapshot == kernel32::INVALID_HANDLE_VALUE {
+        return None;
+    }
 
-// TODO: Windows kernel32 FFI module — needed by the above when re-enabled:
-//
-// #[cfg(windows)]
-// mod kernel32 {
-//     use std::ffi::c_void;
-//     pub const INVALID_HANDLE_VALUE: isize = -1;
-//     #[repr(C)]
-//     pub struct PROCESSENTRY32W {
-//         pub dwSize: u32,
-//         pub cntUsage: u32,
-//         pub th32ProcessID: u32,
-//         pub th32DefaultHeapID: usize,
-//         pub th32ModuleID: u32,
-//         pub cntThreads: u32,
-//         pub th32ParentProcessID: u32,
-//         pub pcPriClassBase: i32,
-//         pub dwFlags: u32,
-//         pub szExeFile: [u16; 260],
-//     }
-//     extern "system" {
-//         pub fn CreateToolhelp32Snapshot(dwFlags: u32, th32ProcessID: u32) -> isize;
-//         pub fn Process32FirstW(hSnapshot: isize, lppe: *mut PROCESSENTRY32W) -> i32;
-//         pub fn Process32NextW(hSnapshot: isize, lppe: *mut PROCESSENTRY32W) -> i32;
-//         pub fn CloseHandle(hObject: isize) -> i32;
-//         pub fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: i32, dwProcessId: u32) -> *mut c_void;
-//         pub fn QueryFullProcessImageNameW(hProcess: *mut c_void, dwFlags: u32, lpExeName: *mut u16, lpdwSize: *mut u32) -> i32;
-//     }
-// }
+    let mut children: Vec<(u32, u32)> = Vec::new();
+    let mut entry = std::mem::MaybeUninit::<kernel32::PROCESSENTRY32W>::zeroed();
+
+    unsafe {
+        (*entry.as_mut_ptr()).dwSize = std::mem::size_of::<kernel32::PROCESSENTRY32W>() as u32;
+        if kernel32::Process32FirstW(snapshot, entry.as_mut_ptr()) != 0 {
+            loop {
+                let e = entry.assume_init();
+                children.push((e.th32ProcessID, e.th32ParentProcessID));
+                if kernel32::Process32NextW(snapshot, entry.as_mut_ptr()) == 0 {
+                    break;
+                }
+            }
+        }
+        kernel32::CloseHandle(snapshot);
+    }
+
+    let mut current = shell_pid;
+    loop {
+        let next = children
+            .iter()
+            .find(|&&(pid, parent)| parent == current && pid != current)
+            .map(|&(pid, _)| pid);
+        match next {
+            Some(next) => current = next,
+            None => break,
+        }
+    }
+
+    Some(current)
+}
+
+#[cfg(windows)]
+mod kernel32 {
+    pub const INVALID_HANDLE_VALUE: isize = -1;
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    #[allow(non_snake_case)]
+    pub struct PROCESSENTRY32W {
+        pub dwSize: u32,
+        pub cntUsage: u32,
+        pub th32ProcessID: u32,
+        pub th32DefaultHeapID: usize,
+        pub th32ModuleID: u32,
+        pub cntThreads: u32,
+        pub th32ParentProcessID: u32,
+        pub pcPriClassBase: i32,
+        pub dwFlags: u32,
+        pub szExeFile: [u16; 260],
+    }
+
+    #[allow(non_snake_case)]
+    unsafe extern "system" {
+        pub fn CreateToolhelp32Snapshot(dwFlags: u32, th32ProcessID: u32) -> isize;
+        pub fn Process32FirstW(hSnapshot: isize, lppe: *mut PROCESSENTRY32W) -> i32;
+        pub fn Process32NextW(hSnapshot: isize, lppe: *mut PROCESSENTRY32W) -> i32;
+        pub fn CloseHandle(hObject: isize) -> i32;
+        pub fn OpenProcess(dwDesiredAccess: u32, bInheritHandle: i32, dwProcessId: u32) -> isize;
+        pub fn QueryFullProcessImageNameW(
+            hProcess: isize,
+            dwFlags: u32,
+            lpExeName: *mut u16,
+            lpdwSize: *mut u32,
+        ) -> i32;
+    }
+}
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
 fn get_process_name(_pid: u32) -> Option<String> {
@@ -754,6 +786,20 @@ mod tests {
     use std::io::Write;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+
+    /// Returns a platform-appropriate dummy executable for PTY plumbing tests.
+    /// On Unix, `cat` blocks on stdin and echoes output. On Windows, `cmd.exe`
+    /// blocks on stdin and keeps the ConPTY alive.
+    fn get_test_executable() -> &'static str {
+        #[cfg(target_os = "windows")]
+        {
+            "cmd.exe"
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            "cat"
+        }
+    }
 
     // ── bytes_to_debug_text ──────────────────────────────────────────
 
@@ -918,7 +964,7 @@ mod tests {
         // Use cat, which blocks on input, so we control when output happens.
         // Portability: `cat` exists on Unix; on Windows the test is skipped.
         // TODO: add Windows support with `cmd /c type CON`
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -958,6 +1004,90 @@ mod tests {
         );
     }
 
+    #[test]
+    fn has_exited_fires_exited_callback_when_child_dies() {
+        let cmd = CommandBuilder::new(get_test_executable());
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        let exited_fired = Arc::new(AtomicBool::new(false));
+        let exited_cb = Arc::clone(&exited_fired);
+        pty.set_status_callback(Some(Box::new(move |status| {
+            if status == crate::PtyStatus::Exited {
+                exited_cb.store(true, Ordering::Relaxed);
+            }
+        })));
+
+        // Kill the child so try_wait returns Ok(Some(...))
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+
+        // Wait for child to be reaped
+        for _ in 0..250 {
+            if pty.has_exited() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        assert!(
+            exited_fired.load(Ordering::Relaxed),
+            "has_exited() must fire PtyStatus::Exited callback when child dies"
+        );
+    }
+
+    #[test]
+    fn has_exited_idempotent_after_child_exits() {
+        let cmd = CommandBuilder::new(get_test_executable());
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        let exit_count = Arc::new(AtomicUsize::new(0));
+        let count_cb = Arc::clone(&exit_count);
+        pty.set_status_callback(Some(Box::new(move |status| {
+            if status == crate::PtyStatus::Exited {
+                count_cb.fetch_add(1, Ordering::Relaxed);
+            }
+        })));
+
+        // Kill the child
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+
+        // Wait for first has_exited to succeed
+        for _ in 0..250 {
+            if pty.has_exited() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        // Record count after has_exited() first returned true
+        let count_after_first = exit_count.load(Ordering::Relaxed);
+
+        // Call has_exited() again — must NOT fire the callback
+        assert!(pty.has_exited(), "second call must also return true");
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let count_after_second = exit_count.load(Ordering::Relaxed);
+        assert_eq!(
+            count_after_first, count_after_second,
+            "has_exited() must not re-fire the Exited callback after returning true"
+        );
+    }
+
     // ── screen / set_scrollback / into_parts / Drop ─────────────────
     //
     // These tests exercise the shared-parser screen sharing path (sync
@@ -967,7 +1097,7 @@ mod tests {
 
     #[test]
     fn screen_loads_from_shared_parser_when_dirty() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1013,7 +1143,7 @@ mod tests {
 
     #[test]
     fn screen_syncs_from_shared_parser() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1055,7 +1185,7 @@ mod tests {
         //
         // Generate enough output (30 lines in a 24-row terminal) to fill the
         // scrollback buffer so that set_scrollback(N) isn't clamped to 0.
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1146,7 +1276,7 @@ mod tests {
     fn set_scrollback_and_scrollback_consistent() {
         // set_scrollback() and scrollback() both operate on the shared parser.
         // Mutations via set_scrollback must be visible through scrollback().
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1204,7 +1334,7 @@ mod tests {
 
     #[test]
     fn into_parts_takes_child_and_reader() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1233,7 +1363,7 @@ mod tests {
 
     #[test]
     fn set_status_callback_with_existing_reader_does_not_panic() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1279,7 +1409,7 @@ mod tests {
 
     #[test]
     fn take_pending_title_clones_foreground_not_consumes() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1300,7 +1430,7 @@ mod tests {
 
     #[test]
     fn take_pending_title_purges_stale_osc_when_fg_present() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1326,7 +1456,7 @@ mod tests {
 
     #[test]
     fn take_pending_title_falls_back_to_osc_when_no_fg() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,
@@ -1352,7 +1482,7 @@ mod tests {
 
     #[test]
     fn take_pending_title_returns_none_when_both_empty() {
-        let cmd = CommandBuilder::new("cat");
+        let cmd = CommandBuilder::new(get_test_executable());
         let size = PtySize {
             rows: 24,
             cols: 80,

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -1772,6 +1772,21 @@ mod tests {
         assert_eq!(line_count, 4, "should span 4 lines, got {}", line_count);
     }
 
+    /// A zero-length selection (click without drag) must return None.
+    #[test]
+    fn selection_text_empty_range_returns_none() {
+        let (term, rb) = make_term_with_content(80, 24, 2000, "Hello World");
+        // Click at a single position without dragging — start == end
+        term.selection
+            .borrow_mut()
+            .begin_drag(LogicalPosition::new(rb, 5));
+        term.selection
+            .borrow_mut()
+            .update_drag(LogicalPosition::new(rb, 5));
+        let text = term.selection_text();
+        assert!(text.is_none(), "zero-length selection must return None");
+    }
+
     #[test]
     fn mouse_selection_works_through_handle_events() {
         use term_wm_core::components::ComponentContext;

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -682,6 +682,29 @@ impl TerminalComponent {
     }
 }
 
+/// RAII guard that saves and restores the vt100 scrollback position.
+/// Guarantees restoration even on panic or early return.
+struct ScrollbackGuard<'a> {
+    screen: &'a mut vt100::Screen,
+    original_offset: usize,
+}
+
+impl<'a> ScrollbackGuard<'a> {
+    fn new(screen: &'a mut vt100::Screen) -> Self {
+        let original_offset = screen.scrollback();
+        Self {
+            screen,
+            original_offset,
+        }
+    }
+}
+
+impl<'a> Drop for ScrollbackGuard<'a> {
+    fn drop(&mut self) {
+        self.screen.set_scrollback(self.original_offset);
+    }
+}
+
 impl SelectionViewport for TerminalComponent {
     fn selection_viewport(&self, area: LayoutRect) -> LayoutRect {
         area
@@ -769,38 +792,85 @@ impl TerminalComponent {
 
     fn selection_text_for_range(&self, range: SelectionRange) -> Option<String> {
         let mut pane = self.pane.borrow_mut();
-        let row_base = pane.max_scrollback().saturating_sub(pane.scrollback());
+
+        // 1. SAFE EXTRACTION: Get max_scrollback BEFORE locking the parser
+        // This prevents Mutex deadlocks if the pane internally accesses the parser.
+        let max_scrollback = pane.max_scrollback();
+
         let parser_arc = pane.shared_parser();
-        let parser = parser_arc.lock().unwrap();
-        let screen = parser.screen();
-        let (rows, cols) = screen.size();
-        if rows == 0 || cols == 0 {
+        let mut parser = parser_arc.lock().unwrap();
+        let screen = parser.screen_mut();
+
+        let (viewport_rows, cols) = screen.size();
+        if viewport_rows == 0 || cols == 0 {
             return None;
         }
-        let (mut end_row, mut end_col) = (range.end.row, range.end.column);
+
+        let guard = ScrollbackGuard::new(screen);
+
+        // 2. BOUNDED PROBE: Use the known max_scrollback instead of usize::MAX.
+        // This prevents O(N) CPU hangs and integer overflow panics.
+        guard.screen.set_scrollback(max_scrollback);
+        let vt100_max_scrollback = guard.screen.scrollback();
+        let vt100_total_lines = vt100_max_scrollback + viewport_rows as usize;
+
+        // Map Pane coordinates to vt100 coordinates
+        let offset_from_pane_to_vt100 = max_scrollback.saturating_sub(vt100_max_scrollback);
+
+        let mut end_row = range.end.row;
+        let mut end_col = range.end.column;
         if end_col == 0 && end_row > range.start.row {
             end_row = end_row.saturating_sub(1);
             end_col = cols as usize;
         }
 
-        let start_row = range.start.row.saturating_sub(row_base);
-        let end_row = end_row.saturating_sub(row_base);
-        if start_row >= rows as usize {
-            return None;
-        }
-        let end_row = end_row.min(rows.saturating_sub(1) as usize);
+        let vt100_start_row = range.start.row.saturating_sub(offset_from_pane_to_vt100);
+        let vt100_end_row = end_row.saturating_sub(offset_from_pane_to_vt100);
+
+        // Clamp to actual vt100 bounds
+        let vt100_start_row = vt100_start_row.min(vt100_total_lines.saturating_sub(1));
+        let vt100_end_row = vt100_end_row.min(vt100_total_lines.saturating_sub(1));
         let start_col = range.start.column.min(cols as usize);
         let end_col = end_col.min(cols as usize);
-        if end_row < start_row {
+
+        if vt100_end_row < vt100_start_row {
             return None;
         }
 
-        Some(screen.contents_between(
-            start_row as u16,
-            start_col as u16,
-            end_row as u16,
-            end_col as u16,
-        ))
+        let mut result = String::new();
+
+        // Paginate using the translated vt100 coordinates
+        for absolute_row in vt100_start_row..=vt100_end_row {
+            let viewport_start = absolute_row.min(vt100_max_scrollback);
+            let offset = vt100_max_scrollback - viewport_start;
+            guard.screen.set_scrollback(offset);
+
+            let viewport_row = (absolute_row - viewport_start) as u16;
+
+            let col_start = if absolute_row == vt100_start_row {
+                start_col as u16
+            } else {
+                0
+            };
+
+            let col_end = if absolute_row == vt100_end_row {
+                end_col as u16
+            } else {
+                cols
+            };
+
+            let line =
+                guard
+                    .screen
+                    .contents_between(viewport_row, col_start, viewport_row, col_end);
+            result.push_str(&line);
+
+            if absolute_row < vt100_end_row {
+                result.push('\n');
+            }
+        }
+
+        Some(result)
     }
 
     pub fn terminate(&mut self) {
@@ -1651,6 +1721,55 @@ mod tests {
             "should copy all 26 chars, got: {:?}",
             text
         );
+    }
+
+    /// Selection within scrollback region using a small max_sb that fills quickly.
+    /// This exercises the paginated extraction loop where absolute_row falls
+    /// entirely in scrollback (not viewport), testing offset_from_pane_to_vt100.
+    #[test]
+    fn selection_text_in_scrollback_with_small_max_sb() {
+        let max_sb = 30;
+        let width = 80u16;
+        let height = 24u16;
+        // Fill 50 lines so scrollback is maxed out at 30
+        let text: String = (1..=50)
+            .map(|i| format!("line {:02} data", i))
+            .collect::<Vec<_>>()
+            .join("\r\n");
+
+        let mut pane = TestPane::new(max_sb);
+        pane.set_parser_size(height, width);
+        pane.write_to_parser(text.as_bytes());
+        let mut term = TerminalComponent::from_pane(Box::new(pane));
+        term.selection_enabled = true;
+
+        // row_base = max_scrollback = 30
+        let rb = max_sb;
+
+        // Select lines 5-8 in the scrollback region (well above viewport)
+        // These are the 5th through 8th most recent lines in the buffer.
+        // Lines in order from oldest to newest in scrollback (index 0 = oldest):
+        // line 01, line 02, ..., line 30 (scrollback)
+        // line 31..50 (in viewport, but we select in scrollback)
+        // row_base=30 means row 30 = viewport row 0, row 29 = scrollback bottom, row 0 = scrollback top
+        term.selection
+            .borrow_mut()
+            .begin_drag(LogicalPosition::new(rb - 8, 0));
+        term.selection
+            .borrow_mut()
+            .update_drag(LogicalPosition::new(rb - 5, 13));
+
+        let text = term.selection_text();
+        assert!(text.is_some(), "should extract text from scrollback region");
+        let t = text.unwrap();
+        // The 4 lines (indices rb-8 through rb-5) should contain unique line identifiers
+        assert!(
+            t.contains("line"),
+            "scrollback selection must contain 'line', got: {:?}",
+            t
+        );
+        let line_count = t.lines().count();
+        assert_eq!(line_count, 4, "should span 4 lines, got {}", line_count);
     }
 
     #[test]

--- a/src/unified_event_source.rs
+++ b/src/unified_event_source.rs
@@ -155,7 +155,9 @@ impl UnifiedEventSource {
         loop {
             match self.rx.try_recv() {
                 Ok(UnifiedEvent::Input(event)) => {
-                    self.input_buffer.push_back(event);
+                    if let Some(normalized) = self.normalizer.normalize(event) {
+                        self.input_buffer.push_back(normalized);
+                    }
                 }
                 Ok(UnifiedEvent::PtyWakeup(key)) => {
                     self.dirty_windows.insert(key);
@@ -320,9 +322,16 @@ impl EventSource for UnifiedEventSource {
             match self.rx.recv_timeout(remaining) {
                 Ok(UnifiedEvent::Input(event)) => {
                     self.last_event_at = Some(Instant::now());
-                    self.frame_pacer.reset();
-                    self.pending_event = Some(event);
-                    return Ok(true);
+                    if let Some(normalized) = self.normalizer.normalize(event) {
+                        self.frame_pacer.reset();
+                        self.pending_event = Some(normalized);
+                        return Ok(true);
+                    }
+                    // Event filtered out — update remaining and continue.
+                    if let Some(t) = self.frame_pacer.time_until_deadline() {
+                        remaining = remaining.min(t);
+                    }
+                    continue;
                 }
                 Ok(UnifiedEvent::PtyWakeup(key)) => {
                     self.dirty_windows.insert(key);
@@ -481,7 +490,19 @@ impl EventSource for UnifiedEventSource {
         let base = self.current_profile().poll_interval();
         match self.max_sleep_duration {
             Some(max_sleep) => base.min(max_sleep),
-            None => base,
+            None => {
+                #[cfg(target_os = "windows")]
+                {
+                    // Windows ConPTY requires regular event loop ticks to prevent
+                    // background PTY reader threads from stalling. When no explicit
+                    // cap is set, clamp to WINDOWS_MAX_POLL_INTERVAL maximum.
+                    base.min(term_wm_core::power_profile::WINDOWS_MAX_POLL_INTERVAL)
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    base
+                }
+            }
         }
     }
 
@@ -599,6 +620,125 @@ mod tests {
         assert!(
             !source.poll(Duration::ZERO).unwrap(),
             "poll must return false after buffer drained"
+        );
+    }
+
+    /// `drain_pending` must filter out Release events through the
+    /// normalizer, keeping Press and Repeat events in the buffer.
+    #[test]
+    fn drain_pending_filters_release_events() {
+        let (tx, rx) = bounded(EVENT_CHANNEL_CAPACITY);
+        let mut source = UnifiedEventSource {
+            rx,
+            tx: tx.clone(),
+            _input_handle: std::thread::spawn(|| {}),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            dirty_windows: HashSet::new(),
+            exited_windows: Vec::new(),
+            pending_event: None,
+            input_buffer: VecDeque::new(),
+            signal_received: false,
+            normalizer: KeyboardNormalizer::new(),
+            last_event_at: None,
+            frame_pacer: FramePacer::new(),
+            pending_work: false,
+            max_sleep_duration: None,
+        };
+        source._input_handle = std::thread::spawn(|| {});
+
+        // Send: Press, Release, Repeat, Press
+        // On non-Windows: Release filtered, 3 survive (Press, Repeat, Press)
+        // On Windows: Release + Repeat filtered, 2 survive (Press, Press)
+        for (i, kind) in [
+            KeyKind::Press,
+            KeyKind::Release,
+            KeyKind::Repeat,
+            KeyKind::Press,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let evt = Event::Key(KeyEvent {
+                code: KeyCode::Char(char::from(b'a' + i as u8)),
+                modifiers: KeyModifiers::NONE,
+                kind,
+            });
+            tx.send(UnifiedEvent::Input(evt)).unwrap();
+        }
+
+        source.drain_pending();
+
+        // Count surviving events — Release is always filtered, Repeat only on Windows
+        let expected = if cfg!(windows) { 2 } else { 3 };
+        assert_eq!(
+            source.input_buffer.len(),
+            expected,
+            "Release must be filtered; on non-Windows Repeat survives"
+        );
+
+        // Verify Release event (index 1) is absent
+        for evt in &source.input_buffer {
+            if let Event::Key(k) = evt {
+                assert_ne!(
+                    k.kind,
+                    KeyKind::Release,
+                    "Release events must never survive normalization"
+                );
+            }
+        }
+
+        // Verify first and last events are the Press events
+        let first = source.input_buffer.front().unwrap();
+        let last = source.input_buffer.back().unwrap();
+        if let (Event::Key(k1), Event::Key(k2)) = (first, last) {
+            assert_eq!(k1.kind, KeyKind::Press);
+            assert_eq!(k1.code, KeyCode::Char('a'));
+            assert_eq!(k2.kind, KeyKind::Press);
+            assert_eq!(k2.code, KeyCode::Char('d'));
+        } else {
+            panic!("expected Key events");
+        }
+    }
+
+    /// `poll` must skip Release events that arrive via recv_timeout,
+    /// continuing to wait until a valid event arrives or the deadline expires.
+    #[test]
+    fn poll_filters_release_events() {
+        let (tx, rx) = bounded(EVENT_CHANNEL_CAPACITY);
+        let mut source = UnifiedEventSource {
+            rx,
+            tx: tx.clone(),
+            _input_handle: std::thread::spawn(|| {}),
+            shutdown: Arc::new(AtomicBool::new(false)),
+            dirty_windows: HashSet::new(),
+            exited_windows: Vec::new(),
+            pending_event: None,
+            input_buffer: VecDeque::new(),
+            signal_received: false,
+            normalizer: KeyboardNormalizer::new(),
+            last_event_at: None,
+            frame_pacer: FramePacer::new(),
+            pending_work: false,
+            max_sleep_duration: None,
+        };
+        source._input_handle = std::thread::spawn(|| {});
+
+        // Send only Release events (filtered on all platforms)
+        for _ in 0..3 {
+            let evt = Event::Key(KeyEvent {
+                code: KeyCode::Char('x'),
+                modifiers: KeyModifiers::NONE,
+                kind: KeyKind::Release,
+            });
+            tx.send(UnifiedEvent::Input(evt)).unwrap();
+        }
+
+        // poll with a short timeout — should consume the filtered events
+        // and return Ok(false) since no valid event is available
+        let result = source.poll(Duration::from_millis(50));
+        assert!(
+            !result.unwrap() || source.pending_event.is_none(),
+            "poll must not set pending_event for filtered Release events"
         );
     }
 
@@ -839,18 +979,30 @@ mod tests {
         let dummy = std::thread::spawn(|| {});
         source._input_handle = dummy;
 
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
             source.poll_interval(),
             PowerProfile::PowerSaver.poll_interval()
+        );
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            source.poll_interval(),
+            term_wm_core::power_profile::WINDOWS_MAX_POLL_INTERVAL
         );
 
         source.set_max_sleep_duration(Some(Duration::from_millis(100)));
         assert_eq!(source.poll_interval(), Duration::from_millis(100));
 
         source.set_max_sleep_duration(None);
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
             source.poll_interval(),
             PowerProfile::PowerSaver.poll_interval()
+        );
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            source.poll_interval(),
+            term_wm_core::power_profile::WINDOWS_MAX_POLL_INTERVAL
         );
     }
 }


### PR DESCRIPTION
Addresses multiple Windows-specific reliability issues and establishes comprehensive test coverage to prevent regressions across platforms.
Windows ConPTY lifecycle fixes:
- Synthesize PtyStatus::Exited callback in has_exited() when child process dies, preventing reader thread deadlock when ConPTY swallows EOF
- Clamp poll interval to 50ms on Windows (WINDOWS_MAX_POLL_INTERVAL) to prevent ConPTY thread starvation
- Activate native Windows FFI via kernel32 module: CreateToolhelp32Snapshot, OpenProcess, QueryFullProcessImageNameW for process tree walking and foreground process name detection
Input normalization:
- Normalize events through KeyboardNormalizer in both drain_pending() and poll(), filtering Release (all platforms) and Repeat (Windows) before they reach the event buffer
- Remove esc_down stateful tracking from KeyboardNormalizer — now a unit struct. Esc deduplication handled by window manager's super_passthrough_window timeout instead of dropping presses
Selection coordinate fix:
- Rewrite selection_text_for_range with ScrollbackGuard RAII guard for safe scrollback position restoration
- Extract max_scrollback before locking parser to prevent Mutex deadlocks
- Paginated extraction loop handles selections spanning viewport/scrollback boundaries using translated vt100 coordinates
Cross-platform test infrastructure:
- Add get_test_executable() helper returning cat (Unix) or cmd.exe (Windows), replacing all 11 hardcoded "cat" strings in PTY tests
- 10 new tests covering: has_exited() callback firing and idempotency, event normalization in drain/poll, header_buttons() glyph and ordering, scrollback selection with small max_sb, WINDOWS_MAX_POLL_INTERVAL value, and Repeat key passthrough behavior
Other:
- Close button glyph changed from ✖ to X for consistent rendering across terminal emulators
- Version bump to 0.8.19-alpha