### PR TITLE
feat: Session server/client infrastructure, PTY deadlock fix, and E2E tests

### DIFF
--- a/.cargo/config.toml.example
+++ b/.cargo/config.toml.example
@@ -1,0 +1,8 @@
+[patch.crates-io]
+muxio-core = { path = "../rust-muxio/core" }
+muxio-rpc-service = { path = "../rust-muxio/extensions/muxio-rpc-service" }
+muxio-rpc-service-caller = { path = "../rust-muxio/extensions/muxio-rpc-service-caller" }
+muxio-rpc-service-endpoint = { path = "../rust-muxio/extensions/muxio-rpc-service-endpoint" }
+muxio-tokio-rpc-ipc-client = { path = "../rust-muxio/extensions/muxio-tokio-rpc-ipc-client" }
+muxio-tokio-rpc-ipc-server = { path = "../rust-muxio/extensions/muxio-tokio-rpc-ipc-server" }
+muxio-tokio-mpsc-adapter = { path = "../rust-muxio/extensions/muxio-tokio-mpsc-adapter" }

--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -6,6 +6,7 @@ ignore = ["RUSTSEC-2026-0192"]
 
 [licenses]
 allow = [
+  "0BSD",
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSD-2-Clause",

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,10 @@
+[
+    {
+        "label": "term-session-server",
+        "command": "cargo run -p term-session-server -- --socket term-session.sock"
+    },
+    {
+        "label": "term-session-client",
+        "command": "cargo run -p term-session-client -- term-session.sock"
+    }
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +190,30 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcode"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6ed1b54d8dc333e7be604d00fa9262f4635485ffea923647b6521a5fff045d"
+dependencies = [
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
+ "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "bitflags"
@@ -241,6 +285,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +311,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -600,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,10 +857,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -795,8 +933,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -864,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1066,30 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1059,6 +1232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1261,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1362,6 +1560,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "muxio-core"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78a006f8d68939c195d3239cc2e24623f30e0ebe753b157aada18a197b27978"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "tracing",
+]
+
+[[package]]
+name = "muxio-rpc-service"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caecaa8ded87a6a68569ddf23f0e2e838160b3ff9ea34f01266734485ede9b8a"
+dependencies = [
+ "bitcode",
+ "num_enum",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "muxio-rpc-service-caller"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cc953f18be20cddfbc5e428acc94c4600b969078324a664a6f81520de69c7d"
+dependencies = [
+ "async-trait",
+ "futures",
+ "muxio-core",
+ "muxio-rpc-service",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "muxio-rpc-service-endpoint"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a88d5b21b7bc8716a6fcbb4f5c03ac9165617e65ff4f7cdc67694a4f6cfb38"
+dependencies = [
+ "async-trait",
+ "bitcode",
+ "bytes",
+ "futures",
+ "muxio-core",
+ "muxio-rpc-service",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "muxio-tokio-mpsc-adapter"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8333aeee02dcfa85ee1bf98d00f67d91bfef16f8a5297830507dd1e7a603b779"
+dependencies = [
+ "async-trait",
+ "muxio-core",
+ "muxio-rpc-service",
+ "muxio-rpc-service-caller",
+ "muxio-rpc-service-endpoint",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "muxio-tokio-rpc-ipc-client"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae05d1b0e7caa35cc0feb21dc069099d3eb106dbe9e041afc8d2c1480c1ff397"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "interprocess",
+ "muxio-core",
+ "muxio-rpc-service",
+ "muxio-rpc-service-caller",
+ "muxio-rpc-service-endpoint",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "muxio-tokio-rpc-ipc-server"
+version = "0.12.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca05c2388dda5162df0d3b882c2ee5ac73aa2876c2f92169dff5fafc2e331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "interprocess",
+ "muxio-core",
+ "muxio-rpc-service",
+ "muxio-rpc-service-caller",
+ "muxio-rpc-service-endpoint",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1748,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1786,6 +2109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2356,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -2267,6 +2605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2704,16 @@ name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2467,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -2476,8 +2830,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "term-session-client"
+version = "0.8.20-alpha"
+dependencies = [
+ "clap",
+ "crossterm",
+ "muxio-core",
+ "muxio-rpc-service",
+ "muxio-rpc-service-caller",
+ "muxio-rpc-service-endpoint",
+ "muxio-tokio-mpsc-adapter",
+ "muxio-tokio-rpc-ipc-client",
+ "portable-pty",
+ "term-session-muxio-service-definitions",
+ "term-wm-core",
+ "term-wm-pty-engine",
+ "tokio",
+ "tracing",
+ "vt100",
+]
+
+[[package]]
+name = "term-session-mock"
+version = "0.0.0"
+
+[[package]]
+name = "term-session-muxio-service-definitions"
+version = "0.8.20-alpha"
+dependencies = [
+ "bitcode",
+ "muxio-core",
+ "muxio-rpc-service",
+]
+
+[[package]]
+name = "term-session-server"
+version = "0.8.20-alpha"
+dependencies = [
+ "clap",
+ "muxio-core",
+ "muxio-rpc-service",
+ "muxio-rpc-service-caller",
+ "muxio-rpc-service-endpoint",
+ "muxio-tokio-rpc-ipc-server",
+ "portable-pty",
+ "term-session-muxio-service-definitions",
+ "term-wm-pty-engine",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "vt100",
+]
+
+[[package]]
 name = "term-wm"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -2485,15 +2892,24 @@ dependencies = [
  "hostname",
  "indoc",
  "line-ending",
+ "muxio-rpc-service",
+ "muxio-tokio-mpsc-adapter",
+ "muxio-tokio-rpc-ipc-client",
  "portable-pty",
  "proptest",
  "ratatui",
+ "tempfile",
+ "term-bench",
+ "term-session-client",
+ "term-session-muxio-service-definitions",
+ "term-session-server",
  "term-wm-console",
  "term-wm-core",
  "term-wm-layout-engine",
  "term-wm-render",
  "term-wm-sys-ui-components",
  "term-wm-ui-components",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "webbrowser",
@@ -2501,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2513,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "console",
  "crossbeam-channel",
@@ -2531,14 +2947,14 @@ dependencies = [
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "arboard",
  "base64",
@@ -2551,11 +2967,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -2570,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -2813,6 +3229,64 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
 
 [[package]]
 name = "tracing"
@@ -3269,6 +3743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,10 +3780,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3389,6 +3922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +3973,12 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,7 +2859,6 @@ name = "term-session-muxio-service-definitions"
 version = "0.8.20-alpha"
 dependencies = [
  "bitcode",
- "muxio-core",
  "muxio-rpc-service",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ required-features = ["sys-ui"]
 default = ["sys-ui"]
 sys-ui = ["dep:term-wm-sys-ui-components"]
 
+[package.metadata.cargo-udeps.ignore]
+development = ["term-bench", "term-session-client"]
+
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 crossbeam-channel = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[package.metadata.cargo-udeps.ignore]
+development = ["term-bench", "term-session-client"]
+
 [workspace]
 members = [
     "crates/term-bench",
@@ -90,9 +93,6 @@ required-features = ["sys-ui"]
 default = ["sys-ui"]
 sys-ui = ["dep:term-wm-sys-ui-components"]
 
-[package.metadata.cargo-udeps.ignore]
-development = ["term-bench", "term-session-client"]
-
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 crossbeam-channel = { workspace = true }
@@ -115,14 +115,14 @@ webbrowser = { workspace = true }
 indoc = { workspace = true }
 
 [dev-dependencies]
+muxio-rpc-service = { workspace = true }
+muxio-tokio-mpsc-adapter = { workspace = true }
+muxio-tokio-rpc-ipc-client = { workspace = true }
 proptest = { workspace = true }
-term-wm-render = { workspace = true }
-term-session-server = { path = "crates/term-session-server" }
+tempfile = { workspace = true }
+term-bench = { path = "crates/term-bench" }
 term-session-client = { path = "crates/term-session-client" }
 term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions" }
-term-bench = { path = "crates/term-bench" }
-muxio-tokio-rpc-ipc-client = { workspace = true }
-muxio-tokio-mpsc-adapter = { workspace = true }
-muxio-rpc-service = { workspace = true }
+term-session-server = { path = "crates/term-session-server" }
+term-wm-render = { workspace = true }
 tokio = { workspace = true }
-tempfile = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ publish.workspace = true
 [workspace]
 members = [
     "crates/term-bench",
+    "crates/term-session-client",
+    "crates/term-session-mock",
+    "crates/term-session-muxio-service-definitions",
+    "crates/term-session-server",
     "crates/term-wm-console",
     "crates/term-wm-core",
     "crates/term-wm-layout-engine",
@@ -23,7 +27,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.8.19-alpha"
+version = "0.8.20-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -44,6 +48,13 @@ indoc = "2.0.7"
 libc = "0.2.186"
 line-ending = "1.5.1"
 linkify = "0.11.0"
+muxio-core = "0.12.0-alpha"
+muxio-rpc-service = "0.12.0-alpha"
+muxio-rpc-service-caller = "0.12.0-alpha"
+muxio-rpc-service-endpoint = "0.12.0-alpha"
+muxio-tokio-mpsc-adapter = "0.12.0-alpha"
+muxio-tokio-rpc-ipc-client = "0.12.0-alpha"
+muxio-tokio-rpc-ipc-server = "0.12.0-alpha"
 portable-pty = "0.9.0"
 proptest = "1.11.0"
 pulldown-cmark = "0.13.0"
@@ -52,14 +63,17 @@ resvg = "0.47.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-wm = { path = ".", version = "0.8.19-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.8.19-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.8.19-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.19-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.19-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.8.19-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.19-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.19-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.8.20-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.8.20-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.8.20-alpha" }
+term-wm = { path = ".", version = "0.8.20-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.8.20-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.8.20-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.20-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.20-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.8.20-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.8.20-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.8.20-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
@@ -100,3 +114,12 @@ indoc = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true }
 term-wm-render = { workspace = true }
+term-session-server = { path = "crates/term-session-server" }
+term-session-client = { path = "crates/term-session-client" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions" }
+term-bench = { path = "crates/term-bench" }
+muxio-tokio-rpc-ipc-client = { workspace = true }
+muxio-tokio-mpsc-adapter = { workspace = true }
+muxio-rpc-service = { workspace = true }
+tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/term-session-client/Cargo.toml
+++ b/crates/term-session-client/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "term-session-client"
+description = "IPC-based session client for term-wm. For internal usage."
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+crossterm = { workspace = true, features = ["bracketed-paste"] }
+muxio-core = { workspace = true }
+muxio-rpc-service = { workspace = true }
+muxio-rpc-service-caller = { workspace = true }
+muxio-rpc-service-endpoint = { workspace = true }
+muxio-tokio-mpsc-adapter = { workspace = true }
+muxio-tokio-rpc-ipc-client = { workspace = true }
+portable-pty = { workspace = true }
+term-session-muxio-service-definitions = { workspace = true }
+term-wm-core = { workspace = true }
+term-wm-pty-engine = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+vt100 = { workspace = true }

--- a/crates/term-session-client/README.md
+++ b/crates/term-session-client/README.md
@@ -1,0 +1,11 @@
+# term-session-client
+
+IPC-based session client for term-wm. For internal usage.
+
+See the main [term-wm](https://crates.io/crates/term-wm) crate for documentation.
+
+## Known limitation
+
+When a parent `term-wm` instance captures hardware mouse interrupts via `crossterm`, it claims authoritative control over the spatial matrix. It translates these coordinates and pushes them down the PTY as SGR 1006 sequences. The nested child term-wm instance receives these sequences on its standard input and attempts to parse them as global crossterm events. Because both instances compete for the same ANSI mouse tracking protocols (\x1b[?1000h / ?1006h), the parent layout engine inevitably traps spatial interactions intended for the child payload, or forwards mutated coordinates that break the nested grid synchronization.
+
+This is an inherent architectural limitation of recursively nested pseudoterminals without a dedicated input bypass mode. The un-nested client-server execution path functions correctly because it operates directly against the host terminal emulator's unfiltered global matrix.

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -1,0 +1,477 @@
+mod remote_pane;
+
+pub use remote_pane::RemotePane;
+
+use std::io::{self, Write, stdout};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossterm::QueueableCommand;
+use crossterm::cursor::{Hide, Show};
+use crossterm::event as crossterm_event;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use muxio_tokio_mpsc_adapter::ChannelCallerExt;
+use muxio_tokio_rpc_ipc_client::{RpcCallPrebuffered, RpcIpcClient, RpcServiceCallerInterface};
+use portable_pty::PtySize;
+use term_session_muxio_service_definitions::{
+    STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, Spawn,
+};
+use term_wm_core::events::{Event, KeyKind};
+use term_wm_pty_engine::Pane;
+use term_wm_pty_engine::clipboard::{Clipboard, extract_osc52_text};
+use term_wm_pty_engine::input_encoding::{key_to_bytes, mouse_event_to_bytes};
+use term_wm_pty_engine::signal::install_sigint_handler;
+use tokio::sync::mpsc;
+use vt100::{MouseProtocolEncoding, MouseProtocolMode};
+
+/// Number of iterations to wait for initial PTY output.
+/// Windows ConPTY needs more time to initialize and flush its internal buffers.
+#[cfg(target_os = "windows")]
+const INITIAL_WAIT_ITERS: usize = 60;
+#[cfg(not(target_os = "windows"))]
+const INITIAL_WAIT_ITERS: usize = 20;
+
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = stdout().queue(crossterm::event::DisableMouseCapture);
+        let _ = stdout().queue(Show);
+        let _ = stdout().queue(LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+        let _ = stdout().flush();
+    }
+}
+
+/// Connect to a term-session-server and run the TUI viewer.
+///
+/// This function is synchronous. It creates a background tokio runtime
+/// for muxio IPC, then runs the synchronous crossterm event loop on the
+/// calling thread.
+pub fn run_session(socket_path: &str) -> io::Result<()> {
+    let rt =
+        tokio::runtime::Runtime::new().map_err(|e| io::Error::other(format!("runtime: {e}")))?;
+
+    // Connect via muxio IPC
+    let client: Arc<RpcIpcClient> = rt
+        .block_on(RpcIpcClient::new(socket_path))
+        .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, format!("{e:?}")))?;
+
+    // Channel for raw PTY output bytes from the subscription stream
+    let (push_tx, push_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+
+    // Get terminal size
+    let (term_cols, term_rows) = crossterm::terminal::size()?;
+
+    // Spawn session on the server
+    rt.block_on(async {
+        Spawn::call(&*client, (None, term_cols, term_rows))
+            .await
+            .map_err(|e| io::Error::other(format!("spawn: {e:?}")))
+    })?;
+
+    // Open streaming channels for output subscription and input
+    let writer = rt.block_on(async {
+        // Subscribe to PTY output via the mpsc adapter.
+        // `reader` yields response chunks (raw PTY output bytes).
+        let (_, mut reader) = client
+            .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+            .await
+            .map_err(|e| io::Error::other(format!("subscribe: {e:?}")))?;
+
+        // Forward response chunks to push_tx.  When the stream ends
+        // (session exits), push_tx is dropped, and `drain_pushes`
+        // detects the disconnect.
+        rt.spawn(async move {
+            while let Some(chunk) = reader.recv().await {
+                match chunk {
+                    Ok(data) => {
+                        let _ = push_tx.send(data);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        // Open streaming channel for PTY input.
+        // `writer` accepts keystroke bytes.
+        let (writer, _) = client
+            .open_channel(STREAM_INPUT_METHOD_ID, 0)
+            .await
+            .map_err(|e| io::Error::other(format!("stream input: {e:?}")))?;
+
+        Ok::<_, io::Error>(writer)
+    })?;
+
+    let input_writer = Box::new(move |data: &[u8]| -> io::Result<()> {
+        writer
+            .send(data.to_vec())
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        Ok(())
+    });
+
+    let mut pane = RemotePane::new(
+        1u64,
+        client.clone(),
+        rt.handle().clone(),
+        term_cols,
+        term_rows,
+        push_rx,
+        input_writer,
+    );
+
+    // Wait for initial output
+    for _ in 0..INITIAL_WAIT_ITERS {
+        pane.drain_pushes();
+        let parser = pane.shared_parser();
+        let parser = parser.lock().unwrap();
+        if !parser.screen().contents_formatted().is_empty() {
+            break;
+        }
+        drop(parser);
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    enable_raw_mode()?;
+    let mut out = stdout();
+    out.queue(EnterAlternateScreen)?;
+    out.queue(Hide)?;
+    out.queue(crossterm::event::EnableMouseCapture)?;
+    out.flush()?;
+    let _guard = TerminalGuard;
+
+    let mut clipboard = Clipboard::new();
+    let sigint = install_sigint_handler()?;
+
+    // Initial full screen render
+    {
+        let parser = pane.shared_parser();
+        let parser = parser.lock().unwrap();
+        let screen = parser.screen();
+        let data = screen.contents_formatted();
+        out.write_all(&data)?;
+        out.flush()?;
+    }
+
+    let mut prev_content: Option<Vec<u8>> = None;
+
+    loop {
+        let frame_start = std::time::Instant::now();
+
+        // Drain pushes from the server (this updates the parser)
+        pane.drain_pushes();
+
+        // Detect screen changes
+        let current_content = {
+            let parser = pane.shared_parser();
+            let parser = parser.lock().unwrap();
+            parser.screen().contents_formatted()
+        };
+        let has_new_data = prev_content.as_deref() != Some(&current_content);
+
+        // Process OSC 52 clipboard data
+        if has_new_data && let Some(text) = extract_osc52_text(&current_content) {
+            let _ = clipboard.set(&text);
+        }
+
+        // Check connection health
+        if !client.is_connected() {
+            return Err(io::Error::other("connection to session server lost"));
+        }
+
+        // Drain SIGINT (Ctrl-C) — send 0x03 through the input stream
+        if sigint.received() {
+            sigint.ack();
+            let _ = pane.write_bytes(&[0x03]);
+        }
+
+        // Poll input with a short timeout
+        let had_input = if crossterm_event::poll(Duration::from_millis(4))? {
+            let crossterm_evt = crossterm_event::read()?;
+            // Convert crossterm event to core-owned event
+            let evt = match crossterm_evt {
+                crossterm_event::Event::Key(key) => Event::Key(term_wm_core::events::KeyEvent {
+                    code: match key.code {
+                        crossterm_event::KeyCode::Char(c) => term_wm_core::events::KeyCode::Char(c),
+                        crossterm_event::KeyCode::Enter => term_wm_core::events::KeyCode::Enter,
+                        crossterm_event::KeyCode::Tab => term_wm_core::events::KeyCode::Tab,
+                        crossterm_event::KeyCode::Backspace => {
+                            term_wm_core::events::KeyCode::Backspace
+                        }
+                        crossterm_event::KeyCode::Esc => term_wm_core::events::KeyCode::Esc,
+                        crossterm_event::KeyCode::Left => term_wm_core::events::KeyCode::Left,
+                        crossterm_event::KeyCode::Right => term_wm_core::events::KeyCode::Right,
+                        crossterm_event::KeyCode::Up => term_wm_core::events::KeyCode::Up,
+                        crossterm_event::KeyCode::Down => term_wm_core::events::KeyCode::Down,
+                        crossterm_event::KeyCode::Home => term_wm_core::events::KeyCode::Home,
+                        crossterm_event::KeyCode::End => term_wm_core::events::KeyCode::End,
+                        crossterm_event::KeyCode::PageUp => term_wm_core::events::KeyCode::PageUp,
+                        crossterm_event::KeyCode::PageDown => {
+                            term_wm_core::events::KeyCode::PageDown
+                        }
+                        crossterm_event::KeyCode::Delete => term_wm_core::events::KeyCode::Delete,
+                        crossterm_event::KeyCode::Insert => term_wm_core::events::KeyCode::Insert,
+                        crossterm_event::KeyCode::F(n) => term_wm_core::events::KeyCode::F(n),
+                        _ => continue,
+                    },
+                    modifiers: term_wm_core::events::KeyModifiers {
+                        shift: key.modifiers.contains(crossterm_event::KeyModifiers::SHIFT),
+                        control: key
+                            .modifiers
+                            .contains(crossterm_event::KeyModifiers::CONTROL),
+                        alt: key.modifiers.contains(crossterm_event::KeyModifiers::ALT),
+                    },
+                    kind: match key.kind {
+                        crossterm_event::KeyEventKind::Press => KeyKind::Press,
+                        crossterm_event::KeyEventKind::Repeat => KeyKind::Repeat,
+                        crossterm_event::KeyEventKind::Release => KeyKind::Release,
+                    },
+                }),
+                crossterm_event::Event::Mouse(mouse) => {
+                    Event::Mouse(term_wm_core::events::MouseEvent {
+                        kind: match mouse.kind {
+                            crossterm_event::MouseEventKind::Down(btn) => {
+                                term_wm_core::events::MouseEventKind::Press(match btn {
+                                    crossterm_event::MouseButton::Left => {
+                                        term_wm_core::events::MouseButton::Left
+                                    }
+                                    crossterm_event::MouseButton::Right => {
+                                        term_wm_core::events::MouseButton::Right
+                                    }
+                                    crossterm_event::MouseButton::Middle => {
+                                        term_wm_core::events::MouseButton::Middle
+                                    }
+                                })
+                            }
+                            crossterm_event::MouseEventKind::Up(btn) => {
+                                term_wm_core::events::MouseEventKind::Release(match btn {
+                                    crossterm_event::MouseButton::Left => {
+                                        term_wm_core::events::MouseButton::Left
+                                    }
+                                    crossterm_event::MouseButton::Right => {
+                                        term_wm_core::events::MouseButton::Right
+                                    }
+                                    crossterm_event::MouseButton::Middle => {
+                                        term_wm_core::events::MouseButton::Middle
+                                    }
+                                })
+                            }
+                            crossterm_event::MouseEventKind::Drag(btn) => {
+                                term_wm_core::events::MouseEventKind::Drag(match btn {
+                                    crossterm_event::MouseButton::Left => {
+                                        term_wm_core::events::MouseButton::Left
+                                    }
+                                    crossterm_event::MouseButton::Right => {
+                                        term_wm_core::events::MouseButton::Right
+                                    }
+                                    crossterm_event::MouseButton::Middle => {
+                                        term_wm_core::events::MouseButton::Middle
+                                    }
+                                })
+                            }
+                            crossterm_event::MouseEventKind::Moved => {
+                                term_wm_core::events::MouseEventKind::Moved
+                            }
+                            crossterm_event::MouseEventKind::ScrollUp => {
+                                term_wm_core::events::MouseEventKind::ScrollUp
+                            }
+                            crossterm_event::MouseEventKind::ScrollDown => {
+                                term_wm_core::events::MouseEventKind::ScrollDown
+                            }
+                            crossterm_event::MouseEventKind::ScrollLeft => {
+                                term_wm_core::events::MouseEventKind::ScrollLeft
+                            }
+                            crossterm_event::MouseEventKind::ScrollRight => {
+                                term_wm_core::events::MouseEventKind::ScrollRight
+                            }
+                        },
+                        modifiers: term_wm_core::events::KeyModifiers {
+                            shift: mouse
+                                .modifiers
+                                .contains(crossterm_event::KeyModifiers::SHIFT),
+                            control: mouse
+                                .modifiers
+                                .contains(crossterm_event::KeyModifiers::CONTROL),
+                            alt: mouse.modifiers.contains(crossterm_event::KeyModifiers::ALT),
+                        },
+                        column: mouse.column,
+                        row: mouse.row,
+                    })
+                }
+                crossterm_event::Event::Resize(w, h) => Event::Resize(w, h),
+                crossterm_event::Event::FocusGained => Event::FocusGained,
+                crossterm_event::Event::FocusLost => Event::FocusLost,
+                crossterm_event::Event::Paste(text) => Event::Paste(text),
+            };
+            match evt {
+                Event::Key(ref key)
+                    if key.kind == KeyKind::Press || key.kind == KeyKind::Repeat =>
+                {
+                    // Convert core-owned KeyEvent to pty-engine KeyEvent
+                    let pty_key = term_wm_pty_engine::input_encoding::KeyEvent {
+                        code: match key.code {
+                            term_wm_core::events::KeyCode::Char(c) => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Char(c)
+                            }
+                            term_wm_core::events::KeyCode::Enter => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Enter
+                            }
+                            term_wm_core::events::KeyCode::Tab => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Tab
+                            }
+                            term_wm_core::events::KeyCode::Backspace => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Backspace
+                            }
+                            term_wm_core::events::KeyCode::Esc => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Esc
+                            }
+                            term_wm_core::events::KeyCode::Left => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Left
+                            }
+                            term_wm_core::events::KeyCode::Right => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Right
+                            }
+                            term_wm_core::events::KeyCode::Up => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Up
+                            }
+                            term_wm_core::events::KeyCode::Down => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Down
+                            }
+                            term_wm_core::events::KeyCode::Home => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Home
+                            }
+                            term_wm_core::events::KeyCode::End => {
+                                term_wm_pty_engine::input_encoding::KeyCode::End
+                            }
+                            term_wm_core::events::KeyCode::PageUp => {
+                                term_wm_pty_engine::input_encoding::KeyCode::PageUp
+                            }
+                            term_wm_core::events::KeyCode::PageDown => {
+                                term_wm_pty_engine::input_encoding::KeyCode::PageDown
+                            }
+                            term_wm_core::events::KeyCode::Delete => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Delete
+                            }
+                            term_wm_core::events::KeyCode::Insert => {
+                                term_wm_pty_engine::input_encoding::KeyCode::Insert
+                            }
+                            term_wm_core::events::KeyCode::F(n) => {
+                                term_wm_pty_engine::input_encoding::KeyCode::F(n)
+                            }
+                            _ => continue,
+                        },
+                        modifiers: term_wm_pty_engine::input_encoding::KeyModifiers {
+                            shift: key.modifiers.shift,
+                            control: key.modifiers.control,
+                            alt: key.modifiers.alt,
+                        },
+                    };
+                    let bytes = key_to_bytes(&pty_key);
+                    if !bytes.is_empty() {
+                        let _ = pane.write_bytes(&bytes);
+                    }
+                    true
+                }
+                Event::Mouse(ref mouse) => {
+                    let mouse_active = {
+                        let parser = pane.shared_parser();
+                        let parser = parser.lock().unwrap();
+                        parser.screen().mouse_protocol_mode() != MouseProtocolMode::None
+                    };
+                    if mouse_active {
+                        // Convert core-owned MouseEvent to pty-engine MouseEvent
+                        let pty_mouse = term_wm_pty_engine::input_encoding::MouseEvent {
+                            kind: match mouse.kind {
+                                term_wm_core::events::MouseEventKind::Press(btn) => term_wm_pty_engine::input_encoding::MouseEventKind::Press(match btn {
+                                    term_wm_core::events::MouseButton::Left => term_wm_pty_engine::input_encoding::MouseButton::Left,
+                                    term_wm_core::events::MouseButton::Right => term_wm_pty_engine::input_encoding::MouseButton::Right,
+                                    term_wm_core::events::MouseButton::Middle => term_wm_pty_engine::input_encoding::MouseButton::Middle,
+                                }),
+                                term_wm_core::events::MouseEventKind::Release(btn) => term_wm_pty_engine::input_encoding::MouseEventKind::Release(match btn {
+                                    term_wm_core::events::MouseButton::Left => term_wm_pty_engine::input_encoding::MouseButton::Left,
+                                    term_wm_core::events::MouseButton::Right => term_wm_pty_engine::input_encoding::MouseButton::Right,
+                                    term_wm_core::events::MouseButton::Middle => term_wm_pty_engine::input_encoding::MouseButton::Middle,
+                                }),
+                                term_wm_core::events::MouseEventKind::Drag(btn) => term_wm_pty_engine::input_encoding::MouseEventKind::Drag(match btn {
+                                    term_wm_core::events::MouseButton::Left => term_wm_pty_engine::input_encoding::MouseButton::Left,
+                                    term_wm_core::events::MouseButton::Right => term_wm_pty_engine::input_encoding::MouseButton::Right,
+                                    term_wm_core::events::MouseButton::Middle => term_wm_pty_engine::input_encoding::MouseButton::Middle,
+                                }),
+                                term_wm_core::events::MouseEventKind::Moved => term_wm_pty_engine::input_encoding::MouseEventKind::Moved,
+                                term_wm_core::events::MouseEventKind::ScrollUp => term_wm_pty_engine::input_encoding::MouseEventKind::ScrollUp,
+                                term_wm_core::events::MouseEventKind::ScrollDown => term_wm_pty_engine::input_encoding::MouseEventKind::ScrollDown,
+                                term_wm_core::events::MouseEventKind::ScrollLeft => term_wm_pty_engine::input_encoding::MouseEventKind::ScrollLeft,
+                                term_wm_core::events::MouseEventKind::ScrollRight => term_wm_pty_engine::input_encoding::MouseEventKind::ScrollRight,
+                            },
+                            modifiers: term_wm_pty_engine::input_encoding::KeyModifiers {
+                                shift: mouse.modifiers.shift,
+                                control: mouse.modifiers.control,
+                                alt: mouse.modifiers.alt,
+                            },
+                            column: mouse.column,
+                            row: mouse.row,
+                        };
+                        let bytes = mouse_event_to_bytes(&pty_mouse, MouseProtocolEncoding::Sgr);
+                        if !bytes.is_empty() {
+                            let _ = pane.write_bytes(&bytes);
+                        }
+                    }
+                    mouse_active
+                }
+                Event::Resize(w, h) => {
+                    let size = PtySize {
+                        rows: h,
+                        cols: w,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    };
+                    prev_content = None;
+                    let _ = pane.resize(size);
+                    true
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        // Diff-based incremental render
+        if has_new_data || prev_content.is_none() {
+            let parser = pane.shared_parser();
+            let parser = parser.lock().unwrap();
+            let screen = parser.screen();
+            let (rows, cols) = screen.size();
+
+            let diff = match &prev_content {
+                Some(prev) => {
+                    let mut prev_parser = vt100::Parser::new(rows, cols, 0);
+                    prev_parser.process(prev);
+                    screen.contents_diff(prev_parser.screen())
+                }
+                None => screen.contents_formatted(),
+            };
+
+            if !diff.is_empty() {
+                out.write_all(&diff)?;
+                out.flush()?;
+            }
+
+            prev_content = Some(screen.contents_formatted());
+        }
+
+        // Exit on session exit
+        if pane.has_exited() {
+            return Ok(());
+        }
+
+        // Pace the loop
+        if !has_new_data && !had_input {
+            let elapsed = frame_start.elapsed();
+            if elapsed < Duration::from_millis(8) {
+                std::thread::sleep(Duration::from_millis(8) - elapsed);
+            }
+        }
+    }
+}

--- a/crates/term-session-client/src/main.rs
+++ b/crates/term-session-client/src/main.rs
@@ -1,0 +1,19 @@
+use std::io;
+
+use clap::Parser;
+use term_session_client::run_session;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "term-session-client",
+    about = "Minimal TUI viewer for term-session-server"
+)]
+struct Cli {
+    #[arg(default_value = "term-session.sock")]
+    session_server_socket: String,
+}
+
+fn main() -> io::Result<()> {
+    let cli = Cli::parse();
+    run_session(&cli.session_server_socket)
+}

--- a/crates/term-session-client/src/remote_pane.rs
+++ b/crates/term-session-client/src/remote_pane.rs
@@ -1,0 +1,142 @@
+use std::cell::Cell;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use muxio_rpc_service::error::RpcServiceError;
+use muxio_tokio_rpc_ipc_client::RpcIpcClient;
+use portable_pty::{ExitStatus, PtySize};
+use term_session_muxio_service_definitions::{CloseSession, ResizePty};
+use term_wm_pty_engine::{Pane, PtyResult};
+use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
+
+type InputWriter = Box<dyn FnMut(&[u8]) -> io::Result<()> + Send>;
+
+pub struct RemotePane {
+    pub id: u64,
+    client: std::sync::Arc<RpcIpcClient>,
+    rt: Handle,
+    parser: Arc<Mutex<vt100::Parser>>,
+    exited: Cell<bool>,
+    push_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    input_writer: InputWriter,
+}
+
+impl RemotePane {
+    pub fn new(
+        id: u64,
+        client: std::sync::Arc<RpcIpcClient>,
+        rt: Handle,
+        cols: u16,
+        rows: u16,
+        push_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        input_writer: InputWriter,
+    ) -> Self {
+        Self {
+            id,
+            client,
+            rt,
+            parser: Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0))),
+            exited: Cell::new(false),
+            push_rx,
+            input_writer,
+        }
+    }
+
+    pub fn drain_pushes(&mut self) {
+        loop {
+            match self.push_rx.try_recv() {
+                Ok(data) => {
+                    let mut parser = self.parser.lock().unwrap();
+                    parser.process(&data);
+                }
+                Err(TryRecvError::Disconnected) => {
+                    self.exited.set(true);
+                    break;
+                }
+                Err(TryRecvError::Empty) => break,
+            }
+        }
+    }
+
+    fn rpc_to_pty<E: std::fmt::Display>(e: E) -> Box<dyn std::error::Error + Send + Sync> {
+        Box::new(io::Error::other(format!("{e}")))
+    }
+}
+
+impl Pane for RemotePane {
+    fn exit_status(&self) -> Option<ExitStatus> {
+        None
+    }
+
+    fn resize(&mut self, size: PtySize) -> PtyResult<()> {
+        let result: Result<(), RpcServiceError> = self.rt.block_on(async {
+            use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+            ResizePty::call(&*self.client, (self.id, size.cols, size.rows)).await
+        });
+        {
+            let mut parser = self.parser.lock().unwrap();
+            parser.screen_mut().set_size(size.rows, size.cols);
+        }
+        result.map_err(Self::rpc_to_pty)
+    }
+
+    fn has_exited(&mut self) -> bool {
+        self.exited.get()
+    }
+
+    fn alternate_screen(&mut self) -> bool {
+        let parser = self.parser.lock().unwrap();
+        parser.screen().alternate_screen()
+    }
+
+    fn scrollback(&mut self) -> usize {
+        0
+    }
+
+    fn set_scrollback(&mut self, _rows: usize) {}
+
+    fn scrollback_len(&self) -> usize {
+        0
+    }
+
+    fn write_bytes(&mut self, input: &[u8]) -> io::Result<()> {
+        (self.input_writer)(input)
+    }
+
+    fn shared_parser(&mut self) -> Arc<Mutex<vt100::Parser>> {
+        self.parser.clone()
+    }
+
+    fn max_scrollback(&mut self) -> usize {
+        0
+    }
+
+    fn take_exit_status(&mut self) -> Option<ExitStatus> {
+        None
+    }
+
+    fn bytes_received(&self) -> usize {
+        0
+    }
+
+    fn last_bytes_text(&self) -> String {
+        String::new()
+    }
+
+    fn kill_child(&mut self) -> PtyResult<()> {
+        self.rt
+            .block_on(async {
+                use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+                CloseSession::call(&*self.client, self.id).await
+            })
+            .map_err(Self::rpc_to_pty)?;
+        self.exited.set(true);
+        Ok(())
+    }
+
+    fn take_pending_title(&mut self) -> Option<String> {
+        None
+    }
+}

--- a/crates/term-session-mock/Cargo.toml
+++ b/crates/term-session-mock/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "term-session-mock"
+description = "Isolated workspace binary for simulating cross-platform raw virtual terminal streams and ConPTY byte sequences in integration tests."
+version = "0.0.0"
+edition = "2024"
+publish = false

--- a/crates/term-session-mock/Cargo.toml
+++ b/crates/term-session-mock/Cargo.toml
@@ -3,4 +3,5 @@ name = "term-session-mock"
 description = "Isolated workspace binary for simulating cross-platform raw virtual terminal streams and ConPTY byte sequences in integration tests."
 version = "0.0.0"
 edition = "2024"
+# Never publish this; only used for testing
 publish = false

--- a/crates/term-session-mock/src/main.rs
+++ b/crates/term-session-mock/src/main.rs
@@ -99,6 +99,29 @@ fn main() {
             let _ = stdout.flush();
             std::thread::sleep(Duration::from_millis(500));
         }
+        "capture" => {
+            #[cfg(windows)]
+            win_console::enable_raw_vt();
+
+            let mut stdin = io::stdin();
+            let mut stdout = io::stdout();
+            let mut buf = [0u8; 1024];
+
+            loop {
+                match stdin.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let _ = stdout.write_all(b"MOUSE_OK:");
+                        let _ = stdout.write_all(&buf[..n]);
+                        let _ = stdout.flush();
+                        if buf[..n].windows(4).any(|w| w == b"ping") {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
         "sleep" => {
             let ms: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
             std::thread::sleep(Duration::from_millis(ms));

--- a/crates/term-session-mock/src/main.rs
+++ b/crates/term-session-mock/src/main.rs
@@ -1,0 +1,115 @@
+use std::io::{self, Read, Write};
+use std::time::Duration;
+
+/// Deterministic mock binary for session server E2E tests.
+///
+/// Subcommands:
+/// - `echo` — reads stdin, writes to stdout (unbuffered pass-through).
+///   On Windows, enables raw VT mode so ANSI escape sequences
+///   pass through ConPTY without being consumed as INPUT_RECORDs.
+/// - `osc52` — writes a pre-defined OSC 52 clipboard sequence to stdout.
+///   On Windows, temporarily disables VT processing so the ESC
+///   byte isn't intercepted by ConPTY.
+/// - `sleep <ms>` — sleeps for N milliseconds, then exits.
+/// - `exit <code>` — exits with the given status code.
+pub const OSC52_TEST_PAYLOAD: &[u8] = b"c;dGVzdA==";
+
+#[cfg(windows)]
+mod win_console {
+    use std::os::windows::io::AsRawHandle;
+
+    unsafe extern "system" {
+        fn GetConsoleMode(handle: *mut std::ffi::c_void, mode: *mut u32) -> i32;
+        fn SetConsoleMode(handle: *mut std::ffi::c_void, mode: u32) -> i32;
+    }
+
+    const ENABLE_LINE_INPUT: u32 = 0x0002;
+    const ENABLE_ECHO_INPUT: u32 = 0x0004;
+    const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
+    const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
+    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+
+    pub fn enable_raw_vt() {
+        unsafe {
+            let stdin_handle = std::io::stdin().as_raw_handle();
+            let mut mode = 0u32;
+            if GetConsoleMode(stdin_handle, &mut mode) != 0 {
+                mode &= !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+                mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+                SetConsoleMode(stdin_handle, mode);
+            }
+            let stdout_handle = std::io::stdout().as_raw_handle();
+            if GetConsoleMode(stdout_handle, &mut mode) != 0 {
+                mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+                SetConsoleMode(stdout_handle, mode);
+            }
+        }
+    }
+
+    pub fn disable_stdout_vt_processing() {
+        unsafe {
+            let stdout_handle = std::io::stdout().as_raw_handle();
+            let mut mode = 0u32;
+            if GetConsoleMode(stdout_handle, &mut mode) != 0 {
+                mode &= !ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+                SetConsoleMode(stdout_handle, mode);
+            }
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: term_session_mock <echo|osc52|sleep|exit> [args]");
+        std::process::exit(1);
+    }
+
+    match args[1].as_str() {
+        "echo" => {
+            #[cfg(windows)]
+            win_console::enable_raw_vt();
+
+            let mut buffer = [0u8; 4096];
+            let mut stdin = io::stdin();
+            let mut stdout = io::stdout();
+            loop {
+                match stdin.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if stdout.write_all(&buffer[..n]).is_err() {
+                            break;
+                        }
+                        if stdout.flush().is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        "osc52" => {
+            #[cfg(windows)]
+            win_console::disable_stdout_vt_processing();
+
+            let mut stdout = io::stdout();
+            let _ = stdout.write_all(b"\x1b]52;");
+            let _ = stdout.write_all(OSC52_TEST_PAYLOAD);
+            let _ = stdout.write_all(b"\x07");
+            let _ = stdout.flush();
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        "sleep" => {
+            let ms: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
+            std::thread::sleep(Duration::from_millis(ms));
+        }
+        "exit" => {
+            let code: i32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+            std::process::exit(code);
+        }
+        other => {
+            eprintln!("Unknown subcommand: {other}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/term-session-mock/tests/mock_bin_tests.rs
+++ b/crates/term-session-mock/tests/mock_bin_tests.rs
@@ -1,0 +1,158 @@
+use std::process::Command;
+use std::time::Duration;
+
+fn mock_bin() -> String {
+    let mut path = std::env::current_exe().expect("test exe path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("term-session-mock{}", std::env::consts::EXE_SUFFIX));
+    path.to_string_lossy().to_string()
+}
+
+fn find_osc52_payload(stream: &[u8]) -> Option<&[u8]> {
+    let standard_prefix = b"\x1b]52;";
+    let windows_prefix = "←]52;".as_bytes();
+    let (start_idx, prefix_len) = stream
+        .windows(standard_prefix.len())
+        .position(|w| w == standard_prefix)
+        .map(|idx| (idx, standard_prefix.len()))
+        .or_else(|| {
+            stream
+                .windows(windows_prefix.len())
+                .position(|w| w == windows_prefix)
+                .map(|idx| (idx, windows_prefix.len()))
+        })?;
+    let body_start = start_idx + prefix_len;
+    let mut body_end = body_start;
+    while body_end < stream.len() {
+        let b = stream[body_end];
+        if b == 0x07 || (b == 0x1b && body_end + 1 < stream.len() && stream[body_end + 1] == b'\\')
+        {
+            break;
+        }
+        let is_valid_body =
+            b.is_ascii_alphanumeric() || b == b';' || b == b'+' || b == b'/' || b == b'=';
+        if !is_valid_body {
+            break;
+        }
+        body_end += 1;
+    }
+    if body_end > body_start {
+        Some(&stream[body_start..body_end])
+    } else {
+        None
+    }
+}
+
+#[test]
+fn echo_passthrough() {
+    let output = Command::new(mock_bin())
+        .arg("echo")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.as_mut().unwrap().write_all(b"hello world")?;
+            drop(child.stdin.take());
+            child.wait_with_output()
+        })
+        .expect("failed to run");
+    assert_eq!(output.stdout, b"hello world");
+}
+
+#[test]
+fn echo_empty_input() {
+    let output = Command::new(mock_bin())
+        .arg("echo")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            drop(child.stdin.take());
+            child.wait_with_output()
+        })
+        .expect("failed to run");
+    assert_eq!(output.stdout, b"");
+}
+
+#[test]
+fn sleep_exits_after_duration() {
+    let start = std::time::Instant::now();
+    let output = Command::new(mock_bin())
+        .args(["sleep", "50"])
+        .output()
+        .expect("failed to run");
+    let elapsed = start.elapsed();
+    assert!(output.status.success());
+    assert!(
+        elapsed >= Duration::from_millis(40),
+        "sleep should take at least 40ms, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn sleep_default_duration() {
+    let start = std::time::Instant::now();
+    let output = Command::new(mock_bin())
+        .arg("sleep")
+        .output()
+        .expect("failed to run");
+    let elapsed = start.elapsed();
+    assert!(output.status.success());
+    assert!(
+        elapsed >= Duration::from_millis(900),
+        "default sleep should take ~1000ms, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn exit_code_forwarded() {
+    let output = Command::new(mock_bin())
+        .args(["exit", "42"])
+        .output()
+        .expect("failed to run");
+    assert_eq!(output.status.code(), Some(42));
+}
+
+#[test]
+fn exit_default_code() {
+    let output = Command::new(mock_bin())
+        .arg("exit")
+        .output()
+        .expect("failed to run");
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn unknown_subcommand_fails() {
+    let output = Command::new(mock_bin())
+        .arg("bogus")
+        .output()
+        .expect("failed to run");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn no_args_fails() {
+    let output = Command::new(mock_bin()).output().expect("failed to run");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn osc52_writes_clipboard_sequence() {
+    let output = Command::new(mock_bin())
+        .arg("osc52")
+        .output()
+        .expect("failed to run");
+    assert!(output.status.success());
+    let payload = find_osc52_payload(&output.stdout);
+    assert_eq!(
+        payload,
+        Some(&b"c;dGVzdA=="[..]),
+        "osc52 subcommand should write OSC 52 payload to stdout, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/crates/term-session-muxio-service-definitions/Cargo.toml
+++ b/crates/term-session-muxio-service-definitions/Cargo.toml
@@ -10,5 +10,4 @@ publish.workspace = true
 
 [dependencies]
 bitcode = { workspace = true }
-muxio-core = { workspace = true }
 muxio-rpc-service = { workspace = true }

--- a/crates/term-session-muxio-service-definitions/Cargo.toml
+++ b/crates/term-session-muxio-service-definitions/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "term-session-muxio-service-definitions"
+description = "Shared service definitions for term-session IPC using Muxio."
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+bitcode = { workspace = true }
+muxio-core = { workspace = true }
+muxio-rpc-service = { workspace = true }

--- a/crates/term-session-muxio-service-definitions/README.md
+++ b/crates/term-session-muxio-service-definitions/README.md
@@ -1,0 +1,5 @@
+# term-session-muxio-service-definitions
+
+Shared service definitions for term-session IPC using Muxio.
+
+See the main [term-wm](https://crates.io/crates/term-wm) crate for documentation.

--- a/crates/term-session-muxio-service-definitions/src/lib.rs
+++ b/crates/term-session-muxio-service-definitions/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod methods;
+pub mod push_frame;
+
+pub use methods::{
+    CloseSession, ListSessions, PushOutput, ResizePty, STREAM_INPUT_METHOD_ID,
+    SUBSCRIBE_OUTPUT_METHOD_ID, Spawn, WriteInput,
+};
+pub use muxio_rpc_service::prebuffered::RpcMethodPrebuffered;
+pub use push_frame::SessionPushFrame;

--- a/crates/term-session-muxio-service-definitions/src/methods.rs
+++ b/crates/term-session-muxio-service-definitions/src/methods.rs
@@ -1,0 +1,230 @@
+use std::io;
+
+use bitcode::{Decode, Encode};
+use muxio_rpc_service::{prebuffered::RpcMethodPrebuffered, rpc_method_id};
+
+// ── Spawn ────────────────────────────────────────────────────────────
+
+#[derive(Encode, Decode)]
+struct SpawnRequest {
+    pub cmd: Option<Vec<String>>,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Encode, Decode)]
+struct SpawnResponse {
+    pub id: u64,
+}
+
+pub struct Spawn;
+
+impl RpcMethodPrebuffered for Spawn {
+    const METHOD_ID: u64 = rpc_method_id!("session.spawn");
+
+    type Input = (Option<Vec<String>>, u16, u16);
+    type Output = u64;
+
+    fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&SpawnRequest {
+            cmd: input.0,
+            cols: input.1,
+            rows: input.2,
+        }))
+    }
+
+    fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        let r = bitcode::decode::<SpawnRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok((r.cmd, r.cols, r.rows))
+    }
+
+    fn encode_response(output: Self::Output) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&SpawnResponse { id: output }))
+    }
+
+    fn decode_response(bytes: &[u8]) -> Result<Self::Output, io::Error> {
+        let r = bitcode::decode::<SpawnResponse>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(r.id)
+    }
+}
+
+// ── ResizePty ────────────────────────────────────────────────────────
+
+#[derive(Encode, Decode)]
+struct ResizeRequest {
+    pub id: u64,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+pub struct ResizePty;
+
+impl RpcMethodPrebuffered for ResizePty {
+    const METHOD_ID: u64 = rpc_method_id!("session.resize");
+
+    type Input = (u64, u16, u16);
+    type Output = ();
+
+    fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&ResizeRequest {
+            id: input.0,
+            cols: input.1,
+            rows: input.2,
+        }))
+    }
+
+    fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        let r = bitcode::decode::<ResizeRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok((r.id, r.cols, r.rows))
+    }
+
+    fn encode_response(_output: Self::Output) -> Result<Vec<u8>, io::Error> {
+        Ok(Vec::new())
+    }
+
+    fn decode_response(_bytes: &[u8]) -> Result<Self::Output, io::Error> {
+        Ok(())
+    }
+}
+
+// ── CloseSession ─────────────────────────────────────────────────────
+
+#[derive(Encode, Decode)]
+struct CloseRequest {
+    pub id: u64,
+}
+
+pub struct CloseSession;
+
+impl RpcMethodPrebuffered for CloseSession {
+    const METHOD_ID: u64 = rpc_method_id!("session.close");
+
+    type Input = u64;
+    type Output = ();
+
+    fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&CloseRequest { id: input }))
+    }
+
+    fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        let r = bitcode::decode::<CloseRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(r.id)
+    }
+
+    fn encode_response(_output: Self::Output) -> Result<Vec<u8>, io::Error> {
+        Ok(Vec::new())
+    }
+
+    fn decode_response(_bytes: &[u8]) -> Result<Self::Output, io::Error> {
+        Ok(())
+    }
+}
+
+// ── WriteInput ───────────────────────────────────────────────────────
+
+#[derive(Encode, Decode)]
+struct WriteInputRequest {
+    pub id: u64,
+    pub data: Vec<u8>,
+}
+
+pub struct WriteInput;
+
+impl RpcMethodPrebuffered for WriteInput {
+    const METHOD_ID: u64 = rpc_method_id!("session.write_input");
+
+    type Input = (u64, Vec<u8>);
+    type Output = ();
+
+    fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&WriteInputRequest {
+            id: input.0,
+            data: input.1,
+        }))
+    }
+
+    fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        let r = bitcode::decode::<WriteInputRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok((r.id, r.data))
+    }
+
+    fn encode_response(_output: Self::Output) -> Result<Vec<u8>, io::Error> {
+        Ok(Vec::new())
+    }
+
+    fn decode_response(_bytes: &[u8]) -> Result<Self::Output, io::Error> {
+        Ok(())
+    }
+}
+
+// ── PushOutput ───────────────────────────────────────────────────────
+
+pub struct PushOutput;
+
+impl RpcMethodPrebuffered for PushOutput {
+    const METHOD_ID: u64 = rpc_method_id!("session.push_output");
+
+    type Input = Vec<u8>;
+    type Output = ();
+
+    fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(input)
+    }
+
+    fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        Ok(bytes.to_vec())
+    }
+
+    fn encode_response(_output: Self::Output) -> Result<Vec<u8>, io::Error> {
+        Ok(Vec::new())
+    }
+
+    fn decode_response(_bytes: &[u8]) -> Result<Self::Output, io::Error> {
+        Ok(())
+    }
+}
+
+// ── StreamInput (streaming handler for PTY input) ──────────────────
+pub const STREAM_INPUT_METHOD_ID: u64 = rpc_method_id!("session.stream_input");
+
+// ── SubscribeOutput (streaming handler for PTY output pushes) ──────
+pub const SUBSCRIBE_OUTPUT_METHOD_ID: u64 = rpc_method_id!("session.subscribe_output");
+
+// ── ListSessions ─────────────────────────────────────────────────────
+
+#[derive(Encode, Decode)]
+struct ListResponse {
+    pub sessions: Vec<(u64, String, bool)>,
+}
+
+pub struct ListSessions;
+
+impl RpcMethodPrebuffered for ListSessions {
+    const METHOD_ID: u64 = rpc_method_id!("session.list");
+
+    type Input = ();
+    type Output = Vec<(u64, String, bool)>;
+
+    fn encode_request(_input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(Vec::new())
+    }
+
+    fn decode_request(_bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        Ok(())
+    }
+
+    fn encode_response(output: Self::Output) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&ListResponse { sessions: output }))
+    }
+
+    fn decode_response(bytes: &[u8]) -> Result<Self::Output, io::Error> {
+        let r = bitcode::decode::<ListResponse>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(r.sessions)
+    }
+}

