### PR TITLE
feat: bracketed paste, right-click paste, and OSC 52 clipboard forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,9 +2932,11 @@ name = "term-wm-console"
 version = "0.8.20-alpha"
 dependencies = [
  "crossterm",
+ "libc",
  "ratatui",
  "term-wm-core",
  "term-wm-layout-engine",
+ "term-wm-pty-engine",
  "term-wm-render",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ sys-ui = ["dep:term-wm-sys-ui-components"]
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 crossbeam-channel = { workspace = true }
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = ["bracketed-paste"] }
 hostname = { workspace = true }
 libc = { workspace = true }
 line-ending = { workspace = true }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -23,7 +23,7 @@ use term_session_muxio_service_definitions::{
 };
 use term_wm_core::events::{Event, KeyKind};
 use term_wm_pty_engine::Pane;
-use term_wm_pty_engine::clipboard::{Clipboard, extract_osc52_text};
+use term_wm_pty_engine::clipboard::{Clipboard, Osc52Extractor};
 use term_wm_pty_engine::input_encoding::{key_to_bytes, mouse_event_to_bytes};
 use term_wm_pty_engine::signal::install_sigint_handler;
 use tokio::sync::mpsc;
@@ -152,6 +152,9 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
     // Channel for raw PTY output bytes from the subscription stream
     let (push_tx, push_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
+    // Side-channel for intercepted OSC 52 clipboard text
+    let (clip_tx, mut clip_rx) = mpsc::unbounded_channel::<String>();
+
     // Get terminal size
     let (term_cols, term_rows) = crossterm::terminal::size()?;
 
@@ -174,10 +177,27 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
         // Forward response chunks to push_tx.  When the stream ends
         // (session exits), push_tx is dropped, and `drain_pushes`
         // detects the disconnect.
+        // Intercept OSC 52 clipboard sequences from the raw byte stream
+        // before the VT100 parser can consume them.
         rt.spawn(async move {
+            let mut osc52 = Osc52Extractor::new();
+            let mut prev_tail: [u8; 8] = [0; 8];
+
             while let Some(chunk) = reader.recv().await {
                 match chunk {
                     Ok(data) => {
+                        if let Some(text) = osc52.push(&data, &prev_tail) {
+                            let _ = clip_tx.send(text);
+                        }
+
+                        let n = data.len();
+                        if n >= 8 {
+                            prev_tail.copy_from_slice(&data[n - 8..n]);
+                        } else if n > 0 {
+                            prev_tail.rotate_left(n);
+                            prev_tail[8 - n..].copy_from_slice(&data[..n]);
+                        }
+
                         let _ = push_tx.send(data);
                     }
                     Err(_) => break,
@@ -258,8 +278,8 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
         };
         let has_new_data = prev_content.as_deref() != Some(&current_content);
 
-        // Process OSC 52 clipboard data
-        if has_new_data && let Some(text) = extract_osc52_text(&current_content) {
+        // Drain any clipboard texts intercepted by the reader task
+        while let Ok(text) = clip_rx.try_recv() {
             let _ = clipboard.set(&text);
         }
 

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -2,7 +2,7 @@ mod remote_pane;
 
 pub use remote_pane::RemotePane;
 
-use std::io::{self, Write, stdout};
+use std::io::{self, IsTerminal, Write, stdout};
 #[cfg(unix)]
 use std::os::unix::io::FromRawFd;
 use std::sync::Arc;
@@ -11,6 +11,7 @@ use std::time::Duration;
 use crossterm::QueueableCommand;
 use crossterm::cursor::{Hide, Show};
 use crossterm::event as crossterm_event;
+use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
@@ -85,15 +86,46 @@ const INITIAL_WAIT_ITERS: usize = 60;
 #[cfg(not(target_os = "windows"))]
 const INITIAL_WAIT_ITERS: usize = 20;
 
-struct TerminalGuard;
+/// Initialize terminal for TUI mode: write startup escape sequences
+/// (alternate screen, hide cursor, bracketed paste, mouse capture) to
+/// the given writer, enable raw mode on stdin, and return a guard that
+/// restores the terminal on drop.
+///
+/// The writer parameter allows tests to capture the ANSI sequences
+/// without writing to a real terminal.
+pub fn init_terminal<W: Write>(mut writer: W) -> io::Result<TerminalGuard<W>> {
+    if std::io::stdin().is_terminal() {
+        enable_raw_mode()?;
+    }
+    writer.queue(EnterAlternateScreen)?;
+    writer.queue(Hide)?;
+    writer.queue(EnableBracketedPaste)?;
+    writer.queue(crossterm::event::EnableMouseCapture)?;
+    writer.flush()?;
+    Ok(TerminalGuard {
+        writer: Some(writer),
+    })
+}
 
-impl Drop for TerminalGuard {
+/// Guard that restores the terminal (leave alternate screen, show cursor,
+/// disable bracketed paste) when dropped.  Generic over `W` so tests can
+/// inject a `Vec<u8>` writer and verify the teardown sequences.
+pub struct TerminalGuard<W: Write = std::io::Stdout> {
+    writer: Option<W>,
+}
+
+impl<W: Write> Drop for TerminalGuard<W> {
     fn drop(&mut self) {
-        let _ = stdout().queue(crossterm::event::DisableMouseCapture);
-        let _ = stdout().queue(Show);
-        let _ = stdout().queue(LeaveAlternateScreen);
-        let _ = disable_raw_mode();
-        let _ = stdout().flush();
+        if let Some(ref mut writer) = self.writer {
+            let _ = writer.queue(crossterm::event::DisableMouseCapture);
+            let _ = writer.queue(DisableBracketedPaste);
+            let _ = writer.queue(Show);
+            let _ = writer.queue(LeaveAlternateScreen);
+            if std::io::stdin().is_terminal() {
+                let _ = disable_raw_mode();
+            }
+            let _ = writer.flush();
+        }
     }
 }
 
@@ -192,13 +224,10 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
         std::thread::sleep(Duration::from_millis(50));
     }
 
-    enable_raw_mode()?;
+    // Pass one stdout handle to init_terminal for the startup sequences
+    // and TerminalGuard teardown; keep a second handle for rendering.
+    let _guard = init_terminal(stdout())?;
     let mut out = stdout();
-    out.queue(EnterAlternateScreen)?;
-    out.queue(Hide)?;
-    out.queue(crossterm::event::EnableMouseCapture)?;
-    out.flush()?;
-    let _guard = TerminalGuard;
 
     let mut clipboard = Clipboard::new();
     let sigint = install_sigint_handler()?;
@@ -489,6 +518,13 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                     let _ = pane.resize(size);
                     true
                 }
+                Event::Paste(text) => {
+                    let mut wrapped = b"\x1b[200~".to_vec();
+                    wrapped.extend_from_slice(text.as_bytes());
+                    wrapped.extend_from_slice(b"\x1b[201~");
+                    let _ = pane.write_bytes(&wrapped);
+                    true
+                }
                 _ => false,
             }
         } else {
@@ -531,5 +567,97 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                 std::thread::sleep(Duration::from_millis(8) - elapsed);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Helper writer that captures bytes into a shared `Vec<u8>`.
+    struct TestWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl TestWriter {
+        fn new() -> (Self, Arc<Mutex<Vec<u8>>>) {
+            let buf = Arc::new(Mutex::new(Vec::new()));
+            (Self { buf: buf.clone() }, buf)
+        }
+    }
+
+    impl Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buf.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Calls the real `init_terminal()` with a test writer and verifies
+    /// the bracketed paste enable sequence `\x1b[?2004h` is written.
+    /// Under `cargo test` stdin is a pipe, so `is_terminal()` returns false
+    /// and the raw-mode OS call is skipped — only the ANSI output matters.
+    #[test]
+    fn init_terminal_writes_bracketed_paste_enable() {
+        let (writer, buf) = TestWriter::new();
+        let _guard = init_terminal(writer).expect("init_terminal");
+        let bytes = buf.lock().unwrap();
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|w| w == b"\x1b[?2004h"),
+            "init_terminal must write bracketed paste enable \\x1b[?2004h. \
+             If this fails, EnableBracketedPaste may have been removed \
+             from the startup sequence. Captured bytes: {:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    /// Constructs a TerminalGuard with a test writer and verifies that
+    /// dropping it writes the bracketed paste disable sequence `\x1b[?2004l`.
+    #[test]
+    fn terminal_guard_teardown_writes_bracketed_paste_disable() {
+        let (writer, buf) = TestWriter::new();
+        {
+            let _guard = TerminalGuard {
+                writer: Some(writer),
+            };
+        }
+        let bytes = buf.lock().unwrap();
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004l".len())
+                .any(|w| w == b"\x1b[?2004l"),
+            "TerminalGuard drop must write bracketed paste disable \\x1b[?2004l. \
+             If this fails, DisableBracketedPaste may have been removed \
+             from TerminalGuard::drop. Captured bytes: {:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    /// Full lifecycle: init_terminal followed by TerminalGuard teardown
+    /// writes both the enable and disable sequences.
+    #[test]
+    fn init_and_teardown_roundtrip_contains_both_sequences() {
+        let (writer, buf) = TestWriter::new();
+        let guard = init_terminal(writer).expect("init_terminal");
+        drop(guard);
+        let bytes = buf.lock().unwrap();
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|w| w == b"\x1b[?2004h"),
+            "init/teardown roundtrip must contain enable \\x1b[?2004h"
+        );
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004l".len())
+                .any(|w| w == b"\x1b[?2004l"),
+            "init/teardown roundtrip must contain disable \\x1b[?2004l"
+        );
     }
 }

