### PR TITLE
perf: Eliminate idle wakeups and heap allocations in session client and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,6 +2980,7 @@ name = "term-session-client"
 version = "0.8.20-alpha"
 dependencies = [
  "clap",
+ "crossbeam-channel",
  "crossterm",
  "libc",
  "muxio-core",

--- a/crates/term-session-client/Cargo.toml
+++ b/crates/term-session-client/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
+crossbeam-channel = { workspace = true }
 crossterm = { workspace = true, features = ["bracketed-paste"] }
 libc = { workspace = true }
 muxio-core = { workspace = true }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -309,7 +309,9 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
 
                         // Non-blocking push; if saturated, sleep 1ms to allow
                         // the main loop to drain the channel without CPU spinning.
-                        while let Err(crossbeam_channel::TrySendError::Full(pending)) = push_tx.try_send(data) {
+                        while let Err(crossbeam_channel::TrySendError::Full(pending)) =
+                            push_tx.try_send(data)
+                        {
                             data = pending;
                             tokio::time::sleep(Duration::from_millis(1)).await;
                         }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -21,12 +21,11 @@ use portable_pty::PtySize;
 use term_session_muxio_service_definitions::{
     STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, Spawn,
 };
-use term_wm_core::events::{Event, KeyKind};
+use term_wm_core::events::{Event, KeyKind, MouseEventKind};
 use term_wm_pty_engine::Pane;
 use term_wm_pty_engine::clipboard::{Clipboard, Osc52Extractor};
 use term_wm_pty_engine::input_encoding::{key_to_bytes, mouse_event_to_bytes};
 use term_wm_pty_engine::signal::install_sigint_handler;
-use tokio::sync::mpsc;
 use vt100::{MouseProtocolEncoding, MouseProtocolMode};
 
 /// Redirect an OS-level file descriptor (stdout or stderr) into `tracing`.
@@ -129,6 +128,109 @@ impl<W: Write> Drop for TerminalGuard<W> {
     }
 }
 
+/// Convert a crossterm event into a core Event for use in the event-driven loop.
+fn convert_crossterm_event(evt: crossterm::event::Event) -> Option<Event> {
+    use term_wm_core::events::KeyCode;
+    match evt {
+        crossterm_event::Event::Key(key) => Some(Event::Key(term_wm_core::events::KeyEvent {
+            code: match key.code {
+                crossterm_event::KeyCode::Char(c) => KeyCode::Char(c),
+                crossterm_event::KeyCode::Enter => KeyCode::Enter,
+                crossterm_event::KeyCode::Tab => KeyCode::Tab,
+                crossterm_event::KeyCode::Backspace => KeyCode::Backspace,
+                crossterm_event::KeyCode::Esc => KeyCode::Esc,
+                crossterm_event::KeyCode::Left => KeyCode::Left,
+                crossterm_event::KeyCode::Right => KeyCode::Right,
+                crossterm_event::KeyCode::Up => KeyCode::Up,
+                crossterm_event::KeyCode::Down => KeyCode::Down,
+                crossterm_event::KeyCode::Home => KeyCode::Home,
+                crossterm_event::KeyCode::End => KeyCode::End,
+                crossterm_event::KeyCode::PageUp => KeyCode::PageUp,
+                crossterm_event::KeyCode::PageDown => KeyCode::PageDown,
+                crossterm_event::KeyCode::Delete => KeyCode::Delete,
+                crossterm_event::KeyCode::Insert => KeyCode::Insert,
+                crossterm_event::KeyCode::F(n) => KeyCode::F(n),
+                _ => return None,
+            },
+            modifiers: term_wm_core::events::KeyModifiers {
+                shift: key.modifiers.contains(crossterm_event::KeyModifiers::SHIFT),
+                control: key
+                    .modifiers
+                    .contains(crossterm_event::KeyModifiers::CONTROL),
+                alt: key.modifiers.contains(crossterm_event::KeyModifiers::ALT),
+            },
+            kind: match key.kind {
+                crossterm_event::KeyEventKind::Press => KeyKind::Press,
+                crossterm_event::KeyEventKind::Repeat => KeyKind::Repeat,
+                crossterm_event::KeyEventKind::Release => KeyKind::Release,
+            },
+        })),
+        crossterm_event::Event::Mouse(mouse) => {
+            Some(Event::Mouse(term_wm_core::events::MouseEvent {
+                kind: match mouse.kind {
+                    crossterm_event::MouseEventKind::Down(btn) => {
+                        MouseEventKind::Press(match btn {
+                            crossterm_event::MouseButton::Left => {
+                                term_wm_core::events::MouseButton::Left
+                            }
+                            crossterm_event::MouseButton::Right => {
+                                term_wm_core::events::MouseButton::Right
+                            }
+                            crossterm_event::MouseButton::Middle => {
+                                term_wm_core::events::MouseButton::Middle
+                            }
+                        })
+                    }
+                    crossterm_event::MouseEventKind::Up(btn) => {
+                        MouseEventKind::Release(match btn {
+                            crossterm_event::MouseButton::Left => {
+                                term_wm_core::events::MouseButton::Left
+                            }
+                            crossterm_event::MouseButton::Right => {
+                                term_wm_core::events::MouseButton::Right
+                            }
+                            crossterm_event::MouseButton::Middle => {
+                                term_wm_core::events::MouseButton::Middle
+                            }
+                        })
+                    }
+                    crossterm_event::MouseEventKind::Drag(btn) => MouseEventKind::Drag(match btn {
+                        crossterm_event::MouseButton::Left => {
+                            term_wm_core::events::MouseButton::Left
+                        }
+                        crossterm_event::MouseButton::Right => {
+                            term_wm_core::events::MouseButton::Right
+                        }
+                        crossterm_event::MouseButton::Middle => {
+                            term_wm_core::events::MouseButton::Middle
+                        }
+                    }),
+                    crossterm_event::MouseEventKind::Moved => MouseEventKind::Moved,
+                    crossterm_event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
+                    crossterm_event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
+                    crossterm_event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
+                    crossterm_event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
+                },
+                modifiers: term_wm_core::events::KeyModifiers {
+                    shift: mouse
+                        .modifiers
+                        .contains(crossterm_event::KeyModifiers::SHIFT),
+                    control: mouse
+                        .modifiers
+                        .contains(crossterm_event::KeyModifiers::CONTROL),
+                    alt: mouse.modifiers.contains(crossterm_event::KeyModifiers::ALT),
+                },
+                column: mouse.column,
+                row: mouse.row,
+            }))
+        }
+        crossterm_event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
+        crossterm_event::Event::FocusGained => Some(Event::FocusGained),
+        crossterm_event::Event::FocusLost => Some(Event::FocusLost),
+        crossterm_event::Event::Paste(text) => Some(Event::Paste(text)),
+    }
+}
+
 /// Connect to a term-session-server and run the TUI viewer.
 ///
 /// This function is synchronous. It creates a background tokio runtime
@@ -149,11 +251,10 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
         .block_on(RpcIpcClient::new(socket_path))
         .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, format!("{e:?}")))?;
 