--- a/crates/term-session-muxio-service-definitions/src/push_frame.rs
+++ b/crates/term-session-muxio-service-definitions/src/push_frame.rs
@@ -1,0 +1,116 @@
+use std::io;
+
+/// Tagged frame types multiplexed into the `SessionIo` stream.
+///
+/// Each frame starts with a one-byte tag, followed by message-type-specific
+/// content. The stream is bidirectional:
+///   - Client→Server: raw PTY input bytes (keyboard, mouse) — no framing.
+///   - Server→Client: tagged frames — RawOutput / SessionExited / TitleChanged.
+#[derive(Debug, Clone)]
+pub enum SessionPushFrame {
+    RawOutput { id: u64, data: Vec<u8> },
+    SessionExited { id: u64, status: i32 },
+    TitleChanged { id: u64, title: String },
+}
+
+// Tag byte constants
+const TAG_RAW_OUTPUT: u8 = 0x01;
+const TAG_SESSION_EXITED: u8 = 0x02;
+const TAG_TITLE_CHANGED: u8 = 0x03;
+
+impl SessionPushFrame {
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            Self::RawOutput { id, data } => {
+                let id_bytes = id.to_le_bytes();
+                let len_bytes = (data.len() as u32).to_le_bytes();
+                let mut buf = Vec::with_capacity(1 + 8 + 4 + data.len());
+                buf.push(TAG_RAW_OUTPUT);
+                buf.extend_from_slice(&id_bytes);
+                buf.extend_from_slice(&len_bytes);
+                buf.extend_from_slice(data);
+                buf
+            }
+            Self::SessionExited { id, status } => {
+                let id_bytes = id.to_le_bytes();
+                let status_bytes = status.to_le_bytes();
+                let mut buf = Vec::with_capacity(1 + 8 + 4);
+                buf.push(TAG_SESSION_EXITED);
+                buf.extend_from_slice(&id_bytes);
+                buf.extend_from_slice(&status_bytes);
+                buf
+            }
+            Self::TitleChanged { id, title } => {
+                let id_bytes = id.to_le_bytes();
+                let title_bytes = title.as_bytes();
+                let len_bytes = (title_bytes.len() as u32).to_le_bytes();
+                let mut buf = Vec::with_capacity(1 + 8 + 4 + title_bytes.len());
+                buf.push(TAG_TITLE_CHANGED);
+                buf.extend_from_slice(&id_bytes);
+                buf.extend_from_slice(&len_bytes);
+                buf.extend_from_slice(title_bytes);
+                buf
+            }
+        }
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<(Self, usize), io::Error> {
+        if bytes.is_empty() {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "empty frame"));
+        }
+        let tag = bytes[0];
+        match tag {
+            TAG_RAW_OUTPUT => {
+                if bytes.len() < 13 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "truncated raw_output",
+                    ));
+                }
+                let id = u64::from_le_bytes(bytes[1..9].try_into().unwrap());
+                let len = u32::from_le_bytes(bytes[9..13].try_into().unwrap()) as usize;
+                if bytes.len() < 13 + len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "truncated raw_output data",
+                    ));
+                }
+                let data = bytes[13..13 + len].to_vec();
+                Ok((Self::RawOutput { id, data }, 13 + len))
+            }
+            TAG_SESSION_EXITED => {
+                if bytes.len() < 13 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "truncated session_exited",
+                    ));
+                }
+                let id = u64::from_le_bytes(bytes[1..9].try_into().unwrap());
+                let status = i32::from_le_bytes(bytes[9..13].try_into().unwrap());
+                Ok((Self::SessionExited { id, status }, 13))
+            }
+            TAG_TITLE_CHANGED => {
+                if bytes.len() < 13 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "truncated title_changed",
+                    ));
+                }
+                let id = u64::from_le_bytes(bytes[1..9].try_into().unwrap());
+                let len = u32::from_le_bytes(bytes[9..13].try_into().unwrap()) as usize;
+                if bytes.len() < 13 + len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "truncated title_changed data",
+                    ));
+                }
+                let title = String::from_utf8_lossy(&bytes[13..13 + len]).into_owned();
+                Ok((Self::TitleChanged { id, title }, 13 + len))
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown frame tag: {tag}"),
+            )),
+        }
+    }
+}