--- a/crates/term-wm-console/Cargo.toml
+++ b/crates/term-wm-console/Cargo.toml
@@ -9,9 +9,13 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = ["bracketed-paste"] }
 ratatui = { workspace = true }
 term-wm-core = { workspace = true }
 term-wm-layout-engine = { workspace = true }
 term-wm-render = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+libc = { workspace = true }
+term-wm-pty-engine = { workspace = true }

--- a/crates/term-wm-console/src/console_render_target.rs
+++ b/crates/term-wm-console/src/console_render_target.rs
@@ -5,8 +5,12 @@ use crossterm::terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternate
 use crossterm::{execute, terminal};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-
 use ratatui::buffer::Buffer;
+
+#[cfg(test)]
+use ratatui::layout::Rect;
+#[cfg(test)]
+use ratatui::{TerminalOptions, Viewport};
 
 use crate::RatatuiBackend;
 use crate::RenderBackend;
@@ -83,9 +87,24 @@ impl ConsoleRenderTarget<CaptureWriter> {
     ///
     /// Disables raw mode management so tests can verify the ANSI byte
     /// stream without mutating the test runner's OS terminal state.
+    ///
+    /// Uses a fixed viewport (80×24) instead of querying the real terminal
+    /// size so the constructor works in CI where no terminal is attached.
     pub fn new_capturing() -> (Self, CaptureWriter) {
         let writer = CaptureWriter::new();
-        let mut rt = Self::with_writer(writer.clone()).expect("new_capturing");
+        let backend = CrosstermBackend::new(writer.clone());
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, 80, 24)),
+            },
+        )
+        .expect("new_capturing");
+        let mut rt = Self {
+            terminal,
+            entered: false,
+            manage_raw_mode: true,
+        };
         rt.manage_raw_mode = false;
         (rt, writer)
     }

--- a/crates/term-wm-console/src/console_render_target.rs
+++ b/crates/term-wm-console/src/console_render_target.rs
@@ -1,6 +1,6 @@
-use std::io::{self, Stdout};
+use std::io::{self, Stdout, Write};
 
-use crossterm::event::DisableMouseCapture;
+use crossterm::event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste};
 use crossterm::terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::{execute, terminal};
 use ratatui::Terminal;
@@ -12,30 +12,117 @@ use crate::RatatuiBackend;
 use crate::RenderBackend;
 use term_wm_core::io::RenderTarget;
 
