### PR TITLE
perf: Row-slice BCE iterators + persistent SoA mask buffers for render path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -276,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +344,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -472,6 +520,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1286,6 +1367,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1877,12 +1967,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2292,7 +2398,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -2357,7 +2463,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -2565,6 +2671,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2931,6 +3050,7 @@ dependencies = [
 name = "term-wm-console"
 version = "0.8.20-alpha"
 dependencies = [
+ "criterion",
  "crossterm",
  "libc",
  "ratatui",
@@ -3244,6 +3364,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,7 +3594,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -4104,6 +4234,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ bitcode = "0.6.9"
 bitflags = "2.13.1"
 clap = { version = "4.6.1", features = ["derive"] }
 console = "0.16.4"
+criterion = { version = "0.8.2", default-features = false }
 crossbeam-channel = "0.5.15"
 crossterm = "0.29.0"
 ctrlc = "3.5.2"

--- a/crates/term-wm-console/Cargo.toml
+++ b/crates/term-wm-console/Cargo.toml
@@ -17,5 +17,10 @@ term-wm-render = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 libc = { workspace = true }
 term-wm-pty-engine = { workspace = true }
+
+[[bench]]
+name = "blit_buffer"
+harness = false

--- a/crates/term-wm-console/benches/blit_buffer.rs
+++ b/crates/term-wm-console/benches/blit_buffer.rs
@@ -1,0 +1,35 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use std::hint::black_box;
+
+// The blit_buffer function is pub in draw_plan_renderer.
+// We import from the crate root.
+use term_wm_console::draw_plan_renderer::blit_buffer;
+
+fn bench_blit_buffer(c: &mut Criterion) {
+    let sizes = [
+        ("80x24 fully contained", Rect::new(0, 0, 80, 24)),
+        ("120x40", Rect::new(0, 0, 120, 40)),
+        ("200x60", Rect::new(0, 0, 200, 60)),
+    ];
+    let mut group = c.benchmark_group("blit_buffer");
+    for (name, area) in sizes {
+        let src = Buffer::empty(area);
+        let mut dst = Buffer::empty(area);
+        group.bench_function(name, |b| {
+            b.iter(|| blit_buffer(black_box(&src), black_box(&mut dst), black_box(area)))
+        });
+    }
+    // Also test clipped/partial blits
+    group.bench_function("80x24 clipped offset", |b| {
+        let src = Buffer::empty(Rect::new(0, 0, 160, 48));
+        let mut dst = Buffer::empty(Rect::new(0, 0, 80, 24));
+        let area = Rect::new(40, 12, 80, 24); // partially overlaps dst
+        b.iter(|| blit_buffer(black_box(&src), black_box(&mut dst), black_box(area)))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_blit_buffer);
+criterion_main!(benches);

--- a/crates/term-wm-console/src/console_render_target.rs
+++ b/crates/term-wm-console/src/console_render_target.rs
@@ -190,7 +190,7 @@ impl<W: Write> RenderTarget for ConsoleRenderTarget<W> {
             .draw(move |frame| {
                 let area = frame.area();
                 let buffer = std::mem::replace(frame.buffer_mut(), Buffer::empty(area));
-                let mut backend = RatatuiBackend::new(buffer, area);
+                let mut backend = RatatuiBackend::new_simple(buffer, area);
                 f(&mut backend);
                 *frame.buffer_mut() = backend.buffer;
             })

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -267,47 +267,70 @@ pub fn render_window_chrome(
     }
 }
 
-/// Convert LayoutRect to Ratatui Rect
+/// Convert LayoutRect to Ratatui Rect with proportional truncation.
+/// Negative coordinates are clamped to 0; width/height are reduced by the
+/// same amount to prevent phantom column projection.
 fn layout_rect_to_clipped_rect(layout: LayoutRect) -> Rect {
+    let x_trunc = if layout.x < 0 { (-layout.x) as u16 } else { 0 };
+    let y_trunc = if layout.y < 0 { (-layout.y) as u16 } else { 0 };
     Rect {
-        x: layout.x as u16,
-        y: layout.y as u16,
-        width: layout.width,
-        height: layout.height,
+        x: layout.x.max(0) as u16,
+        y: layout.y.max(0) as u16,
+        width: layout.width.saturating_sub(x_trunc),
+        height: layout.height.saturating_sub(y_trunc),
     }
 }
 
 /// Copy cells from source buffer to destination buffer within the given area.
-fn blit_buffer(src: &Buffer, dst: &mut Buffer, area: Rect) {
-    for y in area.y..area.y.saturating_add(area.height) {
-        for x in area.x..area.x.saturating_add(area.width) {
-            if let Some(cell) = src.cell((x, y))
-                && let Some(dst_cell) = dst.cell_mut((x, y))
-            {
-                *dst_cell = cell.clone();
-            }
-        }
+/// Uses direct row-slice indexing to eliminate per-cell bounds checks,
+/// with explicit intersection clipping for safety.
+pub fn blit_buffer(src: &Buffer, dst: &mut Buffer, area: Rect) {
+    let clip = area.intersection(src.area).intersection(dst.area);
+    if clip.width == 0 || clip.height == 0 {
+        return;
+    }
+
+    let src_w = src.area.width as usize;
+    let dst_w = dst.area.width as usize;
+    let copy_w = clip.width as usize;
+    let y_end = clip.y.saturating_add(clip.height);
+
+    for y in clip.y..y_end {
+        let src_y = (y - src.area.y) as usize;
+        let dst_y = (y - dst.area.y) as usize;
+        let src_x = (clip.x - src.area.x) as usize;
+        let dst_x = (clip.x - dst.area.x) as usize;
+
+        let src_start = src_y * src_w + src_x;
+        let dst_start = dst_y * dst_w + dst_x;
+
+        dst.content[dst_start..dst_start + copy_w]
+            .clone_from_slice(&src.content[src_start..src_start + copy_w]);
     }
 }
 
 /// Draw plan renderer that consumes the spatial IR and renders components.
 /// Uses swap-based rendering for zero-allocation steady-state.
-/// Holds persistent offscreen buffers that are swapped (not reallocated)
-/// each frame.  The caller takes a buffer via `take_scratch()`, resizes
-/// it for the current window, renders into it, blits the result to the
-/// main buffer, then returns it via `put_scratch()`.  After the first
-/// frame the Buffer capacity is stable — no heap allocations in steady
-/// state.
+/// Holds persistent offscreen buffers AND mask buffers that are swapped
+/// (not reallocated) each frame.  The caller takes a buffer via
+/// `take_scratch()`, resizes it for the current window, renders into it,
+/// blits the result to the main buffer, then returns it via `put_scratch()`.
+/// After the first frame the Buffer and mask capacity is stable — no heap
+/// allocations in steady state.
 pub struct DrawPlanRenderer {
     scratch_buffer: Buffer,
+    scratch_mask: Vec<u8>,
     direct_buffer: Buffer,
+    direct_mask: Vec<u8>,
 }
 
 impl DrawPlanRenderer {
     pub fn new() -> Self {
         Self {
             scratch_buffer: Buffer::empty(Rect::ZERO),
+            scratch_mask: Vec::new(),
             direct_buffer: Buffer::empty(Rect::ZERO),
+            direct_mask: Vec::new(),
         }
     }
 
@@ -400,19 +423,27 @@ impl DrawPlanRenderer {
         hitbox_registry: &mut HitboxRegistry,
     ) {
         let mut buffer = std::mem::replace(&mut self.scratch_buffer, Buffer::empty(Rect::ZERO));
+        let mask = std::mem::take(&mut self.scratch_mask);
         buffer.resize(area);
         buffer.reset();
 
-        let mut backend = RatatuiBackend::new(buffer, area);
+        let mut backend = RatatuiBackend::new(buffer, area, mask);
         let ctx = ComponentContext::new(!region.dimmed).with_screen_area(region.bounds);
         component.render(&mut backend, region.bounds, &ctx, hitbox_registry);
 
         if region.dimmed {
-            self.apply_dim_modifier(&mut backend.buffer);
+            let mut tmp_mask = std::mem::take(&mut backend.mask_buffer);
+            let buf_len = backend.buffer.content.len();
+            if tmp_mask.len() < buf_len {
+                tmp_mask.resize(buf_len, 0);
+            }
+            Self::apply_dim_modifier(&mut backend.buffer, &mut tmp_mask[..buf_len]);
+            backend.mask_buffer = tmp_mask;
         }
 
         blit_buffer(&backend.buffer, target_buf, area);
         self.scratch_buffer = backend.buffer;
+        self.scratch_mask = backend.mask_buffer;
     }
 
     /// Render directly into target buffer (panels, overlays).
@@ -424,10 +455,11 @@ impl DrawPlanRenderer {
         region: &RenderRegion,
     ) {
         let mut buffer = std::mem::replace(&mut self.direct_buffer, Buffer::empty(Rect::ZERO));
+        let mask = std::mem::take(&mut self.direct_mask);
         buffer.resize(area);
         buffer.reset();
 
-        let mut backend = RatatuiBackend::new(buffer, area);
+        let mut backend = RatatuiBackend::new(buffer, area, mask);
         let ctx = ComponentContext::new(true).with_screen_area(region.bounds);
         component.render(
             &mut backend,
@@ -438,6 +470,7 @@ impl DrawPlanRenderer {
 
         blit_buffer(&backend.buffer, target_buf, area);
         self.direct_buffer = backend.buffer;
+        self.direct_mask = backend.mask_buffer;
     }
 
     /// Render a notification toast into the target buffer.
@@ -546,32 +579,37 @@ impl DrawPlanRenderer {
         region: &RenderRegion,
         hitbox_registry: &mut HitboxRegistry,
     ) {
-        // Swap persistent buffer out (leaves empty buffer in place)
+        // Swap persistent buffer AND mask out (leaves empty in place)
         let mut buffer = std::mem::replace(&mut self.scratch_buffer, Buffer::empty(Rect::ZERO));
+        let mask = std::mem::take(&mut self.scratch_mask);
 
-        // Resize and clear the swapped buffer (no allocation after warmup)
+        // Resize and clear (no allocation after warmup)
         buffer.resize(area);
         buffer.reset();
 
-        // Create backend owning the buffer (satisfies 'static for Any)
-        let mut backend = RatatuiBackend::new(buffer, area);
+        // Create backend owning the buffer and mask
+        let mut backend = RatatuiBackend::new(buffer, area, mask);
 
-        // Create component context with screen area
         let ctx = ComponentContext::new(!region.dimmed).with_screen_area(region.bounds);
-
-        // Component renders itself into the backend
         component.render(&mut backend, region.bounds, &ctx, hitbox_registry);
 
-        // Apply dim modifier if needed
+        // Apply dim modifier via two-pass mask if needed
         if region.dimmed {
-            self.apply_dim_modifier(&mut backend.buffer);
+            let mut tmp_mask = std::mem::take(&mut backend.mask_buffer);
+            let buf_len = backend.buffer.content.len();
+            if tmp_mask.len() < buf_len {
+                tmp_mask.resize(buf_len, 0);
+            }
+            Self::apply_dim_modifier(&mut backend.buffer, &mut tmp_mask[..buf_len]);
+            backend.mask_buffer = tmp_mask;
         }
 
         // Blit to main frame
         blit_buffer(&backend.buffer, frame.buffer_mut(), area);
 
-        // Swap buffer back to preserve capacity (zero-allocation)
+        // Swap buffer + mask back to preserve capacity
         self.scratch_buffer = backend.buffer;
+        self.scratch_mask = backend.mask_buffer;
     }
 
     /// Render directly to frame (panels, overlays).
@@ -582,20 +620,16 @@ impl DrawPlanRenderer {
         component: &mut C,
         region: &RenderRegion,
     ) {
-        // Swap direct buffer out
+        // Swap direct buffer AND mask out
         let mut buffer = std::mem::replace(&mut self.direct_buffer, Buffer::empty(Rect::ZERO));
+        let mask = std::mem::take(&mut self.direct_mask);
 
-        // Resize and clear (no allocation after warmup)
         buffer.resize(area);
         buffer.reset();
 
-        // Create backend owning the buffer
-        let mut backend = RatatuiBackend::new(buffer, area);
+        let mut backend = RatatuiBackend::new(buffer, area, mask);
 
-        // Create component context
         let ctx = ComponentContext::new(true).with_screen_area(region.bounds);
-
-        // Component renders into the swapped buffer
         component.render(
             &mut backend,
             region.bounds,
@@ -603,22 +637,37 @@ impl DrawPlanRenderer {
             &mut HitboxRegistry::new(),
         );
 
-        // Blit to frame
         blit_buffer(&backend.buffer, frame.buffer_mut(), area);
 
-        // Swap buffer back to preserve capacity
         self.direct_buffer = backend.buffer;
+        self.direct_mask = backend.mask_buffer;
     }
 
-    /// Apply DIM modifier to a buffer (for unfocused windows).
-    fn apply_dim_modifier(&self, buffer: &mut Buffer) {
-        let area = buffer.area;
-        for y in area.y..area.y + area.height {
-            for x in area.x..area.x + area.width {
-                if let Some(cell) = buffer.cell_mut((x, y))
-                    && !cell.symbol().starts_with(' ')
-                {
-                    cell.modifier.insert(ratatui::style::Modifier::DIM);
+    /// Apply DIM modifier using persistent mask (no heap alloc).
+    /// Two-pass SoA bitmask pattern:
+    ///   Pass 1: Sequential AoS string check → set mask bytes
+    ///   Pass 2: Row-sliced mask apply → bitwise buffer mutation
+    fn apply_dim_modifier(buffer: &mut Buffer, mask: &mut [u8]) {
+        let active_mask = &mut mask[..buffer.content.len()];
+        active_mask.fill(0);
+
+        // Pass 1: Sequential AoS — check symbol, set mask
+        for (i, cell) in buffer.content.iter().enumerate() {
+            if !cell.symbol().starts_with(' ') {
+                active_mask[i] = 1;
+            }
+        }
+
+        // Pass 2: Row-sliced mask apply — SIMD-friendly bitwise mutation
+        let buf_w = buffer.area.width as usize;
+        let dim_bit = ratatui::style::Modifier::DIM;
+        for y in 0..buffer.area.height as usize {
+            let row_start = y * buf_w;
+            let row_slice = &mut buffer.content[row_start..row_start + buf_w];
+            let mask_slice = &active_mask[row_start..row_start + buf_w];
+            for (cell, &val) in row_slice.iter_mut().zip(mask_slice.iter()) {
+                if val == 1 {
+                    cell.modifier.insert(dim_bit);
                 }
             }
         }
@@ -632,9 +681,19 @@ impl DrawPlanRenderer {
         std::mem::replace(&mut self.scratch_buffer, Buffer::empty(Rect::ZERO))
     }
 
+    /// Take the persistent scratch mask alongside the scratch buffer.
+    pub fn take_scratch_mask(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.scratch_mask)
+    }
+
     /// Return a scratch buffer taken with `take_scratch`.
     pub fn put_scratch(&mut self, buf: Buffer) {
         self.scratch_buffer = buf;
+    }
+
+    /// Return a scratch mask taken with `take_scratch_mask`.
+    pub fn put_scratch_mask(&mut self, mask: Vec<u8>) {
+        self.scratch_mask = mask;
     }
 }
 
@@ -805,20 +864,81 @@ pub fn render_overlays<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Te
 }
 
 /// Render a drop-shadow behind a floating window or overlay.
-pub fn render_drop_shadow(buf: &mut Buffer, dest: LayoutRect, z_depth: f32, theme: &Theme) {
-    use ratatui::style::Modifier;
+/// Two-pass SoA bitmask pattern via persistent mask.
+/// Pass 1: set DIM_BIT + SHADOW_BIT in mask.
+/// Pass 2: row-sliced mask apply — SIMD-friendly bitwise mutation.
+const DIM_BIT: u8 = 0b01;
+const SHADOW_BIT: u8 = 0b10;
 
-    let shadow_color = lerp_color(theme.shadow_tint, theme.shadow_bg, z_depth).to_ratatui();
+pub fn render_drop_shadow(
+    buf: &mut Buffer,
+    mask: &mut [u8],
+    dest: LayoutRect,
+    z_depth: f32,
+    theme: &Theme,
+) {
+    let active_mask = &mut mask[..buf.content.len()];
+    active_mask.fill(0);
+
+    // Pure i32 intersection — no u16 truncation, no width anchoring
     let sx = dest.x.saturating_add(SHADOW_OFFSET_X);
     let sy = dest.y.saturating_add(SHADOW_OFFSET_Y);
     let ex = sx.saturating_add(i32::from(dest.width));
     let ey = sy.saturating_add(i32::from(dest.height));
-    for y in sy.max(0)..ey.min(buf.area.height as i32) {
-        for x in sx.max(0)..ex.min(buf.area.width as i32) {
-            if let Some(cell) = buf.cell_mut((x as u16, y as u16)) {
-                if !cell.symbol().starts_with(' ') {
-                    cell.modifier.insert(Modifier::DIM);
-                }
+
+    let buf_x = buf.area.x as i32;
+    let buf_y = buf.area.y as i32;
+    let buf_ex = buf_x + buf.area.width as i32;
+    let buf_ey = buf_y + buf.area.height as i32;
+
+    let clip_x = sx.max(buf_x);
+    let clip_y = sy.max(buf_y);
+    let clip_ex = ex.min(buf_ex);
+    let clip_ey = ey.min(buf_ey);
+
+    if clip_x >= clip_ex || clip_y >= clip_ey {
+        return;
+    }
+
+    let buf_w = buf.area.width as usize;
+    let rel_x_start = (clip_x - buf_x) as usize;
+    let copy_width = (clip_ex - clip_x) as usize;
+
+    let y_start = clip_y as usize;
+    let y_end = clip_ey as usize;
+
+    // Pass 1: Set mask bits — pre-computed start/end per row
+    for y in y_start..y_end {
+        let rel_y = y - buf.area.y as usize;
+        let row_start = rel_y * buf_w;
+        let start_idx = row_start + rel_x_start;
+        let end_idx = start_idx + copy_width;
+
+        for (i, m) in active_mask[start_idx..end_idx].iter_mut().enumerate() {
+            let cell_idx = start_idx + i;
+            *m |= SHADOW_BIT;
+            if !buf.content[cell_idx].symbol().starts_with(' ') {
+                *m |= DIM_BIT;
+            }
+        }
+    }
+
+    // Pass 2: Row-sliced mask apply
+    let shadow_color = lerp_color(theme.shadow_tint, theme.shadow_bg, z_depth).to_ratatui();
+    for y in y_start..y_end {
+        let rel_y = y - buf.area.y as usize;
+        let row_start = rel_y * buf_w;
+        let start_idx = row_start + rel_x_start;
+        let end_idx = start_idx + copy_width;
+
+        let row_slice = &mut buf.content[start_idx..end_idx];
+        let mask_slice = &active_mask[start_idx..end_idx];
+
+        for (cell, &val) in row_slice.iter_mut().zip(mask_slice.iter()) {
+            if val & DIM_BIT != 0 {
+                cell.modifier.insert(ratatui::style::Modifier::DIM);
+            }
+            if val & SHADOW_BIT != 0 {
                 cell.set_bg(shadow_color);
             }
         }
@@ -877,7 +997,7 @@ where
     let inner_bounds: LayoutRect;
     let mut chrome_registry = HitboxRegistry::new();
     {
-        let mut offscreen = RatatuiBackend::new(buffer, local_area);
+        let mut offscreen = RatatuiBackend::new_simple(buffer, local_area);
         // Atomic single-pass: draw chrome + register hitboxes + get inner bounds
         inner_bounds = render_window_chrome(
             &mut offscreen.buffer,
@@ -903,25 +1023,50 @@ where
     };
     let main_buf = &mut ratatui_backend.buffer;
     if surface.draw_shadow {
-        render_drop_shadow(main_buf, surface.dest, 1.0 - surface.z_depth, &theme);
+        // Take mask ownership to avoid borrow conflicts with main_buf
+        let mut tmp_mask = std::mem::take(&mut ratatui_backend.mask_buffer);
+        let buf_len = main_buf.content.len();
+        if tmp_mask.len() < buf_len {
+            tmp_mask.resize(buf_len, 0);
+        }
+        render_drop_shadow(
+            main_buf,
+            &mut tmp_mask[..buf_len],
+            surface.dest,
+            1.0 - surface.z_depth,
+            &theme,
+        );
+        ratatui_backend.mask_buffer = tmp_mask;
     }
+    // Compute desired destination rect and clip to main buffer
     let src_off_x = u16::try_from(-surface.dest.x.min(0)).unwrap_or(0);
     let src_off_y = u16::try_from(-surface.dest.y.min(0)).unwrap_or(0);
     let dest_x = surface.dest.x.max(0) as u16;
     let dest_y = surface.dest.y.max(0) as u16;
     let copy_w = local_area.width.saturating_sub(src_off_x);
     let copy_h = local_area.height.saturating_sub(src_off_y);
-    for y in 0..copy_h {
-        for x in 0..copy_w {
-            let dst_x = dest_x.saturating_add(x);
-            let dst_y = dest_y.saturating_add(y);
-            if let Some(src) = buffer.cell((x + src_off_x, y + src_off_y))
-                && dst_x < main_buf.area.width
-                && dst_y < main_buf.area.height
-                && let Some(dst) = main_buf.cell_mut((dst_x, dst_y))
-            {
-                *dst = src.clone();
-            }
+    let dst_area = Rect::new(dest_x, dest_y, copy_w, copy_h);
+    let dst_clip = dst_area.intersection(main_buf.area);
+    if dst_clip.width > 0 && dst_clip.height > 0 {
+        let src_clip = Rect {
+            x: src_off_x + (dst_clip.x - dest_x),
+            y: src_off_y + (dst_clip.y - dest_y),
+            width: dst_clip.width,
+            height: dst_clip.height,
+        };
+        let src_w = buffer.area.width as usize;
+        let dst_w = main_buf.area.width as usize;
+        let copy_w = dst_clip.width as usize;
+        let y_end = dst_clip.y.saturating_add(dst_clip.height);
+        for y in dst_clip.y..y_end {
+            let src_y = (y - dst_clip.y + src_clip.y) as usize;
+            let dst_y = (y - main_buf.area.y) as usize;
+            let src_x = src_clip.x as usize;
+            let dst_x = (dst_clip.x - main_buf.area.x) as usize;
+            let src_start = src_y * src_w + src_x;
+            let dst_start = dst_y * dst_w + dst_x;
+            main_buf.content[dst_start..dst_start + copy_w]
+                .clone_from_slice(&buffer.content[src_start..src_start + copy_w]);
         }
     }
     // Return the resized buffer to the caller's scratch for reuse next frame
@@ -998,8 +1143,15 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
         } else {
             outer_right
         };
-        for x in header_left..=header_right {
-            if let Some(cell) = buffer.cell_mut((x, header_y)) {
+        // Header bar fill — row-slice BCE
+        {
+            let buf_w = buffer.area.width as usize;
+            let rel_y = header_y as usize - buffer.area.y as usize;
+            let rel_x_start = header_left as usize - buffer.area.x as usize;
+            let rel_x_end = (header_right + 1) as usize - buffer.area.x as usize;
+            let row_slice =
+                &mut buffer.content[rel_y * buf_w + rel_x_start..rel_y * buf_w + rel_x_end];
+            for cell in row_slice.iter_mut() {
                 cell.set_symbol(" ");
                 cell.set_style(header_style);
             }
@@ -1008,16 +1160,20 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
         let header_width = header_right.saturating_sub(header_left).saturating_add(1);
         if title_len <= header_width {
             let start_x = header_left + (header_width - title_len) / 2;
+            let buf_w = buffer.area.width as usize;
+            let rel_y = header_y as usize - buffer.area.y as usize;
             for (idx, ch) in title.chars().enumerate() {
                 let x = start_x + idx as u16;
-                if let Some(cell) = buffer.cell_mut((x, header_y)) {
-                    cell.set_symbol(&ch.to_string());
-                    cell.set_style(header_style);
-                }
+                let rel_x = x as usize - buffer.area.x as usize;
+                let cell = &mut buffer.content[rel_y * buf_w + rel_x];
+                cell.set_symbol(&ch.to_string());
+                cell.set_style(header_style);
             }
         }
         {
             let contrast_fg = theme.menu_selected_fg.to_ratatui();
+            let buf_w = buffer.area.width as usize;
+            let rel_y = header_y as usize - buffer.area.y as usize;
             // Buttons are laid out right-to-left from outer_right
             for (i, btn) in wm_buttons.iter().enumerate() {
                 let bx = if borders_enabled {
@@ -1027,42 +1183,38 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
                 } else {
                     header_right.saturating_sub(HEADER_BUTTON_GAP * i as u16)
                 };
-                if let Some(cell) = buffer.cell_mut((bx, header_y)) {
-                    cell.set_symbol(btn.symbol);
-                    let stoplight_fg = match btn.action {
-                        TermWmAction::CloseWindow => theme.error.to_ratatui(),
-                        TermWmAction::MinimizeWindow => theme.warning.to_ratatui(),
-                        TermWmAction::MaximizeWindow => theme.accent.to_ratatui(),
-                        _ => theme.decorator_header_fg.to_ratatui(),
+                let rel_x = bx as usize - buffer.area.x as usize;
+                let cell = &mut buffer.content[rel_y * buf_w + rel_x];
+                cell.set_symbol(btn.symbol);
+                let stoplight_fg = match btn.action {
+                    TermWmAction::CloseWindow => theme.error.to_ratatui(),
+                    TermWmAction::MinimizeWindow => theme.warning.to_ratatui(),
+                    TermWmAction::MaximizeWindow => theme.accent.to_ratatui(),
+                    _ => theme.decorator_header_fg.to_ratatui(),
+                };
+                let is_hovered = hover_pos == Some((bx, header_y));
+                let style = if is_hovered {
+                    let (hover_bg, hover_fg) = match btn.action {
+                        TermWmAction::CloseWindow => (theme.error.to_ratatui(), contrast_fg),
+                        TermWmAction::MinimizeWindow => (theme.warning.to_ratatui(), contrast_fg),
+                        TermWmAction::MaximizeWindow => (theme.accent.to_ratatui(), contrast_fg),
+                        _ => (theme.accent_alt.to_ratatui(), contrast_fg),
                     };
-                    let is_hovered = hover_pos == Some((bx, header_y));
-                    let style = if is_hovered {
-                        let (hover_bg, hover_fg) = match btn.action {
-                            TermWmAction::CloseWindow => (theme.error.to_ratatui(), contrast_fg),
-                            TermWmAction::MinimizeWindow => {
-                                (theme.warning.to_ratatui(), contrast_fg)
-                            }
-                            TermWmAction::MaximizeWindow => {
-                                (theme.accent.to_ratatui(), contrast_fg)
-                            }
-                            _ => (theme.accent_alt.to_ratatui(), contrast_fg),
-                        };
-                        Style::default()
-                            .bg(hover_bg)
-                            .fg(hover_fg)
-                            .add_modifier(Modifier::BOLD)
-                    } else if matches!(btn.action, TermWmAction::ToggleDirectMode)
-                        && direct_mode
-                        && focused
-                    {
-                        Style::default()
-                            .bg(theme.decorator_header_fg.to_ratatui())
-                            .fg(theme.decorator_header_bg.to_ratatui())
-                    } else {
-                        Style::default().bg(header_bg.to_ratatui()).fg(stoplight_fg)
-                    };
-                    cell.set_style(style);
-                }
+                    Style::default()
+                        .bg(hover_bg)
+                        .fg(hover_fg)
+                        .add_modifier(Modifier::BOLD)
+                } else if matches!(btn.action, TermWmAction::ToggleDirectMode)
+                    && direct_mode
+                    && focused
+                {
+                    Style::default()
+                        .bg(theme.decorator_header_fg.to_ratatui())
+                        .fg(theme.decorator_header_bg.to_ratatui())
+                } else {
+                    Style::default().bg(header_bg.to_ratatui()).fg(stoplight_fg)
+                };
+                cell.set_style(style);
             }
         }
     }
@@ -1074,8 +1226,18 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
         } else {
             ("┌", "┐", "└", "┘")
         };
-        for x in outer_left..=outer_right {
-            if let Some(cell) = buffer.cell_mut((x, outer_top)) {
+        {
+            let buf_w = buffer.area.width as usize;
+            let rel_top = outer_top as usize - buffer.area.y as usize;
+            let rel_bottom = outer_bottom as usize - buffer.area.y as usize;
+            let rel_left = outer_left as usize - buffer.area.x as usize;
+            let rel_right = outer_right as usize - buffer.area.x as usize;
+
+            // Top border — zipped for corner symbols
+            let top_row_start = rel_top * buf_w;
+            for (x, cell) in (outer_left..=outer_right).zip(
+                buffer.content[top_row_start + rel_left..top_row_start + rel_right + 1].iter_mut(),
+            ) {
                 let sym = if x == outer_left {
                     tl
                 } else if x == outer_right {
@@ -1086,9 +1248,13 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
                 cell.set_symbol(sym);
                 cell.set_style(border_style);
             }
-        }
-        for x in outer_left..=outer_right {
-            if let Some(cell) = buffer.cell_mut((x, outer_bottom)) {
+
+            // Bottom border — zipped for corner symbols
+            let bottom_row_start = rel_bottom * buf_w;
+            for (x, cell) in (outer_left..=outer_right).zip(
+                buffer.content[bottom_row_start + rel_left..bottom_row_start + rel_right + 1]
+                    .iter_mut(),
+            ) {
                 let sym = if x == outer_left {
                     bl
                 } else if x == outer_right {
@@ -1099,15 +1265,16 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
                 cell.set_symbol(sym);
                 cell.set_style(border_style);
             }
-        }
-        for y in outer_top.saturating_add(TOP_BORDER_HEIGHT)..outer_bottom {
-            if let Some(cell) = buffer.cell_mut((outer_left, y)) {
-                cell.set_symbol("│");
-                cell.set_style(border_style);
-            }
-            if let Some(cell) = buffer.cell_mut((outer_right, y)) {
-                cell.set_symbol("│");
-                cell.set_style(border_style);
+
+            // Vertical borders — origin-translated direct index (strided, not contiguous)
+            for rel_y in (outer_top.saturating_add(TOP_BORDER_HEIGHT) as usize
+                - buffer.area.y as usize)..rel_bottom
+            {
+                let row_start = rel_y * buf_w;
+                buffer.content[row_start + rel_left].set_symbol("│");
+                buffer.content[row_start + rel_left].set_style(border_style);
+                buffer.content[row_start + rel_right].set_symbol("│");
+                buffer.content[row_start + rel_right].set_style(border_style);
             }
         }
     }
@@ -1163,37 +1330,52 @@ pub fn render_handles_masked(
         if clip.width == 0 || clip.height == 0 {
             continue;
         }
-        let h = buffer.area.height;
-        for y in clip.y..clip.y.saturating_add(clip.height) {
-            for x in clip.x..clip.x.saturating_add(clip.width) {
+        let buf_w = buffer.area.width as usize;
+        let buf_h = buffer.area.height as usize;
+        let origin_y = buffer.area.y as usize;
+        let origin_x = buffer.area.x as usize;
+        let y_end = clip.y.saturating_add(clip.height);
+        for y in clip.y..y_end {
+            let rel_y = y as usize - origin_y;
+            let row_start = rel_y * buf_w;
+            let rel_x_start = clip.x as usize - origin_x;
+            let copy_width = clip.width as usize;
+            let x_start = clip.x;
+            let x_end = clip.x + clip.width;
+            // Compute junction chars per cell (reads neighbors — can't borrow buffer.content mutably yet)
+            let mut junction_chars: Vec<&str> = Vec::with_capacity(copy_width);
+            for x in x_start..x_end {
                 if is_obscured(x, y) {
+                    junction_chars.push("");
                     continue;
                 }
-                // Precompute junction char: check neighbors for existing │
-                // (from pass 1 vertical handles) without holding a mutable borrow.
-                let ch = {
-                    let above_bar = y > 0
-                        && buffer.cell((x, y - 1)).is_some_and(|c| {
-                            let s = c.symbol();
-                            s == "│" || s == "┼" || s == "├" || s == "┤" || s == "┴" || s == "┬"
-                        });
-                    let below_bar = y < h.saturating_sub(1)
-                        && buffer.cell((x, y + 1)).is_some_and(|c| {
-                            let s = c.symbol();
-                            s == "│" || s == "┼" || s == "├" || s == "┤" || s == "┴" || s == "┬"
-                        });
-                    match (above_bar, below_bar) {
-                        (true, true) => "┼",
-                        (true, false) => "┴",
-                        (false, true) => "┬",
-                        (false, false) => "─",
-                    }
+                let rel_x = x as usize - origin_x;
+                let above_bar = rel_y > 0 && {
+                    let s = buffer.content[(rel_y - 1) * buf_w + rel_x].symbol();
+                    s == "│" || s == "┼" || s == "├" || s == "┤" || s == "┴" || s == "┬"
                 };
-                if let Some(cell) = buffer.cell_mut((x, y)) {
-                    cell.reset();
-                    cell.set_symbol(ch);
-                    cell.set_style(style);
+                let below_bar = rel_y + 1 < buf_h && {
+                    let s = buffer.content[(rel_y + 1) * buf_w + rel_x].symbol();
+                    s == "│" || s == "┼" || s == "├" || s == "┤" || s == "┴" || s == "┬"
+                };
+                let ch = match (above_bar, below_bar) {
+                    (true, true) => "┼",
+                    (true, false) => "┴",
+                    (false, true) => "┬",
+                    (false, false) => "─",
+                };
+                junction_chars.push(ch);
+            }
+            // Apply via row-slice BCE (no neighbor reads — no borrow conflict)
+            let row_slice =
+                &mut buffer.content[row_start + rel_x_start..row_start + rel_x_start + copy_width];
+            for (cell, &ch) in row_slice.iter_mut().zip(junction_chars.iter()) {
+                if ch.is_empty() {
+                    continue;
                 }
+                cell.reset();
+                cell.set_symbol(ch);
+                cell.set_style(style);
             }
         }
     }
@@ -1211,44 +1393,57 @@ pub fn render_handles_masked(
             .add_modifier(Modifier::BOLD);
         let max_x = hr.x.saturating_add(hr.width).saturating_sub(1);
         let max_y = hr.y.saturating_add(hr.height).saturating_sub(1);
-        for x in hr.x..=max_x {
-            if is_obscured(x, hr.y) {
-                continue;
-            }
-            if let Some(cell) = buffer.cell_mut((x, hr.y)) {
+        let buf_w = buffer.area.width as usize;
+        let origin_x = buffer.area.x as usize;
+        let origin_y = buffer.area.y as usize;
+        {
+            let top_rel_y = hr.y as usize - origin_y;
+            let bottom_rel_y = max_y as usize - origin_y;
+            let rel_x_start = hr.x as usize - origin_x;
+            let copy_width = (max_x - hr.x + 1) as usize;
+
+            let top_row_start = top_rel_y * buf_w + rel_x_start;
+            let bottom_row_start = bottom_rel_y * buf_w + rel_x_start;
+            for (x, cell) in (hr.x..=max_x)
+                .zip(buffer.content[top_row_start..top_row_start + copy_width].iter_mut())
+            {
+                if is_obscured(x, hr.y) {
+                    continue;
+                }
                 cell.set_symbol("-");
                 cell.set_style(border_style);
             }
-            if is_obscured(x, max_y) {
-                continue;
-            }
-            if let Some(cell) = buffer.cell_mut((x, max_y)) {
+            for (x, cell) in (hr.x..=max_x)
+                .zip(buffer.content[bottom_row_start..bottom_row_start + copy_width].iter_mut())
+            {
+                if is_obscured(x, max_y) {
+                    continue;
+                }
                 cell.set_symbol("-");
                 cell.set_style(border_style);
             }
         }
         for y in hr.y..=max_y {
+            let rel_y = y as usize - origin_y;
+            let left_idx = rel_y * buf_w + hr.x as usize - origin_x;
+            let right_idx = rel_y * buf_w + max_x as usize - origin_x;
             if is_obscured(hr.x, y) {
                 continue;
             }
-            if let Some(cell) = buffer.cell_mut((hr.x, y)) {
-                cell.set_symbol("|");
-                cell.set_style(border_style);
-            }
+            buffer.content[left_idx].set_symbol("|");
+            buffer.content[left_idx].set_style(border_style);
             if is_obscured(max_x, y) {
                 continue;
             }
-            if let Some(cell) = buffer.cell_mut((max_x, y)) {
-                cell.set_symbol("|");
-                cell.set_style(border_style);
-            }
+            buffer.content[right_idx].set_symbol("|");
+            buffer.content[right_idx].set_style(border_style);
         }
         for (cx, cy) in [(hr.x, hr.y), (max_x, hr.y), (hr.x, max_y), (max_x, max_y)] {
-            if !is_obscured(cx, cy)
-                && let Some(cell) = buffer.cell_mut((cx, cy))
-            {
-                cell.set_symbol("+");
-                cell.set_style(border_style);
+            if !is_obscured(cx, cy) {
+                let rel_cx = cx as usize - origin_x;
+                let rel_cy = cy as usize - origin_y;
+                buffer.content[rel_cy * buf_w + rel_cx].set_symbol("+");
+                buffer.content[rel_cy * buf_w + rel_cx].set_style(border_style);
             }
         }
     }
@@ -1282,16 +1477,24 @@ fn fill_handle_bar(
     if clip.width == 0 || clip.height == 0 {
         return;
     }
-    for y in clip.y..clip.y.saturating_add(clip.height) {
-        for x in clip.x..clip.x.saturating_add(clip.width) {
+    let buf_w = buffer.area.width as usize;
+    let origin_x = buffer.area.x as usize;
+    let origin_y = buffer.area.y as usize;
+    let y_end = clip.y.saturating_add(clip.height);
+    for y in clip.y..y_end {
+        let rel_y = y as usize - origin_y;
+        let row_start = rel_y * buf_w;
+        let rel_x_start = clip.x as usize - origin_x;
+        let copy_width = clip.width as usize;
+        let row_slice =
+            &mut buffer.content[row_start + rel_x_start..row_start + rel_x_start + copy_width];
+        for (x, cell) in (clip.x..clip.x + clip.width).zip(row_slice.iter_mut()) {
             if is_obscured(x, y) {
                 continue;
             }
-            if let Some(cell) = buffer.cell_mut((x, y)) {
-                cell.reset();
-                cell.set_symbol(sym);
-                cell.set_style(style);
-            }
+            cell.reset();
+            cell.set_symbol(sym);
+            cell.set_style(style);
         }
     }
 }
@@ -1387,16 +1590,23 @@ pub fn render_resize_outline(
         .fg(theme.accent_alt.to_ratatui())
         .add_modifier(Modifier::BOLD);
 
+    let buf_w = buffer.area.width as usize;
+    let origin_x = buffer.area.x as usize;
+    let origin_y = buffer.area.y as usize;
+
     let Some(edge) = target_edge else { return };
     match edge {
         ResizeEdge::Top => {
             if ry >= by && ry < by.saturating_add(bh) && rect.width > 2 {
-                for x in rx.saturating_add(1)..=right.saturating_sub(1) {
-                    if x >= bx
-                        && x < bx.saturating_add(bw)
-                        && !is_obscured(x, ry)
-                        && let Some(cell) = buffer.cell_mut((x, ry))
-                    {
+                let rel_y = ry as usize - origin_y;
+                let row_start = rel_y * buf_w;
+                let x_start = rx.saturating_add(1) as usize - origin_x;
+                let x_end = right.saturating_sub(1) as usize - origin_x + 1;
+                let row_slice = &mut buffer.content[row_start + x_start..row_start + x_end];
+                for (x, cell) in
+                    (rx.saturating_add(1)..=right.saturating_sub(1)).zip(row_slice.iter_mut())
+                {
+                    if x >= bx && x < bx.saturating_add(bw) && !is_obscured(x, ry) {
                         cell.set_symbol("═");
                         cell.set_style(style);
                     }
@@ -1405,12 +1615,15 @@ pub fn render_resize_outline(
         }
         ResizeEdge::Bottom => {
             if bottom >= by && bottom < by.saturating_add(bh) && rect.width > 2 {
-                for x in rx.saturating_add(1)..=right.saturating_sub(1) {
-                    if x >= bx
-                        && x < bx.saturating_add(bw)
-                        && !is_obscured(x, bottom)
-                        && let Some(cell) = buffer.cell_mut((x, bottom))
-                    {
+                let rel_y = bottom as usize - origin_y;
+                let row_start = rel_y * buf_w;
+                let x_start = rx.saturating_add(1) as usize - origin_x;
+                let x_end = right.saturating_sub(1) as usize - origin_x + 1;
+                let row_slice = &mut buffer.content[row_start + x_start..row_start + x_end];
+                for (x, cell) in
+                    (rx.saturating_add(1)..=right.saturating_sub(1)).zip(row_slice.iter_mut())
+                {
+                    if x >= bx && x < bx.saturating_add(bw) && !is_obscured(x, bottom) {
                         cell.set_symbol("═");
                         cell.set_style(style);
                     }
@@ -1420,11 +1633,9 @@ pub fn render_resize_outline(
         ResizeEdge::Left => {
             if rx >= bx && rx < bx.saturating_add(bw) && rect.height > 2 {
                 for y in ry.saturating_add(1)..=bottom.saturating_sub(1) {
-                    if y >= by
-                        && y < by.saturating_add(bh)
-                        && !is_obscured(rx, y)
-                        && let Some(cell) = buffer.cell_mut((rx, y))
-                    {
+                    if y >= by && y < by.saturating_add(bh) && !is_obscured(rx, y) {
+                        let cell = &mut buffer.content
+                            [(y as usize - origin_y) * buf_w + (rx as usize - origin_x)];
                         cell.set_symbol("║");
                         cell.set_style(style);
                     }
@@ -1434,11 +1645,9 @@ pub fn render_resize_outline(
         ResizeEdge::Right => {
             if right >= bx && right < bx.saturating_add(bw) && rect.height > 2 {
                 for y in ry.saturating_add(1)..=bottom.saturating_sub(1) {
-                    if y >= by
-                        && y < by.saturating_add(bh)
-                        && !is_obscured(right, y)
-                        && let Some(cell) = buffer.cell_mut((right, y))
-                    {
+                    if y >= by && y < by.saturating_add(bh) && !is_obscured(right, y) {
+                        let cell = &mut buffer.content
+                            [(y as usize - origin_y) * buf_w + (right as usize - origin_x)];
                         cell.set_symbol("║");
                         cell.set_style(style);
                     }
@@ -1446,73 +1655,61 @@ pub fn render_resize_outline(
             }
         }
         ResizeEdge::TopLeft => {
-            if rx >= bx
-                && ry >= by
-                && !is_obscured(rx, ry)
-                && let Some(cell) = buffer.cell_mut((rx, ry))
-            {
-                cell.set_symbol("╔");
-                cell.set_style(style);
+            if rx >= bx && ry >= by && !is_obscured(rx, ry) {
+                buffer.content[(ry as usize - origin_y) * buf_w + (rx as usize - origin_x)]
+                    .set_symbol("╔");
+                buffer.content[(ry as usize - origin_y) * buf_w + (rx as usize - origin_x)]
+                    .set_style(style);
             }
-            if ry >= by
-                && ry < by.saturating_add(bh)
-                && let Some(cell) = buffer.cell_mut((rx.saturating_add(1), ry))
-            {
+            if ry >= by && ry < by.saturating_add(bh) {
+                let cell = &mut buffer.content
+                    [(ry as usize - origin_y) * buf_w + ((rx as usize + 1) - origin_x)];
                 cell.set_symbol("═");
                 cell.set_style(style);
             }
-            if rx >= bx
-                && rx < bx.saturating_add(bw)
-                && let Some(cell) = buffer.cell_mut((rx, ry.saturating_add(1)))
-            {
+            if rx >= bx && rx < bx.saturating_add(bw) {
+                let cell = &mut buffer.content
+                    [((ry as usize + 1) - origin_y) * buf_w + (rx as usize - origin_x)];
                 cell.set_symbol("║");
                 cell.set_style(style);
             }
         }
         ResizeEdge::TopRight => {
-            if right < bx.saturating_add(bw)
-                && ry >= by
-                && !is_obscured(right, ry)
-                && let Some(cell) = buffer.cell_mut((right, ry))
-            {
-                cell.set_symbol("╗");
-                cell.set_style(style);
+            if right < bx.saturating_add(bw) && ry >= by && !is_obscured(right, ry) {
+                buffer.content[(ry as usize - origin_y) * buf_w + (right as usize - origin_x)]
+                    .set_symbol("╗");
+                buffer.content[(ry as usize - origin_y) * buf_w + (right as usize - origin_x)]
+                    .set_style(style);
             }
-            if ry >= by
-                && ry < by.saturating_add(bh)
-                && let Some(cell) = buffer.cell_mut((right.saturating_sub(1), ry))
-            {
+            if ry >= by && ry < by.saturating_add(bh) {
+                let cell = &mut buffer.content
+                    [(ry as usize - origin_y) * buf_w + ((right as usize - 1) - origin_x)];
                 cell.set_symbol("═");
                 cell.set_style(style);
             }
-            if right >= bx
-                && right < bx.saturating_add(bw)
-                && let Some(cell) = buffer.cell_mut((right, ry.saturating_add(1)))
-            {
+            if right >= bx && right < bx.saturating_add(bw) {
+                let cell = &mut buffer.content
+                    [((ry as usize + 1) - origin_y) * buf_w + (right as usize - origin_x)];
                 cell.set_symbol("║");
                 cell.set_style(style);
             }
         }
         ResizeEdge::BottomLeft => {
-            if rx >= bx
-                && bottom < by.saturating_add(bh)
-                && !is_obscured(rx, bottom)
-                && let Some(cell) = buffer.cell_mut((rx, bottom))
-            {
-                cell.set_symbol("╚");
-                cell.set_style(style);
+            if rx >= bx && bottom < by.saturating_add(bh) && !is_obscured(rx, bottom) {
+                buffer.content[(bottom as usize - origin_y) * buf_w + (rx as usize - origin_x)]
+                    .set_symbol("╚");
+                buffer.content[(bottom as usize - origin_y) * buf_w + (rx as usize - origin_x)]
+                    .set_style(style);
             }
-            if bottom >= by
-                && bottom < by.saturating_add(bh)
-                && let Some(cell) = buffer.cell_mut((rx.saturating_add(1), bottom))
-            {
+            if bottom >= by && bottom < by.saturating_add(bh) {
+                let cell = &mut buffer.content
+                    [(bottom as usize - origin_y) * buf_w + ((rx as usize + 1) - origin_x)];
                 cell.set_symbol("═");
                 cell.set_style(style);
             }
-            if rx >= bx
-                && rx < bx.saturating_add(bw)
-                && let Some(cell) = buffer.cell_mut((rx, bottom.saturating_sub(1)))
-            {
+            if rx >= bx && rx < bx.saturating_add(bw) {
+                let cell = &mut buffer.content
+                    [((bottom as usize - 1) - origin_y) * buf_w + (rx as usize - origin_x)];
                 cell.set_symbol("║");
                 cell.set_style(style);
             }
@@ -1521,22 +1718,21 @@ pub fn render_resize_outline(
             if right < bx.saturating_add(bw)
                 && bottom < by.saturating_add(bh)
                 && !is_obscured(right, bottom)
-                && let Some(cell) = buffer.cell_mut((right, bottom))
             {
-                cell.set_symbol("╝");
-                cell.set_style(style);
+                buffer.content[(bottom as usize - origin_y) * buf_w + (right as usize - origin_x)]
+                    .set_symbol("╝");
+                buffer.content[(bottom as usize - origin_y) * buf_w + (right as usize - origin_x)]
+                    .set_style(style);
             }
-            if bottom >= by
-                && bottom < by.saturating_add(bh)
-                && let Some(cell) = buffer.cell_mut((right.saturating_sub(1), bottom))
-            {
+            if bottom >= by && bottom < by.saturating_add(bh) {
+                let cell = &mut buffer.content
+                    [(bottom as usize - origin_y) * buf_w + ((right as usize - 1) - origin_x)];
                 cell.set_symbol("═");
                 cell.set_style(style);
             }
-            if right >= bx
-                && right < bx.saturating_add(bw)
-                && let Some(cell) = buffer.cell_mut((right, bottom.saturating_sub(1)))
-            {
+            if right >= bx && right < bx.saturating_add(bw) {
+                let cell = &mut buffer.content
+                    [((bottom as usize - 1) - origin_y) * buf_w + (right as usize - origin_x)];
                 cell.set_symbol("║");
                 cell.set_style(style);
             }
@@ -1559,55 +1755,68 @@ pub fn render_ghost_preview(buf: &mut Buffer, preview_rect: LayoutRect, theme: &
     let right = clip.x + clip.width - 1;
     let top = clip.y;
     let bottom = clip.y + clip.height - 1;
+    let buf_w = buf.area.width as usize;
+    let origin_x = buf.area.x as usize;
+    let origin_y = buf.area.y as usize;
 
-    // Corners
-    for &(pos, sym) in &[
+    // Corners — origin-translated direct index
+    for &((cx, cy), sym) in &[
         ((left, top), "┌"),
         ((right, top), "┐"),
         ((left, bottom), "└"),
         ((right, bottom), "┘"),
     ] {
-        if let Some(cell) = buf.cell_mut(pos) {
-            cell.set_symbol(sym);
-            cell.set_fg(fg_color);
-            cell.modifier.insert(Modifier::DIM);
-        }
+        let rel_x = cx as usize - origin_x;
+        let rel_y = cy as usize - origin_y;
+        let cell = &mut buf.content[rel_y * buf_w + rel_x];
+        cell.set_symbol(sym);
+        cell.set_fg(fg_color);
+        cell.modifier.insert(Modifier::DIM);
     }
 
-    // Top/bottom edges (horizontal dashes)
+    // Top/bottom edges (horizontal dashes) — row-slice BCE
     if clip.width > 2 {
-        for x in (left + 1)..right {
-            for &y in &[top, bottom] {
-                if let Some(cell) = buf.cell_mut((x, y)) {
-                    cell.set_symbol("─");
-                    cell.set_fg(fg_color);
-                    cell.modifier.insert(Modifier::DIM);
-                }
+        let rel_x_start = (left + 1) as usize - origin_x;
+        let rel_x_end = right as usize - origin_x;
+        for &y in &[top, bottom] {
+            let rel_y = y as usize - origin_y;
+            let row_start = rel_y * buf_w;
+            let row_slice = &mut buf.content[row_start + rel_x_start..row_start + rel_x_end];
+            for cell in row_slice.iter_mut() {
+                cell.set_symbol("─");
+                cell.set_fg(fg_color);
+                cell.modifier.insert(Modifier::DIM);
             }
         }
     }
 
-    // Left/right edges (vertical dashes)
+    // Left/right edges (vertical dashes) — origin-translated direct index
     if clip.height > 2 {
         for y in (top + 1)..bottom {
+            let rel_y = y as usize - origin_y;
+            let row_start = rel_y * buf_w;
             for &x in &[left, right] {
-                if let Some(cell) = buf.cell_mut((x, y)) {
-                    cell.set_symbol("│");
-                    cell.set_fg(fg_color);
-                    cell.modifier.insert(Modifier::DIM);
-                }
+                let rel_x = x as usize - origin_x;
+                let cell = &mut buf.content[row_start + rel_x];
+                cell.set_symbol("│");
+                cell.set_fg(fg_color);
+                cell.modifier.insert(Modifier::DIM);
             }
         }
     }
 
-    // Interior shade fill — pure background tint, preserves underlying text
+    // Interior shade fill — LICM-hoisted BCE row-slice iterator
     if clip.width > 2 && clip.height > 2 {
         let preview_bg = theme.accent.to_ratatui();
-        for y in (top + 1)..bottom {
-            for x in (left + 1)..right {
-                if let Some(cell) = buf.cell_mut((x, y)) {
-                    cell.set_bg(preview_bg);
-                }
+        let buf_w = buf.area.width as usize;
+        let rel_x_start = (left + 1) as usize - buf.area.x as usize;
+        let rel_x_end = right as usize - buf.area.x as usize;
+        for y in (top + 1) as usize..bottom as usize {
+            let rel_y = y - buf.area.y as usize;
+            let row_start = rel_y * buf_w;
+            let row_slice = &mut buf.content[row_start + rel_x_start..row_start + rel_x_end];
+            for cell in row_slice.iter_mut() {
+                cell.set_bg(preview_bg);
             }
         }
     }
@@ -1676,9 +1885,9 @@ pub fn render_cursor_overlay<
     }
 
     // Apply REVERSED to cell under cursor (preserves text).
-    if let Some(cell) = buf.cell_mut((hx, hy)) {
-        cell.set_style(cell.style().add_modifier(Modifier::REVERSED));
-    }
+    let buf_w = buf.area.width as usize;
+    let cell = &mut buf.content[hy as usize * buf_w + hx as usize];
+    cell.set_style(cell.style().add_modifier(Modifier::REVERSED));
 }
 
 #[cfg(test)]
@@ -1733,7 +1942,7 @@ mod tests {
         for cell in main_buffer.content.iter_mut() {
             cell.set_symbol(".");
         }
-        let mut backend = RatatuiBackend::new(main_buffer, main_area);
+        let mut backend = RatatuiBackend::new_simple(main_buffer, main_area);
 
         let surface = WindowSurface {
             full: term_wm_core::Rect {
@@ -1826,7 +2035,7 @@ mod tests {
             height: 20,
         };
         let main_buffer = Buffer::empty(main_area);
-        let mut backend = RatatuiBackend::new(main_buffer, main_area);
+        let mut backend = RatatuiBackend::new_simple(main_buffer, main_area);
 
         let surface = WindowSurface {
             full: term_wm_core::Rect {
@@ -1909,6 +2118,87 @@ mod tests {
             chrome_hb.hit_test(screen(30, 3)).is_none(),
             "click at col 30 should NOT hit the floating window (way past right edge)"
         );
+    }
+
+    // ── blit_buffer tests ────────────────────────────────────────────────
+
+    #[test]
+    fn blit_buffer_fully_contained() {
+        let mut src = Buffer::empty(RatatuiRect::new(0, 0, 80, 24));
+        let mut dst = Buffer::empty(RatatuiRect::new(0, 0, 80, 24));
+        // Fill src with a known pattern
+        for (i, cell) in src.content.iter_mut().enumerate() {
+            let ch = char::from(b'a' + (i % 26) as u8);
+            cell.set_symbol(&ch.to_string());
+        }
+        let area = RatatuiRect::new(10, 5, 30, 10);
+        blit_buffer(&src, &mut dst, area);
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                let src_cell = src.cell((x, y)).unwrap();
+                let dst_cell = dst.cell((x, y)).unwrap();
+                assert_eq!(
+                    src_cell.symbol(),
+                    dst_cell.symbol(),
+                    "cell mismatch at ({}, {})",
+                    x,
+                    y
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn blit_buffer_partial_overlap() {
+        let src = Buffer::empty(RatatuiRect::new(0, 0, 160, 48));
+        let mut dst = Buffer::empty(RatatuiRect::new(0, 0, 80, 24));
+        let before = dst.clone();
+        // Area that partially overlaps dst (extends beyond right and bottom)
+        let area = RatatuiRect::new(40, 12, 80, 24);
+        blit_buffer(&src, &mut dst, area);
+        // Cells within the clipped intersection should be copied
+        let clip = area.intersection(dst.area);
+        for y in clip.y..clip.y + clip.height {
+            for x in clip.x..clip.x + clip.width {
+                let dst_cell = dst.cell((x, y)).unwrap();
+                assert_eq!(
+                    dst_cell.symbol(),
+                    " ",
+                    "clipped cell at ({}, {}) should be empty from src",
+                    x,
+                    y
+                );
+            }
+        }
+        // Cells outside the intersection should be unchanged
+        let mut any_outside_unchanged = false;
+        for y in dst.area.y..dst.area.y + dst.area.height {
+            for x in dst.area.x..dst.area.x + dst.area.width {
+                if x >= clip.x && x < clip.x + clip.width && y >= clip.y && y < clip.y + clip.height
+                {
+                    continue;
+                }
+                let old = before.cell((x, y)).unwrap().symbol();
+                let new = dst.cell((x, y)).unwrap().symbol();
+                assert_eq!(old, new, "cell outside clip at ({}, {}) changed", x, y);
+                any_outside_unchanged = true;
+            }
+        }
+        assert!(
+            any_outside_unchanged,
+            "at least one cell should be outside the clip"
+        );
+    }
+
+    #[test]
+    fn blit_buffer_no_overlap_short_circuit() {
+        let src = Buffer::empty(RatatuiRect::new(0, 0, 80, 24));
+        let mut dst = Buffer::empty(RatatuiRect::new(0, 0, 80, 24));
+        // Area completely disjoint from both buffers
+        let area = RatatuiRect::new(200, 200, 10, 10);
+        let before = dst.clone();
+        blit_buffer(&src, &mut dst, area);
+        assert_eq!(dst, before, "no-overlap blit must not modify dst");
     }
 
     // ── render_cursor_overlay tests ──────────────────────────────────────

--- a/crates/term-wm-console/src/lib.rs
+++ b/crates/term-wm-console/src/lib.rs
@@ -10,21 +10,45 @@ pub use term_wm_render::RenderBackend;
 /// Concrete Ratatui backend implementation.
 /// Owns the Buffer by value (satisfying 'static for Any downcasting).
 /// Swap-based rendering preserves buffer capacity without allocation.
+/// Owns persistent mask_buffer for two-pass SoA rendering.
 pub struct RatatuiBackend {
     pub buffer: Buffer,
     pub area: RatatuiRect,
+    pub mask_buffer: Vec<u8>,
 }
 
 impl RenderBackend for RatatuiBackend {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
     }
+
+    fn acquire_mask(&mut self) -> &mut [u8] {
+        let needed = self.buffer.content.len();
+        if self.mask_buffer.len() < needed {
+            self.mask_buffer.resize(needed, 0);
+        }
+        &mut self.mask_buffer[..needed]
+    }
 }
 
 impl RatatuiBackend {
-    /// Create a backend owning the given buffer.
-    pub fn new(buffer: Buffer, area: RatatuiRect) -> Self {
-        Self { buffer, area }
+    /// Create a backend owning the given buffer and mask.
+    pub fn new(buffer: Buffer, area: RatatuiRect, mask_buffer: Vec<u8>) -> Self {
+        Self {
+            buffer,
+            area,
+            mask_buffer,
+        }
+    }
+
+    /// Create a backend without a persistent mask (test/component convenience).
+    /// Uses an empty Vec that will be resized on first acquire_mask() call.
+    pub fn new_simple(buffer: Buffer, area: RatatuiRect) -> Self {
+        Self {
+            buffer,
+            area,
+            mask_buffer: Vec::new(),
+        }
     }
 
     /// Get mutable reference to the underlying Ratatui buffer.

--- a/crates/term-wm-render/src/lib.rs
+++ b/crates/term-wm-render/src/lib.rs
@@ -6,7 +6,7 @@ pub trait RenderBackend: std::any::Any {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 
     /// Returns a zero-initialized persistent mask slice sized to the current buffer.
-    /// The mask is a flat Vec<u8> that decouples conditional string checks from
+    /// The mask is a flat `Vec<u8>` that decouples conditional string checks from
     /// bitwise buffer mutation — enabling SIMD-friendly two-pass rendering.
     /// Allocates only when the buffer grows; zero allocations in steady state.
     fn acquire_mask(&mut self) -> &mut [u8];

--- a/crates/term-wm-render/src/lib.rs
+++ b/crates/term-wm-render/src/lib.rs
@@ -4,6 +4,12 @@
 pub trait RenderBackend: std::any::Any {
     /// Downcast to concrete backend type.
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
+    /// Returns a zero-initialized persistent mask slice sized to the current buffer.
+    /// The mask is a flat Vec<u8> that decouples conditional string checks from
+    /// bitwise buffer mutation — enabling SIMD-friendly two-pass rendering.
+    /// Allocates only when the buffer grows; zero allocations in steady state.
+    fn acquire_mask(&mut self) -> &mut [u8];
 }
 
 /// Abstraction over the terminal output backend.

--- a/crates/term-wm-sys-ui-components/src/wm_bottom_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_bottom_panel.rs
@@ -396,7 +396,7 @@ mod tests {
         p.area = area;
         let ratatui_area = layout_rect_to_clipped_rect(area);
         let buf = Buffer::empty(ratatui_area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, ratatui_area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area);
 
         p.render_bottom_impl(&mut backend, true, &term_wm_core::theme::NOIR);
 
@@ -426,7 +426,7 @@ mod tests {
         p.area = area;
         let ratatui_area = layout_rect_to_clipped_rect(area);
         let buf = Buffer::empty(ratatui_area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, ratatui_area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area);
 
         p.render_bottom_impl(&mut backend, true, &term_wm_core::theme::NOIR);
 
@@ -476,7 +476,7 @@ mod tests {
         p.area = area;
         let ratatui_area = layout_rect_to_clipped_rect(area);
         let buf = Buffer::empty(ratatui_area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, ratatui_area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area);
 
         p.render_bottom_impl(&mut backend, true, &term_wm_core::theme::NOIR);
 

--- a/crates/term-wm-sys-ui-components/src/wm_debug_log.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_debug_log.rs
@@ -210,7 +210,7 @@ mod tests {
         };
         let ratatui_area = term_wm_ui_components::helpers::layout_rect_to_clipped_rect(area);
         let buf = ratatui::buffer::Buffer::empty(ratatui_area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, ratatui_area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area);
         {
             Component::render(
                 &mut comp,

--- a/crates/term-wm-sys-ui-components/src/wm_fab.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_fab.rs
@@ -141,7 +141,7 @@ mod tests {
 
     fn make_backend(w: u16, h: u16) -> term_wm_console::RatatuiBackend {
         let buf = Buffer::empty(ratatui::layout::Rect::new(0, 0, w, h));
-        term_wm_console::RatatuiBackend::new(buf, ratatui::layout::Rect::new(0, 0, w, h))
+        term_wm_console::RatatuiBackend::new_simple(buf, ratatui::layout::Rect::new(0, 0, w, h))
     }
 
     #[test]

--- a/crates/term-wm-sys-ui-components/src/wm_help_overlay.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_help_overlay.rs
@@ -289,7 +289,7 @@ mod tests {
             height: 24,
         };
         let buffer = Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
         {
             let layout_area = LayoutRect {
                 x: 0,

--- a/crates/term-wm-sys-ui-components/src/wm_notification.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_notification.rs
@@ -64,7 +64,7 @@ mod tests {
     fn make_backend(area: LayoutRect) -> term_wm_console::RatatuiBackend {
         let ratatui_area = term_wm_ui_components::helpers::layout_rect_to_clipped_rect(area);
         let buf = Buffer::empty(ratatui_area);
-        term_wm_console::RatatuiBackend::new(buf, ratatui_area)
+        term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area)
     }
 
     #[test]

--- a/crates/term-wm-sys-ui-components/src/wm_session_manager.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_session_manager.rs
@@ -194,7 +194,7 @@ mod tests {
 
     fn make_backend(w: u16, h: u16) -> term_wm_console::RatatuiBackend {
         let buf = Buffer::empty(ratatui::layout::Rect::new(0, 0, w, h));
-        term_wm_console::RatatuiBackend::new(buf, ratatui::layout::Rect::new(0, 0, w, h))
+        term_wm_console::RatatuiBackend::new_simple(buf, ratatui::layout::Rect::new(0, 0, w, h))
     }
 
     #[test]

--- a/crates/term-wm-sys-ui-components/src/wm_system_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_system_panel.rs
@@ -176,7 +176,8 @@ mod tests {
     fn system_panel_render_does_not_panic() {
         let mut panel = WmSystemPanelComponent::new();
         let buffer = Buffer::empty(Rect::new(0, 0, 60, 20));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 60, 20));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 60, 20));
         let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
             x: 0,
             y: 0,
@@ -250,7 +251,8 @@ mod tests {
     fn spacer_render_is_noop() {
         let mut spacer = SpacerComponent::new(3);
         let buffer = Buffer::empty(Rect::new(0, 0, 40, 10));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 10));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 10));
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         spacer.render(

--- a/crates/term-wm-sys-ui-components/src/wm_top_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_top_panel.rs
@@ -471,7 +471,7 @@ mod tests {
 
     fn make_backend(w: u16, h: u16) -> term_wm_console::RatatuiBackend {
         let buf = Buffer::empty(ratatui::layout::Rect::new(0, 0, w, h));
-        term_wm_console::RatatuiBackend::new(buf, ratatui::layout::Rect::new(0, 0, w, h))
+        term_wm_console::RatatuiBackend::new_simple(buf, ratatui::layout::Rect::new(0, 0, w, h))
     }
 
     #[test]

--- a/crates/term-wm-ui-components/src/ascii_image.rs
+++ b/crates/term-wm-ui-components/src/ascii_image.rs
@@ -672,7 +672,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -696,7 +697,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -723,7 +725,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -745,7 +748,8 @@ mod tests {
             height: 0,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 10, 10));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 10, 10));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 10, 10));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -768,7 +772,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -776,7 +781,8 @@ mod tests {
         // Render again with same area and dirty=false — should reuse cache
         img.dirty.set(false);
         let buf2 = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend2 = term_wm_console::RatatuiBackend::new(buf2, RatRect::new(0, 0, 4, 4));
+        let mut backend2 =
+            term_wm_console::RatatuiBackend::new_simple(buf2, RatRect::new(0, 0, 4, 4));
         img.render(&mut backend2, area, &ctx, &mut reg);
         assert_eq!(img.cached.borrow().len(), cache_len_1);
     }
@@ -797,7 +803,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -820,7 +827,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -843,7 +851,8 @@ mod tests {
             height: 5,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 5, 5));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 5, 5));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 5, 5));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);
@@ -864,7 +873,8 @@ mod tests {
             height: 4,
         };
         let buf = Buffer::empty(RatRect::new(0, 0, 4, 4));
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, RatRect::new(0, 0, 4, 4));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buf, RatRect::new(0, 0, 4, 4));
         let ctx = term_wm_core::components::ComponentContext::new(true);
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
         img.render(&mut backend, area, &ctx, &mut reg);

--- a/crates/term-wm-ui-components/src/button.rs
+++ b/crates/term-wm-ui-components/src/button.rs
@@ -134,7 +134,7 @@ mod tests {
 
     fn make_backend() -> term_wm_console::RatatuiBackend {
         let buffer = Buffer::empty(Rect::new(0, 0, 80, 24));
-        term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 80, 24))
+        term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 80, 24))
     }
 
     #[test]

--- a/crates/term-wm-ui-components/src/canvas_scroll_view.rs
+++ b/crates/term-wm-ui-components/src/canvas_scroll_view.rs
@@ -128,7 +128,7 @@ impl<C: Component<TermWmAction>> Component<TermWmAction> for CanvasScrollView<C>
 
         let temp_buf = std::mem::take(&mut self.offscreen_buf);
         let ratatui_area = RatatuiRect::new(0, 0, virtual_width, virtual_height);
-        let mut mock_backend = term_wm_console::RatatuiBackend::new(temp_buf, ratatui_area);
+        let mut mock_backend = term_wm_console::RatatuiBackend::new_simple(temp_buf, ratatui_area);
 
         let mut scratch_registry = HitboxRegistry::new();
         self.inner.render(

--- a/crates/term-wm-ui-components/src/center.rs
+++ b/crates/term-wm-ui-components/src/center.rs
@@ -127,7 +127,8 @@ mod tests {
     fn center_render_delegates_to_child() {
         let mut center = CenterComponent::new(DummyComponent, 10, 5);
         let buffer = Buffer::empty(Rect::new(0, 0, 80, 24));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 80, 24));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 80, 24));
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         center.render(

--- a/crates/term-wm-ui-components/src/confirm_overlay.rs
+++ b/crates/term-wm-ui-components/src/confirm_overlay.rs
@@ -428,7 +428,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -457,7 +457,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -487,7 +487,7 @@ mod tests {
             width: 2,
             height: 1,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -517,7 +517,7 @@ mod tests {
             width: 30,
             height: 8,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,

--- a/crates/term-wm-ui-components/src/dialog_overlay.rs
+++ b/crates/term-wm-ui-components/src/dialog_overlay.rs
@@ -429,7 +429,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -461,7 +461,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -490,7 +490,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -521,7 +521,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -554,7 +554,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -582,7 +582,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -609,7 +609,7 @@ mod tests {
             width: 2,
             height: 1,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,

--- a/crates/term-wm-ui-components/src/label.rs
+++ b/crates/term-wm-ui-components/src/label.rs
@@ -114,7 +114,8 @@ mod tests {
     fn label_render_writes_text() {
         let mut label = LabelComponent::new("Status");
         let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 1));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 1));
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         label.render(
@@ -141,7 +142,8 @@ mod tests {
     fn label_render_skips_when_width_zero() {
         let mut label = LabelComponent::new("X");
         let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 1));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 1));
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         label.render(
@@ -161,7 +163,8 @@ mod tests {
     fn label_render_skips_when_height_zero() {
         let mut label = LabelComponent::new("X");
         let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 1));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 1));
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         label.render(

--- a/crates/term-wm-ui-components/src/list.rs
+++ b/crates/term-wm-ui-components/src/list.rs
@@ -289,7 +289,7 @@ mod tests {
             height: area.height,
         });
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(
                 buffer,
                 ratatui::prelude::Rect {
                     x: area.x as u16,
@@ -311,7 +311,7 @@ mod tests {
                 width: area.width,
                 height: area.height,
             });
-            let mut backend = term_wm_console::RatatuiBackend::new(
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(
                 buffer,
                 ratatui::prelude::Rect {
                     x: area.x as u16,
@@ -342,7 +342,7 @@ mod tests {
             width: area.width,
             height: area.height,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: area.x as u16,
@@ -371,7 +371,7 @@ mod tests {
             width: area.width,
             height: area.height,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: area.x as u16,

--- a/crates/term-wm-ui-components/src/markdown_viewer.rs
+++ b/crates/term-wm-ui-components/src/markdown_viewer.rs
@@ -494,7 +494,7 @@ mod markdown_tests {
         };
         let scratch = Buffer::empty(area);
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(scratch, area);
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(scratch, area);
             scroll.render(
                 &mut backend,
                 LayoutRect {
@@ -511,7 +511,7 @@ mod markdown_tests {
         let mut buffer = Buffer::empty(area);
         {
             scroll.content.borrow_mut().go_end();
-            let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
             scroll.render(
                 &mut backend,
                 LayoutRect {
@@ -574,7 +574,7 @@ mod markdown_tests {
 
         let mut with_scroll = Buffer::empty(area);
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(with_scroll, area);
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(with_scroll, area);
             scroll.render(
                 &mut backend,
                 layout_area,
@@ -674,7 +674,7 @@ mod markdown_tests {
 
         let buffer = ratatui::buffer::Buffer::empty(area);
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
             scroll.render(
                 &mut backend,
                 LayoutRect {
@@ -745,7 +745,7 @@ mod markdown_tests {
 
         let mut buffer = Buffer::empty(area);
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
             scroll.render(
                 &mut backend,
                 LayoutRect {

--- a/crates/term-wm-ui-components/src/menu.rs
+++ b/crates/term-wm-ui-components/src/menu.rs
@@ -456,7 +456,7 @@ mod tests {
             height: 10,
         };
         let buf = Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, area);
         let ctx = ComponentContext::new(true);
         menu.render(
             &mut backend,

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -1304,7 +1304,7 @@ mod tests {
             height: 24,
         };
         let buffer = Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
         let ctx = make_ctx(view_offset, handle);
         term.render(
             &mut backend,
@@ -1336,7 +1336,7 @@ mod tests {
             height: 24,
         };
         let buffer = Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
         let ctx = make_ctx(view_offset, handle);
         term.render(
             &mut backend,
@@ -1502,7 +1502,7 @@ mod tests {
             height: 24,
         };
         let buffer = Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
         let ctx = make_ctx(100, handle);
         term.render(
             &mut backend,
@@ -1574,7 +1574,7 @@ mod tests {
             height: 24,
         };
         let buffer = Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
         let ctx = make_ctx(0, handle);
         term.render(
             &mut backend,
@@ -1989,7 +1989,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,
@@ -2087,7 +2087,7 @@ mod tests {
             width: 80,
             height: 24,
         });
-        let mut backend = term_wm_console::RatatuiBackend::new(
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
             buffer,
             ratatui::prelude::Rect {
                 x: 0,

--- a/crates/term-wm-ui-components/src/text_renderer.rs
+++ b/crates/term-wm-ui-components/src/text_renderer.rs
@@ -819,7 +819,7 @@ mod tests {
             height: area.height,
         });
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(
                 buffer,
                 ratatui::prelude::Rect {
                     x: area.x as u16,
@@ -898,7 +898,7 @@ mod tests {
             height: area.height,
         });
         {
-            let mut backend = term_wm_console::RatatuiBackend::new(
+            let mut backend = term_wm_console::RatatuiBackend::new_simple(
                 buffer,
                 ratatui::prelude::Rect {
                     x: area.x as u16,

--- a/crates/term-wm-ui-components/src/toggle_list.rs
+++ b/crates/term-wm-ui-components/src/toggle_list.rs
@@ -351,7 +351,8 @@ mod tests {
     fn render_empty_list() {
         let mut t = ToggleListComponent::new("empty");
         let buffer = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 40, 10));
-        let mut backend = term_wm_console::RatatuiBackend::new(buffer, Rect::new(0, 0, 40, 10));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 10));
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         t.render(

--- a/crates/term-wm-ui-components/src/vertical_stack.rs
+++ b/crates/term-wm-ui-components/src/vertical_stack.rs
@@ -304,8 +304,10 @@ mod tests {
         let mut stack = VerticalStackComponent::<FixedHeight>::new();
         stack.add(FixedHeight::new(3));
         let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 20));
-        let mut backend =
-            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 20));
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::layout::Rect::new(0, 0, 40, 20),
+        );
         let ctx = ComponentContext::new(true);
         let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
         // zero width
@@ -340,8 +342,10 @@ mod tests {
         stack.add(FixedHeight::new(3));
         stack.add(FixedHeight::new(5));
         let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 20));
-        let mut backend =
-            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 20));
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::layout::Rect::new(0, 0, 40, 20),
+        );
         let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
             x: 0,
             y: 0,
@@ -368,8 +372,10 @@ mod tests {
         stack.add(FixedHeight::new(3));
         stack.add(FixedHeight::new(0)); // height 0 = stretch
         let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 20));
-        let mut backend =
-            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 20));
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::layout::Rect::new(0, 0, 40, 20),
+        );
         let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
             x: 0,
             y: 0,
@@ -396,8 +402,10 @@ mod tests {
         stack.add(FixedHeight::new(100)); // exceeds area
         stack.add(FixedHeight::new(0));
         let buffer = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 40, 10));
-        let mut backend =
-            term_wm_console::RatatuiBackend::new(buffer, ratatui::layout::Rect::new(0, 0, 40, 10));
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::layout::Rect::new(0, 0, 40, 10),
+        );
         let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
             x: 0,
             y: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,9 +452,21 @@ pub fn render_app<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmA
         use term_wm_console::RatatuiBackend;
         if let Some(rb) = backend.as_any_mut().downcast_mut::<RatatuiBackend>() {
             let theme = wm.config().theme;
-            for (rect, z) in overlay_shadow_data(wm, area, num_windows, total) {
-                render_drop_shadow(&mut rb.buffer, rect, 1.0 - z, &theme);
+            let mut tmp_mask = std::mem::take(&mut rb.mask_buffer);
+            let buf_len = rb.buffer.content.len();
+            if tmp_mask.len() < buf_len {
+                tmp_mask.resize(buf_len, 0);
             }
+            for (rect, z) in overlay_shadow_data(wm, area, num_windows, total) {
+                render_drop_shadow(
+                    &mut rb.buffer,
+                    &mut tmp_mask[..buf_len],
+                    rect,
+                    1.0 - z,
+                    &theme,
+                );
+            }
+            rb.mask_buffer = tmp_mask;
         }
     }
     // Render overlays (command menu, help, exit confirm)

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -641,7 +641,7 @@ mod drag_snap_pipeline {
             height: AREA.height,
         };
         let buf = Buffer::empty(area);
-        let mut backend = RatatuiBackend::new(buf, area);
+        let mut backend = RatatuiBackend::new_simple(buf, area);
         render_app(&mut backend, wm, engine, renderer);
     }
 
@@ -1426,7 +1426,7 @@ mod floating_tiled_separation {
             height: AREA.height,
         };
         let buf = Buffer::empty(area);
-        let mut backend = RatatuiBackend::new(buf, area);
+        let mut backend = RatatuiBackend::new_simple(buf, area);
         render_app(&mut backend, wm, engine, renderer);
     }
 
@@ -1821,7 +1821,7 @@ mod render_verification {
             height: AREA.height,
         };
         let buf = ratatui::buffer::Buffer::empty(area);
-        let mut backend = term_wm_console::RatatuiBackend::new(buf, area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, area);
         term_wm::render_app(
             &mut backend,
             &mut wm,

--- a/tests/panic_debug_log.rs
+++ b/tests/panic_debug_log.rs
@@ -47,7 +47,7 @@ impl RenderTarget for TestOutput {
             .draw(move |frame| {
                 let area = frame.area();
                 let buffer = Buffer::empty(area);
-                let mut backend = term_wm_console::RatatuiBackend::new(buffer, area);
+                let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
                 f(&mut backend);
                 // Copy rendered buffer back to the terminal frame
                 for y in 0..area.height {


### PR DESCRIPTION
Replaces cell_mut() with direct buffer indexing across all rendering passes to eliminate per-cell bounds checks (Bounds Check Elimination).

Core changes:
- blit_buffer: intersection clipping + clone_from_slice for row-aligned bulk copies (avoids 2×W×H bounds checks per window composite)
- layout_rect_to_clipped_rect: proportional truncation subtracts negative coordinate overflow from width/height (fixes phantom column anchoring)
- render_drop_shadow: pure i32 intersection math — width derived from clip_ex - clip_x, not original unbounded extent (fixes shadow stretch defect when windows move left of origin)

Infrastructure:
- RenderBackend trait: acquire_mask(&mut self) -> &mut [u8] for persistent SoA mask exposure
- RatatuiBackend: mask_buffer: Vec<u8> with swap-based lifecycle (zero allocations in steady state)
- DrawPlanRenderer: scratch_mask + direct_mask alongside scratch/direct buffers with full swap-and-reclaim semantics

Two-pass SoA mask pattern (uniform modifiers):
- apply_dim_modifier: DIM_BIT via Vec<u8> mask → decouples conditional string check from bitwise mutation
- render_drop_shadow: DIM_BIT | SHADOW_BIT via mask → row-sliced zipping

Single-pass BCE slice iteration (structured geometry):
- render_window: row-slice for header/border fills, origin-translated direct index for vertical borders, title, buttons
- fill_handle_bar: zipped occlusion probing + row-slice BCE
- render_handles_masked: origin-translated boundary-guarded neighbor reads for junction chars; zipped occlusion for hover borders
- render_resize_outline: row-slice BCE for horizontal edges, direct index for vertical edges, occlusion guards before memory access
- render_ghost_preview: LICM-hoisted BCE row-slice for interior fill
- render_cursor_overlay: origin-translated direct index

Test coverage:
- blit_buffer: fully contained, partial overlap, no-overlap short-circuit
- 18 total tests pass in term-wm-console (3 new)

Constructor migration:
- RatatuiBackend::new_simple() for test/component call sites (44 sites across 15 files) — avoids Vec::new() boilerplate

Fixes: Shadow stretch regression when window is moved partially off-screen