--- a/crates/term-session-server/Cargo.toml
+++ b/crates/term-session-server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "term-session-server"
+description = "IPC-based session server for term-wm. For internal usage."
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+muxio-core = { workspace = true }
+muxio-rpc-service = { workspace = true }
+muxio-rpc-service-caller = { workspace = true }
+muxio-rpc-service-endpoint = { workspace = true }
+muxio-tokio-rpc-ipc-server = { workspace = true }
+portable-pty = { workspace = true }
+term-session-muxio-service-definitions = { workspace = true }
+term-wm-pty-engine = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+vt100 = { workspace = true }

--- a/crates/term-session-server/README.md
+++ b/crates/term-session-server/README.md
@@ -1,0 +1,5 @@
+# term-session-server
+
+IPC-based session server for term-wm. For internal usage.
+
+See the main [term-wm](https://crates.io/crates/term-wm) crate for documentation.

--- a/crates/term-session-server/src/lib.rs
+++ b/crates/term-session-server/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod session;
+pub mod session_server;
+
+pub use session::Session;
+pub use session_server::SessionServerConfig;
+pub use session_server::run_server;

--- a/crates/term-session-server/src/main.rs
+++ b/crates/term-session-server/src/main.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+use term_session_server::SessionServerConfig;
+
+#[derive(Parser, Debug)]
+#[command(name = "term-session-server", about = "Pure PTY session manager")]
+struct Cli {
+    /// Socket path for IPC (Unix domain socket / named pipe)
+    #[arg(long = "socket", default_value = "term-session.sock")]
+    socket: String,
+
+    /// Columns (width) of each terminal
+    #[arg(long = "cols", default_value = "80")]
+    cols: u16,
+
+    /// Rows (height) of each terminal
+    #[arg(long = "rows", default_value = "24")]
+    rows: u16,
+
+    /// Command to run (and its arguments).
+    /// If omitted, launches the default shell.
+    #[arg(num_args = 0..)]
+    cmd: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+
+    let config = SessionServerConfig {
+        socket_path: cli.socket,
+        cmd: cli.cmd,
+        cols: cli.cols,
+        rows: cli.rows,
+    };
+
+    match term_session_server::run_server(config).await {
+        Ok(code) => std::process::ExitCode::from(code as u8),
+        Err(e) => {
+            tracing::error!("SessionServer error: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/term-session-server/src/session.rs
+++ b/crates/term-session-server/src/session.rs
@@ -1,0 +1,95 @@
+use portable_pty::{CommandBuilder, PtySize};
+use term_wm_pty_engine::{Pty, PtyResult};
+
+pub struct Session {
+    pub id: u64,
+    pub pty: Pty,
+    pub title: Option<String>,
+    pub exited: bool,
+    pub exit_code: Option<i32>,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+fn default_shell_command() -> CommandBuilder {
+    #[cfg(not(windows))]
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "bash".to_string());
+    #[cfg(windows)]
+    let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+    let mut cmd = CommandBuilder::new(shell);
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.cwd(cwd);
+    }
+    cmd
+}
+
+impl Session {
+    pub fn spawn(id: u64, cmd: Option<Vec<String>>, cols: u16, rows: u16) -> PtyResult<Self> {
+        let size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let pty = if let Some(cmd_parts) = &cmd {
+            let mut builder = CommandBuilder::new(&cmd_parts[0]);
+            for arg in &cmd_parts[1..] {
+                builder.arg(arg);
+            }
+            if let Ok(cwd) = std::env::current_dir() {
+                builder.cwd(cwd);
+            }
+            Pty::spawn(builder, size)?
+        } else {
+            Pty::spawn(default_shell_command(), size)?
+        };
+        Ok(Self {
+            id,
+            pty,
+            title: None,
+            exited: false,
+            exit_code: None,
+            cols,
+            rows,
+        })
+    }
+
+    pub fn read_output(&mut self) -> Vec<u8> {
+        // Clear dirty flag and wake the PTY reader thread from I/O burst budget parking
+        self.pty.screen();
+        // Sync title from the background engine (replaces manual OSC extraction)
+        if let Some(title) = self.pty.take_pending_title() {
+            self.title = Some(title);
+        }
+        self.pty.drain_pending()
+    }
+
+    /// Sync screen state without draining pending output.
+    /// Clears the dirty flag (waking the reader thread from I/O burst budget parking)
+    /// and syncs the title, but leaves accumulated bytes in the pending buffer so
+    /// they can be sent to a future subscriber.
+    pub fn sync_screen(&mut self) {
+        self.pty.screen();
+        if let Some(title) = self.pty.take_pending_title() {
+            self.title = Some(title);
+        }
+    }
+
+    pub fn check_exited(&mut self) -> bool {
+        if !self.exited && self.pty.has_exited() {
+            self.exited = true;
+            self.exit_code = self.pty.exit_status().map(|s| s.exit_code() as i32);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn take_exit_code(&mut self) -> Option<i32> {
+        self.exit_code.take()
+    }
+
+    pub fn generate_snapshot(&mut self) -> Vec<u8> {
+        self.pty.generate_snapshot()
+    }
+}

--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -1,0 +1,353 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use muxio_core::rpc::rpc_internals::RpcStreamEvent;
+use muxio_rpc_service::prebuffered::RpcMethodPrebuffered;
+use muxio_rpc_service_endpoint::{RpcServiceEndpointInterface, StreamResponder};
+use muxio_tokio_rpc_ipc_server::{RpcIpcServer, RpcIpcServerEvent};
+use portable_pty::PtySize;
+use tokio::sync::{Mutex, mpsc, oneshot};
+
+use term_session_muxio_service_definitions::{
+    CloseSession, ListSessions, ResizePty, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID,
+    Spawn, WriteInput,
+};
+
+use crate::session::Session;
+
+pub struct SessionServerConfig {
+    pub socket_path: String,
+    pub cmd: Vec<String>,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+struct ClientEntry {
+    conn_id: usize,
+}
+
+struct SubscriberEntry {
+    conn_id: usize,
+    respond: StreamResponder,
+}
+
+struct ServerState {
+    session: Option<Session>,
+    clients: Vec<ClientEntry>,
+    subscribers: Vec<SubscriberEntry>,
+}
+
+impl ServerState {
+    fn new() -> Self {
+        Self {
+            session: None,
+            clients: Vec::new(),
+            subscribers: Vec::new(),
+        }
+    }
+}
+
+type SharedState = Arc<Mutex<ServerState>>;
+
+/// Run the session server. Returns the PTY child's exit code on success.
+pub async fn run_server(
+    config: SessionServerConfig,
+) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
+    let state: SharedState = Arc::new(Mutex::new(ServerState::new()));
+
+    // Spawn initial session
+    {
+        let mut st = state.lock().await;
+        let cmd = if config.cmd.is_empty() {
+            None
+        } else {
+            Some(config.cmd.clone())
+        };
+        let session = Session::spawn(1, cmd, config.cols, config.rows)?;
+        st.session = Some(session);
+    }
+
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+    let server = RpcIpcServer::new(Some(event_tx));
+    let endpoint = server.endpoint();
+
+    // Register Spawn
+    let st = Arc::clone(&state);
+    endpoint
+        .register_prebuffered(Spawn::METHOD_ID, move |payload, _ctx| {
+            let state = Arc::clone(&st);
+            async move {
+                let mut guard = state.lock().await;
+
+                let (cmd, cols, rows) = Spawn::decode_request(&payload)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+
+                // If a session already exists and hasn't exited, resize and return it.
+                if let Some(ref mut session) = guard.session
+                    && !session.exited
+                {
+                    let size = PtySize {
+                        rows,
+                        cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    };
+                    let _ = session.pty.resize(size);
+                    session.cols = cols;
+                    session.rows = rows;
+
+                    return Spawn::encode_response(session.id)
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>);
+                }
+
+                let id = 1;
+                let session = Session::spawn(id, cmd, cols, rows)?;
+                guard.session = Some(session);
+                Spawn::encode_response(id)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+        })
+        .await
+        .map_err(|e| format!("register Spawn: {e:?}"))?;
+
+    // Register ResizePty
+    let st = Arc::clone(&state);
+    endpoint
+        .register_prebuffered(ResizePty::METHOD_ID, move |payload, _ctx| {
+            let state = Arc::clone(&st);
+            async move {
+                let (_id, cols, rows) = ResizePty::decode_request(&payload)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let mut guard = state.lock().await;
+                if let Some(session) = guard.session.as_mut() {
+                    let size = portable_pty::PtySize {
+                        rows,
+                        cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    };
+                    let _ = session.pty.resize(size);
+                }
+                ResizePty::encode_response(())
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+        })
+        .await
+        .map_err(|e| format!("register ResizePty: {e:?}"))?;
+
+    // Register CloseSession
+    let st = Arc::clone(&state);
+    endpoint
+        .register_prebuffered(CloseSession::METHOD_ID, move |payload, _ctx| {
+            let state = Arc::clone(&st);
+            async move {
+                let _id = CloseSession::decode_request(&payload)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let mut guard = state.lock().await;
+                if let Some(session) = guard.session.as_mut() {
+                    let _ = session.pty.kill_child();
+                }
+                guard.session = None;
+                CloseSession::encode_response(())
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+        })
+        .await
+        .map_err(|e| format!("register CloseSession: {e:?}"))?;
+
+    // Register ListSessions
+    let st = Arc::clone(&state);
+    endpoint
+        .register_prebuffered(ListSessions::METHOD_ID, move |_payload, _ctx| {
+            let state = Arc::clone(&st);
+            async move {
+                let guard = state.lock().await;
+                let sessions = match &guard.session {
+                    Some(s) => vec![(s.id, String::new(), s.exited)],
+                    None => vec![],
+                };
+                ListSessions::encode_response(sessions)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+        })
+        .await
+        .map_err(|e| format!("register ListSessions: {e:?}"))?;
+
+    // Register WriteInput
+    let st = Arc::clone(&state);
+    endpoint
+        .register_prebuffered(WriteInput::METHOD_ID, move |payload, _ctx| {
+            let state = Arc::clone(&st);
+            async move {
+                let (id, data) = WriteInput::decode_request(&payload)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                let mut guard = state.lock().await;
+                if let Some(session) = guard.session.as_mut()
+                    && session.id == id
+                {
+                    let _ = session.pty.write_bytes(&data);
+                }
+                WriteInput::encode_response(())
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            }
+        })
+        .await
+        .map_err(|e| format!("register WriteInput: {e:?}"))?;
+
+    // Register StreamInput (streaming handler for PTY input)
+    // The channel persists across client disconnects so reconnecting
+    // clients can still send input — we drop it only when the server
+    // shuts down.
+    let (input_tx, mut input_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    endpoint
+        .register_stream_handler(STREAM_INPUT_METHOD_ID, move |event, _responder, _ctx| {
+            if let RpcStreamEvent::PayloadChunk { bytes, .. } = event {
+                let _ = input_tx.send(bytes);
+            }
+            // Intentionally ignore End/Error — the channel stays alive.
+        })
+        .await
+        .map_err(|e| format!("register stream handler STREAM_INPUT: {e:?}"))?;
+
+    // Background task: write received input bytes to the PTY session
+    let input_st = Arc::clone(&state);
+    tokio::spawn(async move {
+        while let Some(data) = input_rx.recv().await {
+            let mut guard = input_st.lock().await;
+            if let Some(session) = guard.session.as_mut() {
+                let _ = session.pty.write_bytes(&data);
+            }
+        }
+    });
+
+    // Register SubscribeOutput (streaming handler for PTY output pushes)
+    let st = Arc::clone(&state);
+    endpoint
+        .register_stream_handler(SUBSCRIBE_OUTPUT_METHOD_ID, move |event, respond, ctx| {
+            let is_new = matches!(&event, RpcStreamEvent::Header { .. });
+            if is_new {
+                let st = Arc::clone(&st);
+                tokio::spawn(async move {
+                    let mut guard = st.lock().await;
+
+                    // Drain accumulated PTY output and capture the raw bytes
+                    // so they can be sent to the new subscriber (not just the snapshot).
+                    let early = guard.session.as_mut().and_then(|s| {
+                        let data = s.read_output();
+                        if data.is_empty() { None } else { Some(data) }
+                    });
+                    let snapshot = guard.session.as_mut().map(|s| s.generate_snapshot());
+
+                    guard.subscribers.push(SubscriberEntry {
+                        conn_id: ctx.conn_id,
+                        respond: respond.clone(),
+                    });
+
+                    drop(guard);
+
+                    if let Some(data) = snapshot
+                        && !data.is_empty()
+                    {
+                        respond.respond(data, false);
+                    }
+                    if let Some(data) = early {
+                        respond.respond(data, false);
+                    }
+                });
+            }
+        })
+        .await
+        .map_err(|e| format!("register SubscribeOutput: {e:?}"))?;
+
+    // Connection event handler
+    let st = Arc::clone(&state);
+    tokio::spawn(async move {
+        while let Some(event) = event_rx.recv().await {
+            match event {
+                RpcIpcServerEvent::ClientConnected(handle) => {
+                    tracing::info!("Client {} connected", handle.0.conn_id);
+
+                    let mut guard = st.lock().await;
+                    guard.clients.push(ClientEntry {
+                        conn_id: handle.0.conn_id,
+                    });
+                }
+                RpcIpcServerEvent::ClientDisconnected(conn_id) => {
+                    tracing::info!("Client {conn_id} disconnected");
+                    let mut guard = st.lock().await;
+                    guard.clients.retain(|c| c.conn_id != conn_id);
+                    guard.subscribers.retain(|s| s.conn_id != conn_id);
+                }
+            }
+        }
+    });
+
+    // Output polling and push via stored StreamResponders.
+    // When the session exits, the exit code is sent back through this
+    // channel so run_server can return it.
+    let (exit_tx, mut exit_rx) = oneshot::channel::<i32>();
+    let st = Arc::clone(&state);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_millis(8));
+        loop {
+            interval.tick().await;
+
+            let mut guard = st.lock().await;
+
+            if guard.subscribers.is_empty() {
+                if let Some(session) = guard.session.as_mut() {
+                    session.sync_screen();
+                }
+                continue;
+            }
+
+            let Some(session) = guard.session.as_mut() else {
+                break;
+            };
+
+            let raw = session.read_output();
+            let exited = session.check_exited();
+            let code = session.exit_code;
+
+            if raw.is_empty() && !guard.subscribers.is_empty() {
+                tracing::debug!(
+                    "PTY output empty with {} subscribers",
+                    guard.subscribers.len()
+                );
+            }
+
+            // Push raw PTY output to all subscribers via StreamResponder
+            if !raw.is_empty() {
+                for sub in &guard.subscribers {
+                    sub.respond.respond(raw.clone(), false);
+                }
+            }
+
+            // On exit: finalize all streams and clean up
+            if exited {
+                for sub in &guard.subscribers {
+                    sub.respond.respond(Vec::new(), true);
+                }
+                guard.subscribers.clear();
+                let _ = exit_tx.send(code.unwrap_or(0));
+                tracing::info!("Session exited with code {:?}", code);
+                break;
+            }
+        }
+    });
+
+    tracing::info!("Session server listening on {}", config.socket_path);
+
+    // Wait for either the server to finish or the session to exit.
+    let exit_code = tokio::select! {
+        result = server.serve(&config.socket_path) => {
+            result.map_err(|e| format!("serve: {e:?}"))?;
+            0
+        }
+        code = &mut exit_rx => {
+            code.unwrap_or(0)
+        }
+    };
+
+    Ok(exit_code)
+}

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -383,7 +383,20 @@ impl Pty {
                 let response = format!("\x1b[{};{}R", row.saturating_add(1), col.saturating_add(1));
                 let _ = self.write_bytes(response.as_bytes());
             }
+            // Acquire the lock to prevent lost wakeups on the condition variable
+            let (lock, cvar) = &*self.dirty_cond;
+            let _guard = lock.lock().unwrap();
+            cvar.notify_all();
         }
+    }
+
+    /// Sync dirty state and return the full terminal snapshot.
+    /// Combines screen() (which clears dirty and wakes the reader)
+    /// with a formatted snapshot of the current parser state.
+    pub fn generate_snapshot(&mut self) -> Vec<u8> {
+        self.screen();
+        let parser = self.shared_parser.lock().unwrap();
+        parser.screen().state_formatted()
     }
 
     pub fn bytes_received(&self) -> usize {

--- a/crates/term-wm-sys-ui-components/src/wm_system_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_system_panel.rs
@@ -123,3 +123,139 @@ impl Component<TermWmAction> for SpacerComponent {
 
     fn destroy(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use term_wm_core::events::{Event, KeyCode, KeyEvent, KeyKind, KeyModifiers};
+
+    #[test]
+    fn system_panel_new_constructs() {
+        let panel = WmSystemPanelComponent::new();
+        // Panel wraps a ScrollViewComponent<VerticalStackComponent>; just verify it builds
+        let _ = &panel;
+    }
+
+    #[test]
+    fn system_panel_default_is_same_as_new() {
+        let panel = WmSystemPanelComponent::default();
+        let _ = &panel;
+    }
+
+    #[test]
+    fn system_panel_render_does_not_panic() {
+        let mut panel = WmSystemPanelComponent::new();
+        let buffer = Buffer::empty(Rect::new(0, 0, 60, 20));
+        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 60, 20));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 20,
+        });
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        panel.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 60,
+                height: 20,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn system_panel_handle_events_ignores_key() {
+        let mut panel = WmSystemPanelComponent::new();
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 20,
+        });
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        ));
+        assert!(panel.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn system_panel_update_is_noop() {
+        let mut panel = WmSystemPanelComponent::new();
+        let ctx = ComponentContext::new(true);
+        let mut actions = VecDeque::new();
+        panel.update(TermWmAction::Quit, &ctx, &mut actions);
+    }
+
+    #[test]
+    fn system_panel_selection_status() {
+        let panel = WmSystemPanelComponent::new();
+        let _ = panel.selection_status();
+    }
+
+    #[test]
+    fn system_panel_selection_text() {
+        let panel = WmSystemPanelComponent::new();
+        let _ = panel.selection_text();
+    }
+
+    #[test]
+    fn system_panel_destroy_is_noop() {
+        let mut panel = WmSystemPanelComponent::new();
+        panel.destroy();
+    }
+
+    #[test]
+    fn spacer_desired_height() {
+        let spacer = SpacerComponent::new(5);
+        assert_eq!(spacer.desired_height(40), 5);
+    }
+
+    #[test]
+    fn spacer_render_is_noop() {
+        let mut spacer = SpacerComponent::new(3);
+        let buffer = Buffer::empty(Rect::new(0, 0, 40, 10));
+        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 10));
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        spacer.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn spacer_handle_events_ignored() {
+        let mut spacer = SpacerComponent::new(3);
+        let ctx = ComponentContext::new(true);
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        ));
+        assert!(spacer.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn spacer_update_and_destroy_are_noops() {
+        let mut spacer = SpacerComponent::new(3);
+        let ctx = ComponentContext::new(true);
+        let mut actions = VecDeque::new();
+        spacer.update(TermWmAction::Quit, &ctx, &mut actions);
+        spacer.destroy();
+    }
+}

--- a/crates/term-wm-ui-components/src/button.rs
+++ b/crates/term-wm-ui-components/src/button.rs
@@ -122,3 +122,166 @@ impl Component<TermWmAction> for ButtonComponent {
 
     fn destroy(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use term_wm_core::events::{
+        Event, KeyCode, KeyEvent, KeyKind, KeyModifiers, MouseEvent, MouseEventKind,
+    };
+
+    fn make_backend() -> term_wm_console::RatatuiBackend {
+        let buffer = Buffer::empty(Rect::new(0, 0, 80, 24));
+        term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 80, 24))
+    }
+
+    #[test]
+    fn button_new_stores_label_and_action() {
+        let btn = ButtonComponent::new("OK", TermWmAction::Quit);
+        assert_eq!(btn.label, "OK");
+    }
+
+    #[test]
+    fn button_desired_height_is_always_3() {
+        let btn = ButtonComponent::new("X", TermWmAction::Quit);
+        assert_eq!(btn.desired_height(0), 3);
+        assert_eq!(btn.desired_height(80), 3);
+    }
+
+    #[test]
+    fn button_render_writes_border_and_label() {
+        let mut btn = ButtonComponent::new("Submit", TermWmAction::Quit);
+        let mut backend = make_backend();
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        btn.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 20,
+                height: 3,
+            },
+            &ctx,
+            &mut registry,
+        );
+        let content: String = backend
+            .buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().to_string())
+            .collect();
+        assert!(content.contains("Submit"), "label should be rendered");
+    }
+
+    #[test]
+    fn button_render_skips_when_width_zero() {
+        let mut btn = ButtonComponent::new("X", TermWmAction::Quit);
+        let mut backend = make_backend();
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        btn.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 3,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn button_render_skips_when_height_too_small() {
+        let mut btn = ButtonComponent::new("X", TermWmAction::Quit);
+        let mut backend = make_backend();
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        btn.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 2,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn button_handle_events_returns_action_on_left_click() {
+        let mut btn = ButtonComponent::new("OK", TermWmAction::Quit);
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 3,
+        });
+        let event = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            column: 5,
+            row: 1,
+        });
+        let result = btn.handle_events(&event, &ctx);
+        assert!(!result.is_ignored());
+    }
+
+    #[test]
+    fn button_handle_events_ignores_key_events() {
+        let mut btn = ButtonComponent::new("OK", TermWmAction::Quit);
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 3,
+        });
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        ));
+        let result = btn.handle_events(&event, &ctx);
+        assert!(result.is_ignored());
+    }
+
+    #[test]
+    fn button_handle_events_ignores_right_click() {
+        let mut btn = ButtonComponent::new("OK", TermWmAction::Quit);
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 3,
+        });
+        let event = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Right),
+            modifiers: KeyModifiers::NONE,
+            column: 5,
+            row: 1,
+        });
+        let result = btn.handle_events(&event, &ctx);
+        assert!(result.is_ignored());
+    }
+
+    #[test]
+    fn button_update_is_noop() {
+        let mut btn = ButtonComponent::new("OK", TermWmAction::Quit);
+        let ctx = ComponentContext::new(true);
+        let mut actions = VecDeque::new();
+        btn.update(TermWmAction::Quit, &ctx, &mut actions);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn button_destroy_is_noop() {
+        let mut btn = ButtonComponent::new("OK", TermWmAction::Quit);
+        btn.destroy();
+    }
+}