-pub struct ConsoleRenderTarget {
-    terminal: Terminal<CrosstermBackend<Stdout>>,
-    entered: bool,
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
+
+/// Terminal render target backed by a crossterm/ratatui terminal.
+///
+/// Generic over the writer `W` (defaults to `Stdout`) so tests can inject
+/// a `CaptureWriter` and verify the ANSI sequences produced by `enter()`
+/// and `exit()`.
+///
+/// # Raw mode
+///
+/// [`manage_raw_mode`](Self::manage_raw_mode) controls whether `enter()` /
+/// `exit()` call `crossterm::terminal::enable_raw_mode` / `disable_raw_mode`.
+/// Defaults to `true` for production.  Set to `false` in `new_capturing()` so
+/// tests can verify the ANSI byte stream without the test runner's OS state
+/// being mutated.
+pub struct ConsoleRenderTarget<W: Write = Stdout> {
+    terminal: Terminal<CrosstermBackend<W>>,
+    pub(crate) entered: bool,
+    pub manage_raw_mode: bool,
 }
 
-impl ConsoleRenderTarget {
+impl ConsoleRenderTarget<Stdout> {
+    /// Create a new render target writing to real stdout.
     pub fn new() -> io::Result<Self> {
-        let stdout = io::stdout();
-        let backend = CrosstermBackend::new(stdout);
+        Self::with_writer(io::stdout())
+    }
+}
+
+/// A writer that captures all written bytes into a shared `Vec<u8>` via
+/// `Arc<Mutex<...>>` so the buffer can be read after the writer is moved
+/// into `CrosstermBackend` / `Terminal`.
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub struct CaptureWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+#[cfg(test)]
+impl CaptureWriter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bytes(&self) -> Vec<u8> {
+        self.buf.lock().unwrap().clone()
+    }
+
+    pub fn clear(&self) {
+        self.buf.lock().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+impl Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl ConsoleRenderTarget<CaptureWriter> {
+    /// Create a test render target backed by a `CaptureWriter`.
+    ///
+    /// Disables raw mode management so tests can verify the ANSI byte
+    /// stream without mutating the test runner's OS terminal state.
+    pub fn new_capturing() -> (Self, CaptureWriter) {
+        let writer = CaptureWriter::new();
+        let mut rt = Self::with_writer(writer.clone()).expect("new_capturing");
+        rt.manage_raw_mode = false;
+        (rt, writer)
+    }
+}
+
+impl<W: Write> ConsoleRenderTarget<W> {
+    /// Create a render target with an arbitrary writer backend.
+    pub fn with_writer(writer: W) -> io::Result<Self> {
+        let backend = CrosstermBackend::new(writer);
         let terminal = Terminal::new(backend)?;
         Ok(Self {
             terminal,
             entered: false,
+            manage_raw_mode: true,
         })
     }
 }
 
-impl RenderTarget for ConsoleRenderTarget {
+impl<W: Write> RenderTarget for ConsoleRenderTarget<W> {
     fn enter(&mut self) -> io::Result<()> {
         if self.entered {
             return Ok(());
         }
-        execute!(self.terminal.backend_mut(), EnterAlternateScreen)?;
-        terminal::enable_raw_mode()?;
+
+        // write_ansi() — goes through the writer, testable via CaptureWriter.
+        execute!(
+            self.terminal.backend_mut(),
+            EnterAlternateScreen,
+            EnableBracketedPaste,
+        )?;
+
+        // OS console API (enable_raw_mode on Windows) / raw mode switching.
+        if self.manage_raw_mode {
+            terminal::enable_raw_mode()?;
+        }
+
+        // Also testable via CaptureWriter — see Hide::write_ansi.
         self.terminal.hide_cursor()?;
         self.entered = true;
         Ok(())
@@ -45,17 +132,33 @@ impl RenderTarget for ConsoleRenderTarget {
         if !self.entered {
             return Ok(());
         }
-        execute!(self.terminal.backend_mut(), DisableMouseCapture)?;
-        // TODO: Refactor this constant
-        // Give the terminal emulator time to process DisableMouseCapture
-        // before we disable raw mode (which re-enables echo). Without this
-        // delay, the terminal emulator might still send mouse events that
-        // get echoed as visible characters after raw mode is restored.
-        const MOUSE_DISABLE_DELAY: std::time::Duration = std::time::Duration::from_millis(8);
-        std::thread::sleep(MOUSE_DISABLE_DELAY);
-        terminal::disable_raw_mode()?;
-        execute!(self.terminal.backend_mut(), LeaveAlternateScreen)?;
+
+        // On Windows, DisableMouseCapture overrides is_ansi_code_supported()
+        // to false, forcing execute_winapi() which touches the real console.
+        // Guard it behind manage_raw_mode so tests (CaptureWriter) don't
+        // interact with the OS console.
+        if self.manage_raw_mode {
+            execute!(self.terminal.backend_mut(), DisableMouseCapture)?;
+
+            const MOUSE_DISABLE_DELAY: std::time::Duration = std::time::Duration::from_millis(8);
+            std::thread::sleep(MOUSE_DISABLE_DELAY);
+        }
+
+        // write_ansi() — always write so tests verify the byte stream.
+        execute!(
+            self.terminal.backend_mut(),
+            DisableBracketedPaste,
+            LeaveAlternateScreen,
+        )?;
+
+        // Also testable via CaptureWriter — see Show::write_ansi.
         self.terminal.show_cursor()?;
+
+        // OS console API / raw mode switching.
+        if self.manage_raw_mode {
+            terminal::disable_raw_mode()?;
+        }
+
         self.entered = false;
         Ok(())
     }
@@ -84,8 +187,91 @@ impl RenderTarget for ConsoleRenderTarget {
     }
 }
 
-impl Drop for ConsoleRenderTarget {
+impl<W: Write> Drop for ConsoleRenderTarget<W> {
     fn drop(&mut self) {
         let _ = self.exit();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests that `enter()` writes `\x1b[?2004h` (bracketed paste enable).
+    /// Under `cargo test` stdin is a pipe, so `is_terminal()` returns false
+    /// and the raw-mode OS call is skipped — only the ANSI output matters.
+    #[test]
+    fn enter_writes_bracketed_paste_enable() {
+        let (mut rt, writer) = ConsoleRenderTarget::new_capturing();
+        rt.enter().expect("enter must succeed");
+        let bytes = writer.bytes();
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|w| w == b"\x1b[?2004h"),
+            "enter() must write bracketed paste enable \\x1b[?2004h. \
+             Captured bytes: {:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    /// Tests that `exit()` writes `\x1b[?2004l` (bracketed paste disable).
+    /// Must call `enter()` first so the `entered` guard allows `exit()` to
+    /// run its full body.
+    #[test]
+    fn exit_writes_bracketed_paste_disable() {
+        let (mut rt, writer) = ConsoleRenderTarget::new_capturing();
+        // Must call real enter() so crossterm saves initial terminal state
+        rt.enter().expect("enter must succeed");
+        // Clear the capture buffer so we only assert on exit's output
+        writer.clear();
+        rt.exit().expect("exit must succeed");
+        let bytes = writer.bytes();
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004l".len())
+                .any(|w| w == b"\x1b[?2004l"),
+            "exit() must write bracketed paste disable \\x1b[?2004l. \
+             Captured bytes: {:?}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    /// Tests that the full `enter()` → `exit()` lifecycle writes both
+    /// the enable and disable sequences.
+    #[test]
+    fn enter_and_exit_roundtrip_contains_both_sequences() {
+        let (mut rt, writer) = ConsoleRenderTarget::new_capturing();
+        rt.enter().expect("enter");
+        rt.exit().expect("exit");
+        let bytes = writer.bytes();
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004h".len())
+                .any(|w| w == b"\x1b[?2004h"),
+            "enter/exit roundtrip must contain enable \\x1b[?2004h"
+        );
+        assert!(
+            bytes
+                .windows(b"\x1b[?2004l".len())
+                .any(|w| w == b"\x1b[?2004l"),
+            "enter/exit roundtrip must contain disable \\x1b[?2004l"
+        );
+    }
+
+    /// Tests that calling `enter()` twice does not write additional bytes
+    /// — the `entered` guard on the second call should skip the body.
+    #[test]
+    fn double_enter_is_idempotent() {
+        let (mut rt, writer) = ConsoleRenderTarget::new_capturing();
+        rt.enter().expect("first enter");
+        let first_len = writer.bytes().len();
+        assert!(first_len > 0, "first enter() must write something");
+        rt.enter().expect("second enter (should be no-op)");
+        assert_eq!(
+            writer.bytes().len(),
+            first_len,
+            "second enter() must not write additional bytes"
+        );
     }
 }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -885,6 +885,89 @@ mod tests {
         }
     }
 
+    #[test]
+    fn handle_focused_app_event_routes_mouse_to_component_and_drains_actions() {
+        use crate::events::{MouseButton, MouseEvent, MouseEventKind};
+        use crate::hitbox_registry::{ComponentOwner, HitboxId};
+        use crate::window::WindowState;
+
+        struct FakeApp {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for FakeApp {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+
+        let mut app = FakeApp {
+            wm: WindowManager::<TestComponent>::with_config(
+                crate::wm_config::WmConfig::standalone(),
+                std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+                None,
+                crate::window::LayerManager::new(),
+                std::collections::HashMap::new(),
+            ),
+        };
+
+        let key = app
+            .wm
+            .create_window(TestComponent::ActionRecorder(Default::default()));
+        app.wm.transition_window(key, WindowState::Mapped);
+        app.wm.regions.set(
+            key,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        app.wm.focus_app_window(key);
+
+        // Register a hitbox so dispatch_mouse can route to the component
+        let hitbox_id = HitboxId::new();
+        app.wm.hitbox_registry_mut().register(
+            hitbox_id,
+            ComponentOwner::Window(key),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+
+        let evt = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        let consumed = handle_focused_app_event(&evt, &mut app);
+        assert!(
+            consumed,
+            "mouse Press must be consumed through handle_focused_app_event"
+        );
+
+        // Verify the component received the action via drain_action_queue
+        match app
+            .wm
+            .component_for_key_mut(key)
+            .expect("component must exist")
+        {
+            TestComponent::ActionRecorder(recorder) => {
+                assert!(
+                    recorder.received_mouse_bytes,
+                    "ActionRecorder must receive MouseToBytes via drain_action_queue, actions: {:?}",
+                    recorder.actions
+                );
+            }
+            _ => panic!("component must be ActionRecorder"),
+        }
+    }
+
     // ── selection_snapshot_from ──────────────────────────────────────
 
     #[test]

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -92,6 +92,12 @@ fn drain_action_queue<
             TermWmAction::RequestKeyboardFocus(id) => {
                 app.wm().set_keyboard_focus(key, id);
             }
+            TermWmAction::PasteClipboard => {
+                let text = app.wm().clipboard_mut().and_then(|cb| cb.get().ok());
+                if let Some(text) = text {
+                    queue.push_back((key, TermWmAction::ClipboardPaste(text)));
+                }
+            }
             TermWmAction::ToggleMouseCapture => {
                 app.wm().toggle_mouse_capture();
             }

--- a/crates/term-wm-pty-engine/src/clipboard.rs
+++ b/crates/term-wm-pty-engine/src/clipboard.rs
@@ -151,44 +151,74 @@ impl Clipboard {
 /// Length of the OSC 52 header `\x1b]52;` (ESC + ] + "52;").
 const OSC52_HEADER_LEN: usize = 5;
 
-/// Offset past the `ESC ]` introducer to reach the command.
-const OSC52_ESC_OFFSET: usize = 2;
+/// Length of the Windows ConPTY-transformed header `←]52;` where
+/// the 0x1b ESC byte is rendered as the Unicode left-arrow U+2190
+/// (3-byte UTF-8 sequence: 0xE2 0x86 0x90) followed by `]52;`.
+const OSC52_HEADER_LEN_WIN: usize = 7;
+
+// (OSC52_ESC_OFFSET = 2 is no longer needed; find_osc52_header returns
+//  the position past the full header including the command.)
 
 /// Length of the clipboard-parameter `c;` following the header.
 const CLIPBOARD_PARAM_LEN: usize = 2;
 
-/// Length of the ST string terminator `\x1b\\`.
-const ST_TERMINATOR_LEN: usize = 2;
+// (ST_TERMINATOR_LEN = 2 is no longer needed; implicit terminator
+//  detection handles the case via extract_osc52_text.)
 
 /// Maximum bytes to buffer for an in-progress OSC 52 sequence before
 /// giving up (safety valve against malformed / non-terminated sequences).
 const MAX_OSC52_BUFFER_BYTES: usize = 4 * 1024 * 1024;
 
+/// Standard ESC-prefixed header bytes: `\x1b]52;`
+const OSC52_HDR_STD: &[u8] = b"\x1b]52;";
+/// Windows ConPTY header bytes: `←]52;` (ESC rendered as left-arrow)
+const OSC52_HDR_WIN: &[u8] = "←]52;".as_bytes();
+
+/// Find the OSC 52 header in `data`, returning the offset past the
+/// header (ready for optional `c;` clipboard-param skip) and a flag
+/// indicating whether this was the Windows-transformed variant.
+/// Handles both `\x1b]52;` and `←]52;` (Windows ConPTY).
+fn find_osc52_header(data: &[u8]) -> Option<usize> {
+    if let Some(pos) = data
+        .windows(OSC52_HEADER_LEN)
+        .position(|w| w == OSC52_HDR_STD)
+    {
+        return Some(pos + OSC52_HEADER_LEN);
+    }
+    if let Some(pos) = data
+        .windows(OSC52_HEADER_LEN_WIN)
+        .position(|w| w == OSC52_HDR_WIN)
+    {
+        return Some(pos + OSC52_HEADER_LEN_WIN);
+    }
+    None
+}
+
+/// Returns `true` when `b` is a valid base64 character (A-Z, a-z, 0-9,
+/// `+`, `/`, or padding `=`).
+fn is_base64_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'+' || b == b'/' || b == b'='
+}
+
 /// Scan `data` for a complete OSC 52 clipboard sequence
 /// (`OSC 52 ; c ; BASE64 ST`) and return the decoded text.
 ///
-/// Only the **first** complete sequence is extracted.  Terminators:
-/// - `BEL` (`\x07`)
-/// - `ST`  (`\x1b\\`)
+/// Only the **first** complete sequence is extracted.  Accepts:
+/// - Standard ESC prefix `\x1b]52;`
+/// - Windows ConPTY prefix `←]52;` (ESC rendered as left-arrow)
+/// - Terminator: BEL (`\x07`), ST (`\x1b\\`), or implicit termination at
+///   the first byte that is not a valid base64 character.
 pub fn extract_osc52_text(data: &[u8]) -> Option<String> {
     let mut i = 0;
     while i < data.len() {
-        // Find \x1b]52;
-        if i + OSC52_HEADER_LEN > data.len() || data[i] != 0x1b || data[i + 1] != b']' {
-            i += 1;
-            continue;
-        }
-        // Check for "52;" or "52;c;" or "52;c;" after the ESC ] introducer
-        // The format is: ESC ] 5 2 ; c ; <base64> ST
-        let header = b"52;";
-        if i + OSC52_HEADER_LEN + header.len() > data.len() {
-            break;
-        }
-        if &data[i + OSC52_ESC_OFFSET..i + OSC52_ESC_OFFSET + header.len()] != header {
-            i += 1;
-            continue;
-        }
-        let content_start = i + OSC52_ESC_OFFSET + header.len();
+        let header_end = match find_osc52_header(&data[i..]) {
+            Some(off) => i + off,
+            None => {
+                i += 1;
+                continue;
+            }
+        };
+        let content_start = header_end;
         // Skip optional "c;" — some terminals send "52;c;" and
         // some just "52;".  We accept both.
         let payload_start = if data[content_start..].starts_with(b"c;") {
@@ -196,9 +226,13 @@ pub fn extract_osc52_text(data: &[u8]) -> Option<String> {
         } else {
             content_start
         };
-        // Find the terminator: BEL (\x07) or ST (\x1b\\)
+        // Find the terminator: BEL (\x07), ST (\x1b\\), or any
+        // non-base64 character *after at least one base64 payload byte*
+        // (handles Windows ConPTY where ConPTY consumes the BEL
+        // terminator but leaves the payload intact).
         let mut end = None;
         let mut j = payload_start;
+        let mut seen_base64 = false;
         while j < data.len() {
             if data[j] == 0x07 {
                 end = Some(j);
@@ -208,6 +242,13 @@ pub fn extract_osc52_text(data: &[u8]) -> Option<String> {
                 end = Some(j);
                 break;
             }
+            if !is_base64_char(data[j]) {
+                if seen_base64 {
+                    end = Some(j);
+                }
+                break;
+            }
+            seen_base64 = true;
             j += 1;
         }
         if let Some(end_pos) = end {
@@ -264,11 +305,14 @@ impl Osc52Extractor {
         }
 
         // Common case: header lies entirely inside the current chunk.
-        if let Some(pos) = data
-            .windows(OSC52_HEADER_LEN)
-            .position(|w| w == b"\x1b]52;")
-        {
-            self.buf.extend_from_slice(&data[pos..]);
+        // Handles both \x1b]52; and ←]52; (Windows ConPTY).
+        if let Some(header_end) = find_osc52_header(data) {
+            let header_len = if data.windows(OSC52_HEADER_LEN).any(|w| w == OSC52_HDR_STD) {
+                OSC52_HEADER_LEN
+            } else {
+                OSC52_HEADER_LEN_WIN
+            };
+            self.buf.extend_from_slice(&data[header_end - header_len..]);
             return self.try_extract(data, prev_tail);
         }
 
@@ -276,16 +320,17 @@ impl Osc52Extractor {
         if !prev_tail.is_empty() {
             let mut combined = prev_tail.to_vec();
             combined.extend_from_slice(data);
-            if let Some(pos) = combined
-                .windows(OSC52_HEADER_LEN)
-                .position(|w| w == b"\x1b]52;")
-            {
-                let tail_len = prev_tail.len();
-                if pos < tail_len {
-                    self.buf.extend_from_slice(&combined[pos..tail_len]);
-                }
+            if let Some(header_end) = find_osc52_header(&combined) {
+                let header_len = if combined
+                    .windows(OSC52_HEADER_LEN)
+                    .any(|w| w == OSC52_HDR_STD)
+                {
+                    OSC52_HEADER_LEN
+                } else {
+                    OSC52_HEADER_LEN_WIN
+                };
                 self.buf
-                    .extend_from_slice(&data[pos.saturating_sub(tail_len)..]);
+                    .extend_from_slice(&combined[header_end - header_len..]);
                 return self.try_extract(data, prev_tail);
             }
         }
@@ -304,24 +349,19 @@ impl Osc52Extractor {
         self.buf.clear();
     }
 
-    /// Check `data` and `prev_tail` for a terminator and, if found, run
-    /// the full extraction against the accumulated buffer.
-    /// Safety-valve at [`MAX_OSC52_BUFFER_BYTES`].
-    fn try_extract(&mut self, data: &[u8], prev_tail: &[u8]) -> Option<String> {
-        // BEL (\x07) is always within a single chunk.
-        // ST (\x1b\\) can span the chunk boundary.
-        let has_term = data.contains(&0x07)
-            || data.windows(ST_TERMINATOR_LEN).any(|w| w == b"\x1b\\")
-            || (!prev_tail.is_empty()
-                && prev_tail.last() == Some(&0x1b)
-                && data.first() == Some(&b'\\'));
-        if has_term {
-            let result = extract_osc52_text(&self.buf);
-            self.buf.clear();
-            return result;
-        }
+    /// Check the accumulated buffer for a complete OSC 52 sequence and
+    /// extract it if found.  Handles BEL (`\x07`), ST (`\x1b\\`), and
+    /// implicit termination at any non-base64 character (Windows ConPTY
+    /// drops the BEL terminator).  Safety-valve at
+    /// [`MAX_OSC52_BUFFER_BYTES`].
+    fn try_extract(&mut self, _data: &[u8], _prev_tail: &[u8]) -> Option<String> {
         if self.buf.len() >= MAX_OSC52_BUFFER_BYTES {
             self.buf.clear();
+            return None;
+        }
+        if let Some(result) = extract_osc52_text(&self.buf) {
+            self.buf.clear();
+            return Some(result);
         }
         None
     }

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -536,6 +536,12 @@ impl<C: Component<TermWmAction>> Component<TermWmAction> for ScrollViewComponent
         match event {
             Event::Mouse(_) => self.on_mouse(event, ctx),
             Event::Key(_) => self.on_key(event, ctx),
+            Event::Paste(_) => {
+                let handle = self.scroll_handle();
+                let info = handle.info();
+                let child_ctx = ctx.with_viewport(info, Some(handle));
+                self.content.borrow_mut().handle_events(event, &child_ctx)
+            }
             _ => EventResult::Ignored,
         }
     }

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -2228,6 +2228,136 @@ mod tests {
         );
     }
 
+    // ── Right-Click Paste Tests ────────────────────────────────────────
+    //
+    // These tests verify that right-click mouse events are intercepted by
+    // TerminalComponent::handle_events and produce PasteClipboard (in
+    // normal mode) or pass through to PTY encoding (in direct mode).
+
+    /// Right-click Release in normal mode must produce
+    /// PasteClipboard; Press and Drag must be consumed (not forwarded
+    /// to the PTY).
+    #[test]
+    fn right_click_paste_in_normal_mode() {
+        use term_wm_core::actions::TermWmAction;
+        use term_wm_core::components::{ComponentContext, EventResult};
+        use term_wm_core::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let (mut term, _rb) = make_term_with_content(80, 24, 2000, "Hello World");
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // Right-click Press — must be consumed (intercepted before PTY)
+        let press = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Right),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let press_result = term.handle_events(&press, &ctx);
+        assert!(
+            matches!(press_result, EventResult::Consumed),
+            "right-click Press must be Consumed, got {:?}",
+            press_result
+        );
+
+        // Right-click Drag — must be consumed
+        let drag = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Right),
+            column: 15,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let drag_result = term.handle_events(&drag, &ctx);
+        assert!(
+            matches!(drag_result, EventResult::Consumed),
+            "right-click Drag must be Consumed, got {:?}",
+            drag_result
+        );
+
+        // Right-click Release — must produce PasteClipboard
+        let release = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Release(MouseButton::Right),
+            column: 15,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let release_result = term.handle_events(&release, &ctx);
+        assert!(
+            matches!(
+                release_result,
+                EventResult::Action(TermWmAction::PasteClipboard)
+            ),
+            "right-click Release must produce PasteClipboard, got {:?}",
+            release_result
+        );
+    }
+
+    /// Right-click in direct mode must NOT produce PasteClipboard — it
+    /// must pass through to PTY encoding (MouseToBytes when the PTY has
+    /// enabled mouse tracking).
+    #[test]
+    fn right_click_in_direct_mode_passes_through() {
+        use term_wm_core::actions::TermWmAction;
+        use term_wm_core::components::{ComponentContext, EventResult};
+        use term_wm_core::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut pane = TestPane::new(2000);
+        pane.set_parser_size(24, 80);
+        pane.write_to_parser(b"Hello World");
+        // Enable mouse tracking so the event would produce MouseToBytes
+        pane.write_to_parser(b"\x1b[?1000h");
+        let mut term = TerminalComponent::from_pane(Box::new(pane));
+        term.set_selection_enabled(true);
+
+        let ctx = ComponentContext::new(true)
+            .with_direct_mode(true)
+            .with_screen_area(LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            });
+
+        // Right-click Release in direct mode — must NOT be PasteClipboard
+        let release = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Release(MouseButton::Right),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let result = term.handle_events(&release, &ctx);
+        assert!(
+            !matches!(result, EventResult::Action(TermWmAction::PasteClipboard)),
+            "right-click Release in direct mode must NOT produce PasteClipboard, got {:?}",
+            result
+        );
+        // With mouse tracking enabled, Release should produce MouseToBytes
+        assert!(
+            matches!(result, EventResult::Action(TermWmAction::MouseToBytes(_))),
+            "right-click Release in direct mode should produce MouseToBytes, got {:?}",
+            result
+        );
+
+        // Right-click Press in direct mode — also not consumed/paste-intercepted
+        let press = Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Press(MouseButton::Right),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        });
+        let press_result = term.handle_events(&press, &ctx);
+        assert!(
+            !matches!(press_result, EventResult::Consumed),
+            "right-click Press in direct mode must NOT be Consumed, got {:?}",
+            press_result
+        );
+    }
+
     // ── Bracketed Paste Tests ──────────────────────────────────────────
     //
     // These tests verify that TerminalComponent::handle_events correctly

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -163,6 +163,22 @@ impl Component<TermWmAction> for TerminalComponent {
             }
             Event::Mouse(mouse) => {
                 if !ctx.direct_mode() {
+                    // Right-click paste (Windows Cmd/PS convention).
+                    // Only in normal mode — in direct mode (tmux, vim, etc.)
+                    // right-click passes through to the running program.
+                    match mouse.kind {
+                        MouseEventKind::Press(MouseButton::Right)
+                        | MouseEventKind::Drag(MouseButton::Right) => {
+                            return EventResult::Consumed;
+                        }
+                        MouseEventKind::Release(MouseButton::Right) => {
+                            return EventResult::Action(TermWmAction::PasteClipboard);
+                        }
+                        _ => {}
+                    }
+                }
+
+                if !ctx.direct_mode() {
                     let selection_ready = self.selection_enabled;
                     let area = ctx.screen_area().unwrap_or_default();
                     if handle_selection_mouse(self, selection_ready, mouse, area) {
@@ -240,18 +256,39 @@ impl Component<TermWmAction> for TerminalComponent {
                 if self.pane.borrow_mut().scrollback() > 0 {
                     self.pane.borrow_mut().set_scrollback(0);
                 }
-                if let Err(_err) = self.pane.borrow_mut().write_bytes(&bytes) {
-                    #[cfg(windows)]
-                    eprintln!("terminal input write failed: {_err}");
+                if let Err(err) = self.pane.borrow_mut().write_bytes(&bytes) {
+                    tracing::warn!(?err, "terminal input write failed");
                 }
             }
             TermWmAction::Scroll(delta) => {
                 self.scroll_scrollback(delta);
             }
             TermWmAction::MouseToBytes(bytes) => {
-                if let Err(_err) = self.pane.borrow_mut().write_bytes(&bytes) {
-                    #[cfg(windows)]
-                    eprintln!("terminal mouse write failed: {_err}");
+                if let Err(err) = self.pane.borrow_mut().write_bytes(&bytes) {
+                    tracing::warn!(?err, "terminal mouse write failed");
+                }
+            }
+            TermWmAction::ClipboardPaste(text) => {
+                let bracketed_paste = {
+                    let mut pane = self.pane.borrow_mut();
+                    let parser = pane.shared_parser();
+                    let parser_lock = parser.lock().unwrap();
+                    parser_lock.screen().bracketed_paste()
+                };
+                let bytes = if bracketed_paste {
+                    let mut wrapped = b"\x1b[200~".to_vec();
+                    wrapped.extend_from_slice(text.as_bytes());
+                    wrapped.extend_from_slice(b"\x1b[201~");
+                    wrapped
+                } else {
+                    text.as_bytes().to_vec()
+                };
+                self.selection.borrow_mut().clear();
+                if self.pane.borrow_mut().scrollback() > 0 {
+                    self.pane.borrow_mut().set_scrollback(0);
+                }
+                if let Err(err) = self.pane.borrow_mut().write_bytes(&bytes) {
+                    tracing::warn!(?err, "terminal paste write failed");
                 }
             }
             _ => {}
@@ -2355,5 +2392,72 @@ mod tests {
         } else {
             panic!("expected Action(KeyToBytes), got {:?}", result);
         }
+    }
+
+    /// ClipboardPaste with bracketed paste enabled wraps the text in
+    /// \x1b[200~...\x1b[201~ markers before writing to the pane.
+    #[test]
+    fn clipboard_paste_wraps_when_bracketed_enabled() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+
+        // Enable bracketed paste on the child's parser
+        {
+            let parser = term.pane.borrow_mut().shared_parser();
+            parser.lock().unwrap().process(b"\x1b[?2004h");
+        }
+
+        let ctx = ComponentContext::default();
+        let mut queue = std::collections::VecDeque::new();
+        term.update(
+            TermWmAction::ClipboardPaste("clip".to_string()),
+            &ctx,
+            &mut queue,
+        );
+
+        let written = term.pane.borrow_mut().last_bytes_text();
+        assert_eq!(
+            written, "\x1b[200~clip\x1b[201~",
+            "ClipboardPaste must wrap in bracketed markers when DECSET 2004 is enabled"
+        );
+    }
+
+    /// ClipboardPaste without bracketed paste writes raw bytes to the pane.
+    #[test]
+    fn clipboard_paste_raw_when_bracketed_disabled() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+
+        let ctx = ComponentContext::default();
+        let mut queue = std::collections::VecDeque::new();
+        term.update(
+            TermWmAction::ClipboardPaste("raw".to_string()),
+            &ctx,
+            &mut queue,
+        );
+
+        let written = term.pane.borrow_mut().last_bytes_text();
+        assert_eq!(
+            written, "raw",
+            "ClipboardPaste must write raw bytes when DECSET 2004 is not enabled"
+        );
+    }
+
+    /// ClipboardPaste with empty text is a no-op (no bytes written).
+    #[test]
+    fn clipboard_paste_empty_text_is_noop() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+
+        let ctx = ComponentContext::default();
+        let mut queue = std::collections::VecDeque::new();
+        term.update(
+            TermWmAction::ClipboardPaste(String::new()),
+            &ctx,
+            &mut queue,
+        );
+
+        let written = term.pane.borrow_mut().last_bytes_text();
+        assert_eq!(
+            written, "",
+            "ClipboardPaste with empty text must write nothing"
+        );
     }
 }

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -207,6 +207,23 @@ impl Component<TermWmAction> for TerminalComponent {
                 }
                 EventResult::Action(TermWmAction::MouseToBytes(bytes))
             }
+            Event::Paste(text) => {
+                let bracketed_paste = {
+                    let mut pane = self.pane.borrow_mut();
+                    let parser = pane.shared_parser();
+                    let parser_lock = parser.lock().unwrap();
+                    parser_lock.screen().bracketed_paste()
+                };
+                let bytes = if bracketed_paste {
+                    let mut wrapped = b"\x1b[200~".to_vec();
+                    wrapped.extend_from_slice(text.as_bytes());
+                    wrapped.extend_from_slice(b"\x1b[201~");
+                    wrapped
+                } else {
+                    text.as_bytes().to_vec()
+                };
+                EventResult::Action(TermWmAction::KeyToBytes(bytes))
+            }
             _ => EventResult::Ignored,
         }
     }
@@ -1058,6 +1075,9 @@ fn brighten_indexed(color: Option<TColor>) -> Option<TColor> {
 
 /// Simulated terminal pane for testing scroll synchronization logic without a
 /// real PTY process.
+///
+/// Also tracks written bytes so paste-forwarding tests can verify the exact
+/// byte sequence written to the child PTY (wrapped vs. raw).
 #[cfg(test)]
 struct TestPane {
     parser: std::sync::Arc<std::sync::Mutex<vt100::Parser>>,
@@ -1066,6 +1086,7 @@ struct TestPane {
     alt_screen: bool,
     pending_title: Option<String>,
     kill_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    written_bytes: Vec<u8>,
 }
 
 #[cfg(test)]
@@ -1078,6 +1099,7 @@ impl TestPane {
             alt_screen: false,
             pending_title: None,
             kill_count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            written_bytes: Vec::new(),
         }
     }
 
@@ -1090,6 +1112,7 @@ impl TestPane {
             alt_screen: false,
             pending_title: None,
             kill_count: std::sync::Arc::clone(&kill_count),
+            written_bytes: Vec::new(),
         };
         (pane, kill_count)
     }
@@ -1136,7 +1159,8 @@ impl Pane for TestPane {
         self.current_scrollback = rows.min(self.max_sb);
     }
 
-    fn write_bytes(&mut self, _input: &[u8]) -> std::io::Result<()> {
+    fn write_bytes(&mut self, input: &[u8]) -> std::io::Result<()> {
+        self.written_bytes.extend_from_slice(input);
         Ok(())
     }
 
@@ -1165,7 +1189,7 @@ impl Pane for TestPane {
     }
 
     fn last_bytes_text(&self) -> String {
-        String::new()
+        String::from_utf8_lossy(&self.written_bytes).to_string()
     }
 
     fn kill_child(&mut self) -> term_wm_pty_engine::PtyResult<()> {
@@ -2165,5 +2189,171 @@ mod tests {
             "in normal mode, Drag must be consumed by selection, got {:?}",
             result_drag
         );
+    }
+
+    // ── Bracketed Paste Tests ──────────────────────────────────────────
+    //
+    // These tests verify that TerminalComponent::handle_events correctly
+    // wraps paste text in bracketed escape sequences (\x1b[200~...\x1b[201~)
+    // only when the child PTY has explicitly enabled bracketed paste mode
+    // by sending \x1b[?2004h (DECSET 2004).
+    //
+    // If the child has NOT enabled bracketed paste, the paste text must be
+    // forwarded as raw bytes — wrapping would cause legacy shells to
+    // display rogue "~" characters (the vt100 parser consumes \x1b[200 but
+    // lets the trailing ~ through as a literal).
+
+    /// When the child PTY has bracketed paste enabled (DECSET 2004), the
+    /// paste text must be wrapped in \x1b[200~ ... \x1b[201~ so the child
+    /// (e.g. opencode, vim, nano) can recognize it as a bulk paste rather
+    /// than a keystroke flood.
+    #[test]
+    fn paste_wraps_in_bracketed_when_child_enabled() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+
+        // Simulate the child sending \x1b[?2004h (DECSET 2004) to enable
+        // bracketed paste mode.  The vt100 parser tracks this as
+        // screen().bracketed_paste().
+        {
+            let parser = term.pane.borrow_mut().shared_parser();
+            parser.lock().unwrap().process(b"\x1b[?2004h");
+        }
+
+        let ctx = ComponentContext::default();
+        let event = Event::Paste("hello".to_string());
+        let result = term.handle_events(&event, &ctx);
+
+        // Must produce KeyToBytes with bracketed markers wrapping the text
+        match result {
+            EventResult::Action(TermWmAction::KeyToBytes(bytes)) => {
+                assert_eq!(
+                    bytes, b"\x1b[200~hello\x1b[201~",
+                    "paste must be wrapped in bracketed markers when child has DECSET 2004 enabled"
+                );
+            }
+            other => panic!("expected Action(KeyToBytes), got {:?}", other),
+        }
+    }
+
+    /// When the child PTY has NOT enabled bracketed paste, the paste text
+    /// must be forwarded as raw bytes.  Wrapping would cause legacy shells
+    /// (bash, zsh without bracketed-paste support) to display stray "~"
+    /// characters on screen.
+    #[test]
+    fn paste_sends_raw_when_child_disabled() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+        // Deliberately do NOT send \x1b[?2004h — bracketed_paste defaults
+        // to false in the vt100 parser.
+
+        let ctx = ComponentContext::default();
+        let event = Event::Paste("hello".to_string());
+        let result = term.handle_events(&event, &ctx);
+
+        // Must produce KeyToBytes with raw text (no bracketed wrapping)
+        match result {
+            EventResult::Action(TermWmAction::KeyToBytes(bytes)) => {
+                assert_eq!(
+                    bytes, b"hello",
+                    "paste must be raw bytes when child has not enabled DECSET 2004"
+                );
+            }
+            other => panic!("expected Action(KeyToBytes), got {:?}", other),
+        }
+    }
+
+    /// Even when bracketed paste is enabled, the wrapping must include the
+    /// full bracketed start/end markers (including the trailing ~ in
+    /// \x1b[200~ and \x1b[201~).  A common bug is sending \x1b[200~ but
+    /// forgetting to include the final "~" tilde character.
+    #[test]
+    fn paste_wrapping_includes_trailing_tilde() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+
+        // Enable bracketed paste on the child's parser
+        {
+            let parser = term.pane.borrow_mut().shared_parser();
+            parser.lock().unwrap().process(b"\x1b[?2004h");
+        }
+
+        let ctx = ComponentContext::default();
+        let event = Event::Paste("test".to_string());
+        let result = term.handle_events(&event, &ctx);
+
+        // Verify the wrapped bytes end with \x1b[201~ (including the ~)
+        match result {
+            EventResult::Action(TermWmAction::KeyToBytes(bytes)) => {
+                assert!(
+                    bytes.ends_with(b"\x1b[201~"),
+                    "wrapped bytes must end with \\x1b[201~, got {:?}",
+                    bytes
+                );
+                assert!(
+                    bytes.starts_with(b"\x1b[200~"),
+                    "wrapped bytes must start with \\x1b[200~, got {:?}",
+                    bytes
+                );
+            }
+            other => panic!("expected Action(KeyToBytes), got {:?}", other),
+        }
+    }
+
+    /// Full pipeline test: verify that when handle_events produces a
+    /// KeyToBytes action, calling update() actually writes those bytes
+    /// to the pane (the real PTY or TestPane).
+    #[test]
+    fn paste_full_pipeline_writes_to_pane() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+
+        // Enable bracketed paste on the child's parser
+        {
+            let mut pane = term.pane.borrow_mut();
+            let parser = pane.shared_parser();
+            parser.lock().unwrap().process(b"\x1b[?2004h");
+        }
+
+        let ctx = ComponentContext::default();
+        let event = Event::Paste("data".to_string());
+        let result = term.handle_events(&event, &ctx);
+
+        // Extract the bytes from the action and feed them into update
+        if let EventResult::Action(TermWmAction::KeyToBytes(expected)) = result {
+            let mut queue = std::collections::VecDeque::new();
+            term.update(TermWmAction::KeyToBytes(expected.clone()), &ctx, &mut queue);
+
+            // Verify the pane received exactly the wrapped bytes by checking
+            // the last_written field through the Pane trait method
+            let written = term.pane.borrow_mut().last_bytes_text();
+            assert_eq!(
+                written, "\x1b[200~data\x1b[201~",
+                "wrapped paste bytes must be written to the pane"
+            );
+        } else {
+            panic!("expected Action(KeyToBytes), got {:?}", result);
+        }
+    }
+
+    /// When the child has not enabled bracketed paste, the full pipeline
+    /// must write raw bytes (no wrapping) to the pane.
+    #[test]
+    fn paste_full_pipeline_raw_when_disabled() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(0)));
+        // No \x1b[?2004h — bracketed_paste defaults to false
+
+        let ctx = ComponentContext::default();
+        let event = Event::Paste("raw".to_string());
+        let result = term.handle_events(&event, &ctx);
+
+        if let EventResult::Action(TermWmAction::KeyToBytes(expected)) = result {
+            let mut queue = std::collections::VecDeque::new();
+            term.update(TermWmAction::KeyToBytes(expected.clone()), &ctx, &mut queue);
+
+            let written = term.pane.borrow_mut().last_bytes_text();
+            assert_eq!(
+                written, "raw",
+                "raw bytes (no bracketed wrapping) must be written to the pane when child has not enabled DECSET 2004"
+            );
+        } else {
+            panic!("expected Action(KeyToBytes), got {:?}", result);
+        }
     }
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -12,6 +12,7 @@ use common::session::{
     TEST_COLS, TEST_ROWS, connect_client_with_retry, generate_socket_path, get_bench_bin,
     spawn_session, wait_for_output,
 };
+use term_wm_pty_engine::clipboard::Osc52Extractor;
 
 #[tokio::test]
 async fn session_spawn_returns_id() {
@@ -129,6 +130,61 @@ async fn session_osc52_in_output() {
         Some(common::mock::EXPECTED_OSC52_PAYLOAD),
         "OSC 52 payload extraction failed, got stream: {:?}",
         String::from_utf8_lossy(&output)
+    );
+}
+
+#[tokio::test]
+async fn session_osc52_via_osc52extractor() {
+    let mock = get_mock_bin();
+    let (client, _dir) = spawn_session(vec![mock, "osc52".into()], TEST_COLS, TEST_ROWS).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    let mut extractor = Osc52Extractor::new();
+    let mut prev_tail: [u8; 8] = [0; 8];
+    let mut extracted = None;
+
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(3) {
+        match tokio::time::timeout(Duration::from_millis(200), reader.recv()).await {
+            Ok(Some(Ok(data))) => {
+                eprintln!(
+                    "DEBUG chunk len={} is_active={} hex={:02x?} text={:?}",
+                    data.len(),
+                    extractor.is_active(),
+                    &data[..data.len().min(40)],
+                    String::from_utf8_lossy(&data[..data.len().min(80)])
+                );
+                if let Some(text) = extractor.push(&data, &prev_tail) {
+                    eprintln!("DEBUG EXTRACTED {:?}", text);
+                    extracted = Some(text);
+                    break;
+                }
+                let n = data.len();
+                if n >= 8 {
+                    prev_tail.copy_from_slice(&data[n - 8..n]);
+                } else if n > 0 {
+                    prev_tail.rotate_left(n);
+                    prev_tail[8 - n..].copy_from_slice(&data[..n]);
+                }
+            }
+            Ok(Some(Err(_))) | Ok(None) => break,
+            Err(_) => continue,
+        }
+    }
+    eprintln!(
+        "DEBUG final extracted={:?} is_active={}",
+        extracted,
+        extractor.is_active()
+    );
+
+    assert_eq!(
+        extracted,
+        Some("test".to_string()),
+        "Osc52Extractor should decode 'test' from real server byte stream"
     );
 }
 

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -102,7 +102,10 @@ async fn session_mouse_bytes_forwarded() {
         .await
         .unwrap();
 
-    writer.send(b"ping".to_vec()).unwrap();
+    // NOTE: must include trailing \n — on headless Windows CI where
+    // GetConsoleMode fails, stdin defaults to line-input mode and
+    // blocks until a newline is received.
+    writer.send(b"ping\n".to_vec()).unwrap();
 
     let output = wait_for_output(&mut reader, b"MOUSE_OK:", Duration::from_secs(3)).await;
     assert!(


### PR DESCRIPTION
Terminal lifecycle
- Enable bracketed paste mode (\x1b[?2004h) on terminal enter and disable
  on exit, so child PTYs can distinguish bulk paste from keystroke flood
- Made ConsoleRenderTarget generic over Writer<W> for testability; added
  CaptureWriter to verify ANSI sequences in unit tests

Right-click paste
- Right-click Release in normal mode triggers PasteClipboard, which reads
  from the system clipboard and writes the text to the focused terminal
- Right-click in direct mode (vim, tmux, etc.) passes through to the PTY
  without interception, preserving mouse tracking for the running program

Bracketed paste wrapping
- TerminalComponent::handle_events handles Event::Paste, wrapping paste
  text in \x1b[200~...\x1b[201~ when the child has DECSET 2004 enabled
- Falls back to raw bytes when bracketed paste is not active, preventing
  stray "~" characters in legacy shells
- ScrollViewComponent forwards Paste events to its child component
- ClipboardPaste action routes clipboard content through the same
  bracketed-paste-aware pipeline as typed paste

OSC 52 clipboard improvements
- Windows ConPTY support: detect ←]52; header (ESC rendered as left-arrow)
  in addition to standard \x1b]52;
- Implicit terminator: accept first non-base64 byte as sequence terminator
  when at least one base64 payload byte has been seen (handles ConPTY
  stripping the BEL/ST terminator)
- Osc52Extractor integration test validates extraction against real
  chunked IPC server data
- Remote session client intercepts OSC 52 from raw byte stream before it
  enters the VT100 parser (fixes copy over SSH on macOS)

Testing
- Tests for paste wrapping with/without bracketed paste, right-click
  behavior in normal and direct mode, ClipboardPaste write-to-pane
  pipeline, and OSC 52 extraction via Osc52Extractor
- TestPane tracks written bytes for paste-forwarding assertions
- Captured-writer tests for bracketed-paste enable/disable sequences