-    // Channel for raw PTY output bytes from the subscription stream
-    let (push_tx, push_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-
-    // Side-channel for intercepted OSC 52 clipboard text
-    let (clip_tx, mut clip_rx) = mpsc::unbounded_channel::<String>();
+    // Channels for raw PTY output bytes and clipboard text from the subscription stream.
+    // Using crossbeam so the main loop can block on both input and PTY output.
+    let (push_tx, push_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+    let (clip_tx, clip_rx) = crossbeam_channel::unbounded::<String>();
 
     // Get terminal size
     let (term_cols, term_rows) = crossterm::terminal::size()?;
@@ -175,7 +276,7 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
             .map_err(|e| io::Error::other(format!("subscribe: {e:?}")))?;
 
         // Forward response chunks to push_tx.  When the stream ends
-        // (session exits), push_tx is dropped, and `drain_pushes`
+        // (session exits), the sender is dropped, and `drain_pushes`
         // detects the disconnect.
         // Intercept OSC 52 clipboard sequences from the raw byte stream
         // before the VT100 parser can consume them.
@@ -224,11 +325,11 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
 
     let mut pane = RemotePane::new(
         1u64,
-        client.clone(),
+        Some(client.clone()),
         rt.handle().clone(),
         term_cols,
         term_rows,
-        push_rx,
+        push_rx.clone(),
         input_writer,
     );
 
@@ -252,6 +353,32 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
     let mut clipboard = Clipboard::new();
     let sigint = install_sigint_handler()?;
 
+    // Channel for crossterm input events from a background thread
+    let (input_tx, input_rx) = crossbeam_channel::unbounded::<Event>();
+
+    // Spawn background crossterm input thread.
+    // Uses poll(50ms) so the thread can detect disconnection and exit
+    // promptly when run_session terminates.
+    std::thread::Builder::new()
+        .name("crossterm-input".into())
+        .spawn(move || {
+            loop {
+                match crossterm::event::poll(Duration::from_millis(50)) {
+                    Ok(true) => {
+                        if let Ok(crossterm_evt) = crossterm::event::read()
+                            && let Some(e) = convert_crossterm_event(crossterm_evt)
+                            && input_tx.send(e).is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(false) => continue,
+                    Err(_) => break,
+                }
+            }
+        })
+        .map_err(|e| io::Error::other(format!("spawn input thread: {e}")))?;
+
     // Initial full screen render
     {
         let parser = pane.shared_parser();
@@ -263,160 +390,55 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
     }
 
     let mut prev_content: Option<Vec<u8>> = None;
+    let mut prev_parser: Option<vt100::Parser> = None;
 
     loop {
-        let frame_start = std::time::Instant::now();
-
-        // Drain pushes from the server (this updates the parser)
-        pane.drain_pushes();
-
-        // Detect screen changes
-        let current_content = {
-            let parser = pane.shared_parser();
-            let parser = parser.lock().unwrap();
-            parser.screen().contents_formatted()
+        // Block until either user input or PTY output arrives (0 CPU when idle)
+        let input_event = crossbeam_channel::select! {
+            recv(input_rx) -> msg => {
+                match msg {
+                    Ok(evt) => Some(evt),
+                    Err(_) => return Err(io::Error::other("input thread died")),
+                }
+            }
+            recv(push_rx) -> msg => {
+                match msg {
+                    Ok(data) => {
+                        // PTY output — process directly into parser
+                        let shared = pane.shared_parser();
+                        let mut parser = shared.lock().unwrap();
+                        parser.process(&data);
+                        None
+                    }
+                    Err(_) => {
+                        // push channel disconnected → will be detected
+                        // by drain_pushes() below
+                        None
+                    }
+                }
+            }
         };
-        let has_new_data = prev_content.as_deref() != Some(&current_content);
 
-        // Drain any clipboard texts intercepted by the reader task
+        // Drain any additional buffered PTY data
+        let has_new_data = pane.drain_pushes() || input_event.is_none();
+
+        // Drain clipboard
         while let Ok(text) = clip_rx.try_recv() {
             let _ = clipboard.set(&text);
         }
 
-        // Check connection health
-        if !client.is_connected() {
-            return Err(io::Error::other("connection to session server lost"));
-        }
-
-        // Drain SIGINT (Ctrl-C) — send 0x03 through the input stream
+        // Handle SIGINT
         if sigint.received() {
             sigint.ack();
             let _ = pane.write_bytes(&[0x03]);
         }
 
-        // Poll input with a short timeout
-        let had_input = if crossterm_event::poll(Duration::from_millis(4))? {
-            let crossterm_evt = crossterm_event::read()?;
-            // Convert crossterm event to core-owned event
-            let evt = match crossterm_evt {
-                crossterm_event::Event::Key(key) => Event::Key(term_wm_core::events::KeyEvent {
-                    code: match key.code {
-                        crossterm_event::KeyCode::Char(c) => term_wm_core::events::KeyCode::Char(c),
-                        crossterm_event::KeyCode::Enter => term_wm_core::events::KeyCode::Enter,
-                        crossterm_event::KeyCode::Tab => term_wm_core::events::KeyCode::Tab,
-                        crossterm_event::KeyCode::Backspace => {
-                            term_wm_core::events::KeyCode::Backspace
-                        }
-                        crossterm_event::KeyCode::Esc => term_wm_core::events::KeyCode::Esc,
-                        crossterm_event::KeyCode::Left => term_wm_core::events::KeyCode::Left,
-                        crossterm_event::KeyCode::Right => term_wm_core::events::KeyCode::Right,
-                        crossterm_event::KeyCode::Up => term_wm_core::events::KeyCode::Up,
-                        crossterm_event::KeyCode::Down => term_wm_core::events::KeyCode::Down,
-                        crossterm_event::KeyCode::Home => term_wm_core::events::KeyCode::Home,
-                        crossterm_event::KeyCode::End => term_wm_core::events::KeyCode::End,
-                        crossterm_event::KeyCode::PageUp => term_wm_core::events::KeyCode::PageUp,
-                        crossterm_event::KeyCode::PageDown => {
-                            term_wm_core::events::KeyCode::PageDown
-                        }
-                        crossterm_event::KeyCode::Delete => term_wm_core::events::KeyCode::Delete,
-                        crossterm_event::KeyCode::Insert => term_wm_core::events::KeyCode::Insert,
-                        crossterm_event::KeyCode::F(n) => term_wm_core::events::KeyCode::F(n),
-                        _ => continue,
-                    },
-                    modifiers: term_wm_core::events::KeyModifiers {
-                        shift: key.modifiers.contains(crossterm_event::KeyModifiers::SHIFT),
-                        control: key
-                            .modifiers
-                            .contains(crossterm_event::KeyModifiers::CONTROL),
-                        alt: key.modifiers.contains(crossterm_event::KeyModifiers::ALT),
-                    },
-                    kind: match key.kind {
-                        crossterm_event::KeyEventKind::Press => KeyKind::Press,
-                        crossterm_event::KeyEventKind::Repeat => KeyKind::Repeat,
-                        crossterm_event::KeyEventKind::Release => KeyKind::Release,
-                    },
-                }),
-                crossterm_event::Event::Mouse(mouse) => {
-                    Event::Mouse(term_wm_core::events::MouseEvent {
-                        kind: match mouse.kind {
-                            crossterm_event::MouseEventKind::Down(btn) => {
-                                term_wm_core::events::MouseEventKind::Press(match btn {
-                                    crossterm_event::MouseButton::Left => {
-                                        term_wm_core::events::MouseButton::Left
-                                    }
-                                    crossterm_event::MouseButton::Right => {
-                                        term_wm_core::events::MouseButton::Right
-                                    }
-                                    crossterm_event::MouseButton::Middle => {
-                                        term_wm_core::events::MouseButton::Middle
-                                    }
-                                })
-                            }
-                            crossterm_event::MouseEventKind::Up(btn) => {
-                                term_wm_core::events::MouseEventKind::Release(match btn {
-                                    crossterm_event::MouseButton::Left => {
-                                        term_wm_core::events::MouseButton::Left
-                                    }
-                                    crossterm_event::MouseButton::Right => {
-                                        term_wm_core::events::MouseButton::Right
-                                    }
-                                    crossterm_event::MouseButton::Middle => {
-                                        term_wm_core::events::MouseButton::Middle
-                                    }
-                                })
-                            }
-                            crossterm_event::MouseEventKind::Drag(btn) => {
-                                term_wm_core::events::MouseEventKind::Drag(match btn {
-                                    crossterm_event::MouseButton::Left => {
-                                        term_wm_core::events::MouseButton::Left
-                                    }
-                                    crossterm_event::MouseButton::Right => {
-                                        term_wm_core::events::MouseButton::Right
-                                    }
-                                    crossterm_event::MouseButton::Middle => {
-                                        term_wm_core::events::MouseButton::Middle
-                                    }
-                                })
-                            }
-                            crossterm_event::MouseEventKind::Moved => {
-                                term_wm_core::events::MouseEventKind::Moved
-                            }
-                            crossterm_event::MouseEventKind::ScrollUp => {
-                                term_wm_core::events::MouseEventKind::ScrollUp
-                            }
-                            crossterm_event::MouseEventKind::ScrollDown => {
-                                term_wm_core::events::MouseEventKind::ScrollDown
-                            }
-                            crossterm_event::MouseEventKind::ScrollLeft => {
-                                term_wm_core::events::MouseEventKind::ScrollLeft
-                            }
-                            crossterm_event::MouseEventKind::ScrollRight => {
-                                term_wm_core::events::MouseEventKind::ScrollRight
-                            }
-                        },
-                        modifiers: term_wm_core::events::KeyModifiers {
-                            shift: mouse
-                                .modifiers
-                                .contains(crossterm_event::KeyModifiers::SHIFT),
-                            control: mouse
-                                .modifiers
-                                .contains(crossterm_event::KeyModifiers::CONTROL),
-                            alt: mouse.modifiers.contains(crossterm_event::KeyModifiers::ALT),
-                        },
-                        column: mouse.column,
-                        row: mouse.row,
-                    })
-                }
-                crossterm_event::Event::Resize(w, h) => Event::Resize(w, h),
-                crossterm_event::Event::FocusGained => Event::FocusGained,
-                crossterm_event::Event::FocusLost => Event::FocusLost,
-                crossterm_event::Event::Paste(text) => Event::Paste(text),
-            };
+        // Handle the input event (if any)
+        if let Some(evt) = input_event {
             match evt {
                 Event::Key(ref key)
                     if key.kind == KeyKind::Press || key.kind == KeyKind::Repeat =>
                 {
-                    // Convert core-owned KeyEvent to pty-engine KeyEvent
                     let pty_key = term_wm_pty_engine::input_encoding::KeyEvent {
                         code: match key.code {
                             term_wm_core::events::KeyCode::Char(c) => {
@@ -479,7 +501,6 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                     if !bytes.is_empty() {
                         let _ = pane.write_bytes(&bytes);
                     }
-                    true
                 }
                 Event::Mouse(ref mouse) => {
                     let mouse_active = {
@@ -488,7 +509,6 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                         parser.screen().mouse_protocol_mode() != MouseProtocolMode::None
                     };
                     if mouse_active {
-                        // Convert core-owned MouseEvent to pty-engine MouseEvent
                         let pty_mouse = term_wm_pty_engine::input_encoding::MouseEvent {
                             kind: match mouse.kind {
                                 term_wm_core::events::MouseEventKind::Press(btn) => term_wm_pty_engine::input_encoding::MouseEventKind::Press(match btn {
@@ -525,7 +545,6 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                             let _ = pane.write_bytes(&bytes);
                         }
                     }
-                    mouse_active
                 }
                 Event::Resize(w, h) => {
                     let size = PtySize {
@@ -536,20 +555,22 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                     };
                     prev_content = None;
                     let _ = pane.resize(size);
-                    true
                 }
                 Event::Paste(text) => {
-                    let mut wrapped = b"\x1b[200~".to_vec();
+                    let mut wrapped = Vec::with_capacity(text.len() + 12);
+                    wrapped.extend_from_slice(b"\x1b[200~");
                     wrapped.extend_from_slice(text.as_bytes());
                     wrapped.extend_from_slice(b"\x1b[201~");
                     let _ = pane.write_bytes(&wrapped);
-                    true
                 }
-                _ => false,
+                _ => {}
             }
-        } else {
-            false
-        };
+        }
+
+        // Connection health — check after wakeup
+        if !client.is_connected() {
+            return Err(io::Error::other("connection to session server lost"));
+        }
 
         // Diff-based incremental render
         if has_new_data || prev_content.is_none() {
@@ -560,9 +581,11 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
 
             let diff = match &prev_content {
                 Some(prev) => {
-                    let mut prev_parser = vt100::Parser::new(rows, cols, 0);
-                    prev_parser.process(prev);
-                    screen.contents_diff(prev_parser.screen())
+                    let p = prev_parser.get_or_insert_with(|| vt100::Parser::new(rows, cols, 0));
+                    p.screen_mut().set_size(rows, cols);
+                    p.process(b"\x1bc");
+                    p.process(prev);
+                    screen.contents_diff(p.screen())
                 }
                 None => screen.contents_formatted(),
             };
@@ -578,14 +601,6 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
         // Exit on session exit
         if pane.has_exited() {
             return Ok(());
-        }
-
-        // Pace the loop
-        if !has_new_data && !had_input {
-            let elapsed = frame_start.elapsed();
-            if elapsed < Duration::from_millis(8) {
-                std::thread::sleep(Duration::from_millis(8) - elapsed);
-            }
         }
     }
 }
@@ -678,6 +693,37 @@ mod tests {
                 .windows(b"\x1b[?2004l".len())
                 .any(|w| w == b"\x1b[?2004l"),
             "init/teardown roundtrip must contain disable \\x1b[?2004l"
+        );
+    }
+
+    /// Proves that reusing a parser via set_size + RIS + process yields
+    /// identical screen state to a freshly allocated parser.
+    #[test]
+    fn test_prev_parser_resize_sync_matches_fresh_parser() {
+        let mut prev_parser = vt100::Parser::new(24, 80, 0);
+        prev_parser.process(b"initial screen content");
+
+        // Simulate terminal window resize to 40x120
+        let (new_rows, new_cols) = (40, 120);
+        let new_formatted_content = {
+            let mut p = vt100::Parser::new(new_rows, new_cols, 0);
+            p.process(b"resized screen content");
+            p.screen().contents_formatted().to_vec()
+        };
+
+        // Re-use prev_parser using dimension sync + RIS reset
+        prev_parser.screen_mut().set_size(new_rows, new_cols);
+        prev_parser.process(b"\x1bc");
+        prev_parser.process(&new_formatted_content);
+
+        // Verify against a freshly created parser
+        let mut fresh_parser = vt100::Parser::new(new_rows, new_cols, 0);
+        fresh_parser.process(&new_formatted_content);
+
+        assert_eq!(
+            prev_parser.screen().contents_formatted(),
+            fresh_parser.screen().contents_formatted(),
+            "Reused parser state after set_size + RIS must match fresh parser"
         );
     }
 }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -85,6 +85,13 @@ const INITIAL_WAIT_ITERS: usize = 60;
 #[cfg(not(target_os = "windows"))]
 const INITIAL_WAIT_ITERS: usize = 20;
 
+/// Maximum buffered PTY output frames before backpressure kicks in.
+const PTY_OUTPUT_CHANNEL_CAPACITY: usize = 256;
+/// Maximum buffered clipboard events (human-driven, small capacity is fine).
+const CLIPBOARD_CHANNEL_CAPACITY: usize = 64;
+/// Maximum buffered input events (covers paste bursts without over-allocating).
+const INPUT_CHANNEL_CAPACITY: usize = 64;
+
 /// Initialize terminal for TUI mode: write startup escape sequences
 /// (alternate screen, hide cursor, bracketed paste, mouse capture) to
 /// the given writer, enable raw mode on stdin, and return a guard that
@@ -253,8 +260,9 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
 
     // Channels for raw PTY output bytes and clipboard text from the subscription stream.
     // Using crossbeam so the main loop can block on both input and PTY output.
-    let (push_tx, push_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
-    let (clip_tx, clip_rx) = crossbeam_channel::unbounded::<String>();
+    // Bounded to cap head-of-line queuing under burst load.
+    let (push_tx, push_rx) = crossbeam_channel::bounded::<Vec<u8>>(PTY_OUTPUT_CHANNEL_CAPACITY);
+    let (clip_tx, clip_rx) = crossbeam_channel::bounded::<String>(CLIPBOARD_CHANNEL_CAPACITY);
 
     // Get terminal size
     let (term_cols, term_rows) = crossterm::terminal::size()?;
@@ -286,9 +294,9 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
 
             while let Some(chunk) = reader.recv().await {
                 match chunk {
-                    Ok(data) => {
+                    Ok(mut data) => {
                         if let Some(text) = osc52.push(&data, &prev_tail) {
-                            let _ = clip_tx.send(text);
+                            let _ = clip_tx.try_send(text);
                         }
 
                         let n = data.len();
@@ -299,7 +307,12 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                             prev_tail[8 - n..].copy_from_slice(&data[..n]);
                         }
 
-                        let _ = push_tx.send(data);
+                        // Non-blocking push; if saturated, sleep 1ms to allow
+                        // the main loop to drain the channel without CPU spinning.
+                        while let Err(crossbeam_channel::TrySendError::Full(pending)) = push_tx.try_send(data) {
+                            data = pending;
+                            tokio::time::sleep(Duration::from_millis(1)).await;
+                        }
                     }
                     Err(_) => break,
                 }
@@ -354,7 +367,7 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
     let sigint = install_sigint_handler()?;
 
     // Channel for crossterm input events from a background thread
-    let (input_tx, input_rx) = crossbeam_channel::unbounded::<Event>();
+    let (input_tx, input_rx) = crossbeam_channel::bounded::<Event>(INPUT_CHANNEL_CAPACITY);
 
     // Spawn background crossterm input thread.
     // Uses poll(50ms) so the thread can detect disconnection and exit

--- a/crates/term-session-client/src/remote_pane.rs
+++ b/crates/term-session-client/src/remote_pane.rs
@@ -2,35 +2,34 @@ use std::cell::Cell;
 use std::io;
 use std::sync::{Arc, Mutex};
 
+use crossbeam_channel::{Receiver, TryRecvError};
 use muxio_rpc_service::error::RpcServiceError;
 use muxio_tokio_rpc_ipc_client::RpcIpcClient;
 use portable_pty::{ExitStatus, PtySize};
 use term_session_muxio_service_definitions::{CloseSession, ResizePty};
 use term_wm_pty_engine::{Pane, PtyResult};
 use tokio::runtime::Handle;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TryRecvError;
 
 type InputWriter = Box<dyn FnMut(&[u8]) -> io::Result<()> + Send>;
 
 pub struct RemotePane {
     pub id: u64,
-    client: std::sync::Arc<RpcIpcClient>,
+    client: Option<std::sync::Arc<RpcIpcClient>>,
     rt: Handle,
     parser: Arc<Mutex<vt100::Parser>>,
     exited: Cell<bool>,
-    push_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    push_rx: Receiver<Vec<u8>>,
     input_writer: InputWriter,
 }
 
 impl RemotePane {
     pub fn new(
         id: u64,
-        client: std::sync::Arc<RpcIpcClient>,
+        client: Option<std::sync::Arc<RpcIpcClient>>,
         rt: Handle,
         cols: u16,
         rows: u16,
-        push_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        push_rx: Receiver<Vec<u8>>,
         input_writer: InputWriter,
     ) -> Self {
         Self {
@@ -44,12 +43,16 @@ impl RemotePane {
         }
     }
 
-    pub fn drain_pushes(&mut self) {
+    /// Drain pushes from the server, updating the parser.
+    /// Returns `true` if at least one chunk was processed (screen may have changed).
+    pub fn drain_pushes(&mut self) -> bool {
+        let mut updated = false;
         loop {
             match self.push_rx.try_recv() {
                 Ok(data) => {
                     let mut parser = self.parser.lock().unwrap();
                     parser.process(&data);
+                    updated = true;
                 }
                 Err(TryRecvError::Disconnected) => {
                     self.exited.set(true);
@@ -58,6 +61,7 @@ impl RemotePane {
                 Err(TryRecvError::Empty) => break,
             }
         }
+        updated
     }
 
     fn rpc_to_pty<E: std::fmt::Display>(e: E) -> Box<dyn std::error::Error + Send + Sync> {
@@ -71,15 +75,18 @@ impl Pane for RemotePane {
     }
 
     fn resize(&mut self, size: PtySize) -> PtyResult<()> {
-        let result: Result<(), RpcServiceError> = self.rt.block_on(async {
-            use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
-            ResizePty::call(&*self.client, (self.id, size.cols, size.rows)).await
-        });
+        if let Some(ref client) = self.client {
+            let result: Result<(), RpcServiceError> = self.rt.block_on(async {
+                use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+                ResizePty::call(&**client, (self.id, size.cols, size.rows)).await
+            });
+            result.map_err(Self::rpc_to_pty)?;
+        }
         {
             let mut parser = self.parser.lock().unwrap();
             parser.screen_mut().set_size(size.rows, size.cols);
         }
-        result.map_err(Self::rpc_to_pty)
+        Ok(())
     }
 
     fn has_exited(&mut self) -> bool {
@@ -126,17 +133,46 @@ impl Pane for RemotePane {
     }
 
     fn kill_child(&mut self) -> PtyResult<()> {
-        self.rt
-            .block_on(async {
-                use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
-                CloseSession::call(&*self.client, self.id).await
-            })
-            .map_err(Self::rpc_to_pty)?;
+        if let Some(ref client) = self.client {
+            self.rt
+                .block_on(async {
+                    use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+                    CloseSession::call(&**client, self.id).await
+                })
+                .map_err(Self::rpc_to_pty)?;
+        }
         self.exited.set(true);
         Ok(())
     }
 
     fn take_pending_title(&mut self) -> Option<String> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_drain_pushes_returns_dirty_flag() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let (push_tx, push_rx) = crossbeam_channel::unbounded();
+        let input_writer: InputWriter = Box::new(|_| Ok(()));
+
+        let mut pane = RemotePane::new(1, None, rt.handle().clone(), 80, 24, push_rx, input_writer);
+
+        // 1. Idle call with no pending messages must return false
+        assert!(!pane.drain_pushes());
+
+        // 2. Ingesting bytes must return true
+        push_tx.send(b"hello world".to_vec()).unwrap();
+        assert!(pane.drain_pushes());
+
+        // 3. Subsequent call on drained buffer must return false
+        assert!(!pane.drain_pushes());
     }
 }

--- a/crates/term-session-server/src/session.rs
+++ b/crates/term-session-server/src/session.rs
@@ -1,5 +1,5 @@
 use portable_pty::{CommandBuilder, PtySize};
-use term_wm_pty_engine::{Pty, PtyResult};
+use term_wm_pty_engine::{Pty, PtyResult, PtyStatus};
 
 pub struct Session {
     pub id: u64,
@@ -91,5 +91,9 @@ impl Session {
 
     pub fn generate_snapshot(&mut self) -> Vec<u8> {
         self.pty.generate_snapshot()
+    }
+
+    pub fn set_status_callback(&mut self, cb: Option<Box<dyn Fn(PtyStatus) + Send + Sync>>) {
+        self.pty.set_status_callback(cb);
     }
 }

--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use muxio_core::rpc::rpc_internals::RpcStreamEvent;
 use muxio_rpc_service::prebuffered::RpcMethodPrebuffered;
 use muxio_rpc_service_endpoint::{RpcServiceEndpointInterface, StreamResponder};
 use muxio_tokio_rpc_ipc_server::{RpcIpcServer, RpcIpcServerEvent};
 use portable_pty::PtySize;
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{Mutex, Notify, mpsc, oneshot};
 
 use term_session_muxio_service_definitions::{
     CloseSession, ListSessions, ResizePty, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID,
     Spawn, WriteInput,
 };
+use term_wm_pty_engine::PtyStatus;
 
 use crate::session::Session;
 
@@ -35,15 +35,51 @@ struct ServerState {
     session: Option<Session>,
     clients: Vec<ClientEntry>,
     subscribers: Vec<SubscriberEntry>,
+    notify: Arc<Notify>,
 }
 
 impl ServerState {
-    fn new() -> Self {
+    fn new(notify: Arc<Notify>) -> Self {
         Self {
             session: None,
             clients: Vec::new(),
             subscribers: Vec::new(),
+            notify,
         }
+    }
+
+    /// Replace the current session and attach the Notify callback
+    /// so the background polling task is woken on PTY output.
+    fn set_session(&mut self, mut session: Session) {
+        let n = self.notify.clone();
+        session.set_status_callback(Some(Box::new(move |status| {
+            if matches!(status, PtyStatus::Wakeup | PtyStatus::Exited) {
+                n.notify_one();
+            }
+        })));
+        self.session = Some(session);
+        // Prime notify to process initial startup output generated
+        // before the callback was registered.
+        self.notify.notify_one();
+    }
+
+    /// Terminate and clear the active session, flushing remaining PTY buffers
+    /// and stream completion markers to all active subscribers.
+    fn clear_session(&mut self) {
+        if let Some(mut session) = self.session.take() {
+            let _ = session.pty.kill_child();
+            let raw = session.read_output();
+            if !raw.is_empty() {
+                for sub in &self.subscribers {
+                    sub.respond.respond(raw.clone(), false);
+                }
+            }
+        }
+        for sub in &self.subscribers {
+            sub.respond.respond(Vec::new(), true);
+        }
+        self.subscribers.clear();
+        self.notify.notify_one();
     }
 }
 
@@ -53,7 +89,8 @@ type SharedState = Arc<Mutex<ServerState>>;
 pub async fn run_server(
     config: SessionServerConfig,
 ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
-    let state: SharedState = Arc::new(Mutex::new(ServerState::new()));
+    let notify = Arc::new(Notify::new());
+    let state: SharedState = Arc::new(Mutex::new(ServerState::new(notify.clone())));
 
     // Spawn initial session
     {
@@ -64,7 +101,7 @@ pub async fn run_server(
             Some(config.cmd.clone())
         };
         let session = Session::spawn(1, cmd, config.cols, config.rows)?;
-        st.session = Some(session);
+        st.set_session(session);
     }
 
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
@@ -102,7 +139,7 @@ pub async fn run_server(
 
                 let id = 1;
                 let session = Session::spawn(id, cmd, cols, rows)?;
-                guard.session = Some(session);
+                guard.set_session(session);
                 Spawn::encode_response(id)
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
             }
@@ -144,10 +181,7 @@ pub async fn run_server(
                 let _id = CloseSession::decode_request(&payload)
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
                 let mut guard = state.lock().await;
-                if let Some(session) = guard.session.as_mut() {
-                    let _ = session.pty.kill_child();
-                }
-                guard.session = None;
+                guard.clear_session();
                 CloseSession::encode_response(())
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
             }
@@ -243,6 +277,10 @@ pub async fn run_server(
                         respond: respond.clone(),
                     });
 
+                    // Wake the polling loop — the session may have pending
+                    // output or exit state that needs processing.
+                    guard.notify.notify_one();
+
                     drop(guard);
 
                     if let Some(data) = snapshot
@@ -282,26 +320,28 @@ pub async fn run_server(
         }
     });
 
-    // Output polling and push via stored StreamResponders.
+    // Output polling via Notify — blocks until PTY produces output.
     // When the session exits, the exit code is sent back through this
     // channel so run_server can return it.
     let (exit_tx, mut exit_rx) = oneshot::channel::<i32>();
     let st = Arc::clone(&state);
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_millis(8));
         loop {
-            interval.tick().await;
+            // Block until PTY actually produces output — 0 wakeups when idle
+            notify.notified().await;
 
             let mut guard = st.lock().await;
 
             if guard.subscribers.is_empty() {
                 if let Some(session) = guard.session.as_mut() {
+                    // No subscribers — drain dirty flag to keep reader budget flowing
                     session.sync_screen();
                 }
                 continue;
             }
 
             let Some(session) = guard.session.as_mut() else {
+                let _ = exit_tx.send(0);
                 break;
             };
 


### PR DESCRIPTION
Convert both client and server loops from timer-based polling to event-driven blocking, eliminating ~125 Hz idle wakeups. Fix server output truncation on session teardown and client allocation hot-paths.

term-session-client (~330 lines changed):
  - Add crossbeam-channel dependency. Replace tokio::sync::mpsc for PTY output (push_rx) and clipboard (clip_rx) so the main loop can block on both input and PTY channels simultaneously.
  - Extract convert_crossterm_event() as a standalone function (previously inline in the poll/read loop).
  - Spawn a background crossterm input thread (50ms poll interval) that terminates cleanly when run_session drops the receiver.
  - Replace 4ms poll + 8ms sleep main loop with crossbeam_channel::select! — thread parks with 0 CPU until EITHER user input OR PTY output arrives.
  - drain_pushes() returns bool dirty-flag; contents_formatted() is only called when data actually arrived (eliminates ~125 heap allocs/sec on idle).
  - Hoist prev_parser and reuse across frames via set_size() + RIS (\x1bc) reset instead of allocating a fresh vt100::Parser on every diff (eliminates per-frame parser heap allocation).
  - Pre-allocate paste buffer with Vec::with_capacity.
  - RemotePane::new() accepts Option<Arc<RpcIpcClient>> so unit tests pass None without Unix socket bindings — removes #[cfg(unix)] gate from test_drain_pushes_returns_dirty_flag.
  - Add test_prev_parser_resize_sync_matches_fresh_parser.

term-session-server (~65 lines changed):
  - Add Session::set_status_callback() passthrough.
  - Store tokio::sync::Notify in ServerState.
  - Add ServerState::set_session() — registers a PtyStatus callback that wakes the Notify on Wakeup/Exited, and primes the Notify for startup output produced before registration.
  - Add ServerState::clear_session() — takes ownership of the session, kills child, drains pending output via read_output(), broadcasts remaining bytes and stream-completion markers to subscribers, then wakes the polling loop.
  - Replace 8ms tokio::time::interval loop with notify.notified().await (zero wakeups when idle).
  - CloseSession handler uses clear_session() instead of inline kill + session = None (fixes deadlock where polling loop parked forever after session teardown).
  - SubscribeOutput handler wakes polling loop via guard.notify.notify_one() so pending exit/output is processed when the first subscriber connects.
  - Remove unused std::time::Duration import.

Closes deadlock where ::close_session left the background task permanently parked on notify.notified().await. Closes data loss where session teardown dropped the Pty without draining trailing output bytes.