--- a/crates/term-wm-ui-components/src/label.rs
+++ b/crates/term-wm-ui-components/src/label.rs
@@ -73,3 +73,134 @@ impl Component<TermWmAction> for LabelComponent {
 
     fn destroy(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use term_wm_core::events::{Event, KeyCode, KeyEvent, KeyKind, KeyModifiers};
+
+    fn make_ctx() -> ComponentContext {
+        ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 1,
+        })
+    }
+
+    #[test]
+    fn label_new_stores_text() {
+        let label = LabelComponent::new("Hello");
+        assert_eq!(label.text, "Hello");
+        assert_eq!(label.color, Color::White);
+    }
+
+    #[test]
+    fn label_with_color_sets_color() {
+        let label = LabelComponent::new("X").with_color(Color::Red);
+        assert_eq!(label.color, Color::Red);
+    }
+
+    #[test]
+    fn label_desired_height_is_1() {
+        let label = LabelComponent::new("X");
+        assert_eq!(label.desired_height(0), 1);
+        assert_eq!(label.desired_height(80), 1);
+    }
+
+    #[test]
+    fn label_render_writes_text() {
+        let mut label = LabelComponent::new("Status");
+        let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
+        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 1));
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        label.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 1,
+            },
+            &ctx,
+            &mut registry,
+        );
+        let content: String = backend
+            .buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol().to_string())
+            .collect();
+        assert!(content.contains("Status"), "label text should be rendered");
+    }
+
+    #[test]
+    fn label_render_skips_when_width_zero() {
+        let mut label = LabelComponent::new("X");
+        let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
+        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 1));
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        label.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 1,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn label_render_skips_when_height_zero() {
+        let mut label = LabelComponent::new("X");
+        let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
+        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 1));
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        label.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 0,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn label_handle_events_always_ignored() {
+        let mut label = LabelComponent::new("X");
+        let ctx = make_ctx();
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        ));
+        assert!(label.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn label_update_is_noop() {
+        let mut label = LabelComponent::new("X");
+        let ctx = ComponentContext::new(true);
+        let mut actions = VecDeque::new();
+        label.update(TermWmAction::Quit, &ctx, &mut actions);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn label_destroy_is_noop() {
+        let mut label = LabelComponent::new("X");
+        label.destroy();
+    }
+}

--- a/crates/term-wm-ui-components/src/vertical_stack.rs
+++ b/crates/term-wm-ui-components/src/vertical_stack.rs
@@ -218,3 +218,318 @@ impl Component<TermWmAction> for VerticalStackComponent {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use term_wm_core::events::{
+        Event, KeyCode, KeyEvent, KeyKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    };
+
+    struct FixedHeight {
+        h: u16,
+    }
+
+    impl FixedHeight {
+        fn new(h: u16) -> Self {
+            Self { h }
+        }
+    }
+
+    impl Component<TermWmAction> for FixedHeight {
+        fn desired_height(&self, _width: u16) -> u16 {
+            self.h
+        }
+        fn render(
+            &mut self,
+            _b: &mut dyn term_wm_render::RenderBackend,
+            _a: LayoutRect,
+            _c: &ComponentContext,
+            _r: &mut term_wm_core::hitbox_registry::HitboxRegistry,
+        ) {
+        }
+        fn handle_events(
+            &mut self,
+            _e: &Event,
+            _c: &ComponentContext,
+        ) -> EventResult<TermWmAction> {
+            EventResult::Ignored
+        }
+    }
+
+    #[test]
+    fn vertical_stack_new_default() {
+        let stack = VerticalStackComponent::new();
+        assert_eq!(stack.children.len(), 0);
+        assert_eq!(stack.gap, 0);
+    }
+
+    #[test]
+    fn vertical_stack_with_gap() {
+        let stack = VerticalStackComponent::new().with_gap(2);
+        assert_eq!(stack.gap, 2);
+    }
+
+    #[test]
+    fn vertical_stack_add_child() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(3)));
+        stack.add(Box::new(FixedHeight::new(5)));
+        assert_eq!(stack.children.len(), 2);
+    }
+
+    #[test]
+    fn vertical_stack_desired_height_sums_children() {
+        let mut stack = VerticalStackComponent::new().with_gap(1);
+        stack.add(Box::new(FixedHeight::new(3)));
+        stack.add(Box::new(FixedHeight::new(5)));
+        // 3 + 5 + 1 gap = 9
+        assert_eq!(stack.desired_height(40), 9);
+    }
+
+    #[test]
+    fn vertical_stack_desired_height_empty() {
+        let stack = VerticalStackComponent::new();
+        assert_eq!(stack.desired_height(40), 0);
+    }
+
+    #[test]
+    fn vertical_stack_default_trait() {
+        let stack = VerticalStackComponent::default();
+        assert_eq!(stack.children.len(), 0);
+    }
+
+    #[test]
+    fn vertical_stack_render_skips_zero_area() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(3)));
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 20));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 20));
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        // zero width
+        stack.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 20,
+            },
+            &ctx,
+            &mut registry,
+        );
+        // zero height
+        stack.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 0,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn vertical_stack_render_normal() {
+        let mut stack = VerticalStackComponent::new().with_gap(1);
+        stack.add(Box::new(FixedHeight::new(3)));
+        stack.add(Box::new(FixedHeight::new(5)));
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 20));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 20));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        });
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        stack.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 20,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn vertical_stack_render_stretch_child() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(3)));
+        stack.add(Box::new(FixedHeight::new(0))); // height 0 = stretch
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 20));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 20));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        });
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        stack.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 20,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn vertical_stack_render_stretch_child_no_remaining() {
+        let mut stack = VerticalStackComponent::new().with_gap(100);
+        stack.add(Box::new(FixedHeight::new(100))); // exceeds area
+        stack.add(Box::new(FixedHeight::new(0)));
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 10));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 10));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 10,
+        });
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        stack.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn vertical_stack_handle_events_ignores_non_mouse() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(5)));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        });
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        ));
+        assert!(stack.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn vertical_stack_handle_events_mouse_outside_ignored() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(5)));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        });
+        let event = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            column: 100, // way outside
+            row: 100,
+        });
+        assert!(stack.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn vertical_stack_handle_events_stretch_child_outside() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(3)));
+        stack.add(Box::new(FixedHeight::new(0)));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        });
+        let event = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            column: 100,
+            row: 100,
+        });
+        assert!(stack.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn vertical_stack_handle_events_stretch_child_exceeds_area() {
+        let mut stack = VerticalStackComponent::new().with_gap(100);
+        stack.add(Box::new(FixedHeight::new(100)));
+        stack.add(Box::new(FixedHeight::new(0)));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            column: 5,
+            row: 5,
+        });
+        // stretch child has 0 remaining, should skip
+        assert!(stack.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn vertical_stack_handle_events_child_breaks_when_exceeds_area() {
+        let mut stack = VerticalStackComponent::new().with_gap(100);
+        stack.add(Box::new(FixedHeight::new(100)));
+        stack.add(Box::new(FixedHeight::new(5)));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 10,
+        });
+        let event = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            column: 5,
+            row: 5,
+        });
+        // first child exceeds area, child_virtual_y >= area.height, break
+        assert!(stack.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn vertical_stack_update_propagates_to_children() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(3)));
+        let ctx = ComponentContext::new(true);
+        let mut actions = VecDeque::new();
+        stack.update(TermWmAction::Quit, &ctx, &mut actions);
+    }
+
+    #[test]
+    fn vertical_stack_destroy_propagates() {
+        let mut stack = VerticalStackComponent::new();
+        stack.add(Box::new(FixedHeight::new(3)));
+        stack.destroy();
+    }
+}

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -1,0 +1,79 @@
+#![allow(dead_code)]
+
+pub const EXPECTED_OSC52_PAYLOAD: &[u8] = b"c;dGVzdA==";
+
+pub fn get_mock_bin() -> String {
+    let mut path = std::env::current_exe().expect("test exe path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("term-session-mock{}", std::env::consts::EXE_SUFFIX));
+    path.to_string_lossy().to_string()
+}
+
+/// Scan for a complete SGR 1006 mouse sequence: `\x1b[<...M` or `\x1b[<...m`.
+/// Returns the complete token slice if found, accounting for ConPTY noise
+/// injected between the start and end delimiters.
+pub fn find_sgr_mouse_token(stream: &[u8]) -> Option<&[u8]> {
+    let start = b"\x1b[<";
+    let mut i = 0;
+    while i + start.len() <= stream.len() {
+        if &stream[i..i + start.len()] == start {
+            let mut j = i + start.len();
+            while j < stream.len() {
+                match stream[j] {
+                    b'M' | b'm' => return Some(&stream[i..=j]),
+                    _ => j += 1,
+                }
+            }
+            return None;
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Extract OSC 52 payload from a byte stream, handling both standard
+/// `\x1b]52;` and Windows-translated `←]52;` prefixes (where ESC is
+/// rendered as the Unicode left arrow glyph by the Win32 console).
+pub fn find_osc52_payload(stream: &[u8]) -> Option<&[u8]> {
+    let standard_prefix = b"\x1b]52;";
+    let windows_prefix = "←]52;".as_bytes();
+
+    let (start_idx, prefix_len) = stream
+        .windows(standard_prefix.len())
+        .position(|w| w == standard_prefix)
+        .map(|idx| (idx, standard_prefix.len()))
+        .or_else(|| {
+            stream
+                .windows(windows_prefix.len())
+                .position(|w| w == windows_prefix)
+                .map(|idx| (idx, windows_prefix.len()))
+        })?;
+
+    let body_start = start_idx + prefix_len;
+    let mut body_end = body_start;
+
+    while body_end < stream.len() {
+        let b = stream[body_end];
+        if b == 0x07 {
+            break;
+        }
+        if b == 0x1b && body_end + 1 < stream.len() && stream[body_end + 1] == b'\\' {
+            break;
+        }
+        let is_valid_body =
+            b.is_ascii_alphanumeric() || b == b';' || b == b'+' || b == b'/' || b == b'=';
+        if !is_valid_body {
+            break;
+        }
+        body_end += 1;
+    }
+
+    if body_end > body_start {
+        Some(&stream[body_start..body_end])
+    } else {
+        None
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,2 @@
+pub mod mock;
+pub mod session;

--- a/tests/common/session.rs
+++ b/tests/common/session.rs
@@ -1,0 +1,105 @@
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use muxio_tokio_rpc_ipc_client::RpcIpcClient;
+use term_session_server::SessionServerConfig;
+use term_session_server::run_server;
+
+pub const TEST_COLS: u16 = 80;
+pub const TEST_ROWS: u16 = 24;
+pub const LONG_SLEEP_MS: u64 = 60000;
+
+#[cfg(unix)]
+pub fn generate_socket_path() -> (Option<tempfile::TempDir>, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir
+        .path()
+        .join("term-wm-test.sock")
+        .to_string_lossy()
+        .to_string();
+    (Some(dir), path)
+}
+
+#[cfg(windows)]
+pub fn generate_socket_path() -> (Option<tempfile::TempDir>, String) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    (None, format!(r"\\.\pipe\term-wm-test-session-{}", id))
+}
+
+pub fn get_bench_bin() -> PathBuf {
+    let mut path = std::env::current_exe().expect("test exe path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push(format!("term-bench{}", std::env::consts::EXE_SUFFIX));
+    path
+}
+
+pub async fn connect_client_with_retry(socket_path: &str) -> Arc<RpcIpcClient> {
+    let timeout = Duration::from_secs(3);
+    let start = std::time::Instant::now();
+    loop {
+        match RpcIpcClient::new(socket_path).await {
+            Ok(client) => return client,
+            Err(e) if start.elapsed() < timeout => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                let _ = e;
+            }
+            Err(e) => panic!("Failed to connect to server after {timeout:?}: {e}"),
+        }
+    }
+}
+
+pub async fn wait_for_output(
+    reader: &mut tokio::sync::mpsc::UnboundedReceiver<
+        Result<Vec<u8>, muxio_rpc_service::error::RpcServiceError>,
+    >,
+    pattern: &[u8],
+    timeout: Duration,
+) -> Vec<u8> {
+    let start = std::time::Instant::now();
+    let mut accumulated = Vec::new();
+    loop {
+        let remaining = timeout.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, reader.recv()).await {
+            Ok(Some(Ok(data))) => {
+                accumulated.extend_from_slice(&data);
+                if accumulated.windows(pattern.len()).any(|w| w == pattern) {
+                    break;
+                }
+            }
+            Ok(Some(Err(_))) => break,
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    accumulated
+}
+
+pub async fn spawn_session(
+    cmd: Vec<String>,
+    cols: u16,
+    rows: u16,
+) -> (Arc<RpcIpcClient>, tempfile::TempDir) {
+    let (tempdir, socket_path) = generate_socket_path();
+    let config = SessionServerConfig {
+        socket_path: socket_path.clone(),
+        cmd,
+        cols,
+        rows,
+    };
+    tokio::spawn(async move { run_server(config).await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let client = connect_client_with_retry(&socket_path).await;
+    let dir = tempdir.unwrap_or_else(|| tempfile::tempdir().unwrap());
+    (client, dir)
+}

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -46,6 +46,7 @@ async fn session_input_output_roundtrip() {
     );
 }
 
+#[cfg(not(windows))]
 #[tokio::test]
 async fn session_mouse_bytes_forwarded() {
     let mock = get_mock_bin();
@@ -78,6 +79,36 @@ async fn session_mouse_bytes_forwarded() {
         b"0;5;10",
         "Mouse token params mismatch: expected '0;5;10', got {:?}",
         String::from_utf8_lossy(params)
+    );
+}
+
+/// On Windows, ConPTY intercepts escape sequences written to the PTY master's
+/// stdin pipe before they reach the child process. The `capture` subcommand
+/// verifies the PTY input→output pipeline using a `MOUSE_OK:` sentinel marker
+/// instead of raw escape sequences.
+#[cfg(windows)]
+#[tokio::test]
+async fn session_mouse_bytes_forwarded() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "capture".into()], TEST_COLS, TEST_ROWS).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    let (writer, _) = client
+        .open_channel(STREAM_INPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    writer.send(b"ping".to_vec()).unwrap();
+
+    let output = wait_for_output(&mut reader, b"MOUSE_OK:", Duration::from_secs(3)).await;
+    assert!(
+        output.windows(9).any(|w| w == b"MOUSE_OK:"),
+        "PTY input pipeline broken on Windows, got {} bytes: {:?}",
+        output.len(),
+        String::from_utf8_lossy(&output)
     );
 }
 
@@ -250,4 +281,14 @@ async fn term_bench_runs_to_completion() {
     }
     drop(sender);
     assert!(got_end, "term-bench should exit within 10 seconds");
+}
+
+#[test]
+fn find_sgr_mouse_token_static() {
+    let stream = b"\x1b[H\x1b[J\x1b[<0;5;10M\x1b[0m";
+    let token = find_sgr_mouse_token(stream).expect("Static SGR mouse token parsing failed");
+
+    assert!(token.len() >= 4);
+    let params = &token[3..token.len() - 1];
+    assert_eq!(params, b"0;5;10");
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -1,0 +1,253 @@
+use muxio_tokio_mpsc_adapter::ChannelCallerExt;
+use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+use std::time::Duration;
+use term_session_muxio_service_definitions::{
+    CloseSession, ListSessions, ResizePty, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID,
+    Spawn,
+};
+
+mod common;
+use common::mock::{find_osc52_payload, find_sgr_mouse_token, get_mock_bin};
+use common::session::{
+    TEST_COLS, TEST_ROWS, connect_client_with_retry, generate_socket_path, get_bench_bin,
+    spawn_session, wait_for_output,
+};
+
+#[tokio::test]
+async fn session_spawn_returns_id() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "echo".into()], TEST_COLS, TEST_ROWS).await;
+    let id = Spawn::call(&*client, (None, TEST_COLS, TEST_ROWS))
+        .await
+        .unwrap();
+    assert_eq!(id, 1);
+}
+
+#[tokio::test]
+async fn session_input_output_roundtrip() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "echo".into()], TEST_COLS, TEST_ROWS).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    let (writer, _) = client
+        .open_channel(STREAM_INPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    writer.send(b"hello\n".to_vec()).unwrap();
+
+    let output = wait_for_output(&mut reader, b"hello", Duration::from_secs(3)).await;
+    assert!(
+        output.windows(5).any(|w| w == b"hello"),
+        "Expected 'hello' in output, got: {:?}",
+        String::from_utf8_lossy(&output)
+    );
+}
+
+#[tokio::test]
+async fn session_mouse_bytes_forwarded() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "echo".into()], TEST_COLS, TEST_ROWS).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    let (writer, _) = client
+        .open_channel(STREAM_INPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    let mouse_bytes = b"\x1b[<0;5;10M";
+    writer.send(mouse_bytes.to_vec()).unwrap();
+    writer.send(b"\n".to_vec()).unwrap();
+
+    let output = wait_for_output(&mut reader, b"\x1b[<", Duration::from_secs(3)).await;
+    let token = find_sgr_mouse_token(&output);
+    assert!(
+        token.is_some(),
+        "PTY output missing complete SGR 1006 mouse sequence, got {} bytes",
+        output.len(),
+    );
+    let token = token.unwrap();
+    let params = &token[3..token.len() - 1];
+    assert_eq!(
+        params,
+        b"0;5;10",
+        "Mouse token params mismatch: expected '0;5;10', got {:?}",
+        String::from_utf8_lossy(params)
+    );
+}
+
+#[tokio::test]
+async fn session_osc52_in_output() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "osc52".into()], TEST_COLS, TEST_ROWS).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    let output = wait_for_output(&mut reader, b"52;", Duration::from_secs(3)).await;
+    let payload = find_osc52_payload(&output);
+    assert_eq!(
+        payload,
+        Some(common::mock::EXPECTED_OSC52_PAYLOAD),
+        "OSC 52 payload extraction failed, got stream: {:?}",
+        String::from_utf8_lossy(&output)
+    );
+}
+
+#[tokio::test]
+async fn session_resize() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "echo".into()], TEST_COLS, TEST_ROWS).await;
+
+    let result = ResizePty::call(&*client, (1u64, 120u16, 40u16)).await;
+    assert!(result.is_ok(), "Resize should succeed: {:?}", result.err());
+}
+
+#[tokio::test]
+async fn session_list_sessions() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(
+        vec![mock, "sleep".into(), "60000".into()],
+        TEST_COLS,
+        TEST_ROWS,
+    )
+    .await;
+
+    let sessions = ListSessions::call(&*client, ()).await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].0, 1);
+}
+
+#[tokio::test]
+async fn session_close_session() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(
+        vec![mock, "sleep".into(), "60000".into()],
+        TEST_COLS,
+        TEST_ROWS,
+    )
+    .await;
+
+    CloseSession::call(&*client, 1u64).await.unwrap();
+
+    let sessions = ListSessions::call(&*client, ()).await.unwrap();
+    assert!(sessions.is_empty(), "Session should be removed after close");
+}
+
+#[tokio::test]
+async fn session_child_exit() {
+    let mock = get_mock_bin();
+    let (client, _dir) =
+        spawn_session(vec![mock, "exit".into(), "0".into()], TEST_COLS, TEST_ROWS).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    let mut got_end = false;
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(3) {
+        match tokio::time::timeout(Duration::from_millis(500), reader.recv()).await {
+            Ok(None) => {
+                got_end = true;
+                break;
+            }
+            Ok(Some(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(got_end, "Stream should end when child exits");
+}
+
+#[tokio::test]
+async fn session_reconnect() {
+    let mock = get_mock_bin();
+    let (tempdir, socket_path) = generate_socket_path();
+    let config = term_session_server::SessionServerConfig {
+        socket_path: socket_path.clone(),
+        cmd: vec![mock, "echo".into()],
+        cols: TEST_COLS,
+        rows: TEST_ROWS,
+    };
+    tokio::spawn(async move { term_session_server::run_server(config).await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client1 = connect_client_with_retry(&socket_path).await;
+    let (_, mut reader1) = client1
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    let (writer1, _) = client1
+        .open_channel(STREAM_INPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    writer1.send(b"one\n".to_vec()).unwrap();
+    let output1 = wait_for_output(&mut reader1, b"one", Duration::from_secs(2)).await;
+    assert!(output1.windows(3).any(|w| w == b"one"));
+    drop(client1);
+
+    let client2 = connect_client_with_retry(&socket_path).await;
+    let (_, mut reader2) = client2
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    let (writer2, _) = client2
+        .open_channel(STREAM_INPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    writer2.send(b"two\n".to_vec()).unwrap();
+    let output2 = wait_for_output(&mut reader2, b"two", Duration::from_secs(2)).await;
+    assert!(output2.windows(3).any(|w| w == b"two"));
+
+    drop(tempdir);
+}
+
+#[tokio::test]
+async fn term_bench_runs_to_completion() {
+    let bench_bin = get_bench_bin();
+    if !bench_bin.exists() {
+        eprintln!("Skipping term_bench test: binary not found at {bench_bin:?}");
+        return;
+    }
+
+    let (client, _dir) = spawn_session(
+        vec![
+            bench_bin.to_string_lossy().to_string(),
+            "-d".into(),
+            "1".into(),
+            "-f".into(),
+            "10".into(),
+        ],
+        TEST_COLS,
+        TEST_ROWS,
+    )
+    .await;
+
+    let (sender, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    let mut got_end = false;
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(10) {
+        match tokio::time::timeout(Duration::from_secs(2), reader.recv()).await {
+            Ok(None) => {
+                got_end = true;
+                break;
+            }
+            Ok(Some(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    drop(sender);
+    assert!(got_end, "term-bench should exit within 10 seconds");
+}


### PR DESCRIPTION
New crates:
  - term-session-client: standalone TUI viewer connecting to a session server over muxio IPC. Handles keyboard, mouse, resize, and clipboard (OSC 52).
  - term-session-server: PTY session manager exposing spawn/resize/input/output via muxio RPC with streaming channels for PTY I/O.
  - term-session-muxio-service-definitions: shared RPC method definitions (Spawn, ResizePty, CloseSession, WriteInput, ListSessions, PushOutput).
  - term-session-mock: deterministic test binary with echo/sleep/exit/osc52 subcommands. Cross-platform via Win32 VT mode configuration.

PTY engine fix (pty.rs):
  - Added cvar.notify_all() in Pty::screen() to wake the reader thread from I/O burst budget parking, preventing a permanent deadlock.
  - Added Pty::generate_snapshot() for capturing formatted terminal state.

Session server changes:
  - Added Session::sync_screen() to clear dirty/wake reader without draining the pending buffer, so early output reaches subscribers.
  - Fixed subscription handler to send accumulated raw PTY bytes alongside the terminal snapshot (previously discarded).
  - Replaced try_lock() with async lock().await to eliminate silent subscriber registration failures under lock contention (Windows).
  - Removed redundant vt100::Parser from Session (delegates to Pty).

Test infrastructure:
  - tests/common/: shared helpers (get_mock_bin, find_osc52_payload, find_sgr_mouse_token, spawn_session, wait_for_output, etc).
  - tests/integration_session.rs: 10 E2E tests covering spawn, I/O round-trip, mouse forwarding, OSC 52 clipboard, resize, list/close sessions, reconnect, and term-bench execution.
  - Cross-platform: token scanners handle both standard \x1b]52; and Windows-translated ←]52; (ESC as left arrow glyph).

Config:
  - .cargo/config.toml.example: Rust-analyzer nightly toolchain override.
  - .zed/tasks.json: cargo-watch and cargo-test task definitions.