### PR TITLE
fix: Render initial frame before event loop, fix FramePacer clock capture, add regression test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1817,7 +1817,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2583,7 +2583,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2701,6 +2701,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2847,7 +2872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2962,7 +2987,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3046,6 +3071,7 @@ dependencies = [
  "portable-pty",
  "proptest",
  "ratatui",
+ "serial_test",
  "tempfile",
  "term-session-client",
  "term-session-muxio-service-definitions",
@@ -3184,7 +3210,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3946,7 +3972,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ proptest = "1.11.0"
 pulldown-cmark = "0.13.0"
 ratatui = "0.30.0"
 resvg = "0.47.0"
+serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
@@ -97,7 +98,6 @@ required-features = ["sys-ui"]
 [features]
 default = ["sys-ui"]
 sys-ui = ["dep:term-wm-sys-ui-components"]
-
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 crossbeam-channel = { workspace = true }
@@ -127,6 +127,7 @@ muxio-rpc-service = { workspace = true }
 muxio-tokio-mpsc-adapter = { workspace = true }
 muxio-tokio-rpc-ipc-client = { workspace = true }
 proptest = { workspace = true }
+serial_test = { workspace = true }
 tempfile = { workspace = true }
 term-session-client = { path = "crates/term-session-client" }
 term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions" }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -243,6 +243,32 @@ where
     event_loop
         .driver()
         .set_mouse_capture(app.wm().mouse_capture_enabled())?;
+
+    // ── Initial pre-loop render ──────────────────────────────────────
+    //
+    // Render the initial frame unconditionally before entering the event
+    // loop.  The FramePacer cannot produce the first frame: on the very
+    // first handler(None) call, notify_pending() sets a deadline 16ms
+    // in the future, and try_expire() checks the same instant — so the
+    // deadline is always too far ahead.  Without this pre-loop render,
+    // input-driven sources (ConsoleEventSource, test mocks) would park
+    // in PowerSaver and never draw until a hardware interrupt arrives.
+    //
+    // The catch_unwind boundary is required because some components or
+    // tests intentionally panic on frame zero (e.g. render_panic test).
+    // Without it, an uncaught panic would abort the process or skip the
+    // event loop entirely.  On panic, repair() restores the terminal so
+    // the loop can continue with a clean slate on the next frame.
+    app.wm().begin_frame();
+    app.wm().prepare_draw();
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        output.draw(|frame| draw(frame, app))
+    }))
+    .is_err()
+    {
+        output.repair()?;
+    }
+
     event_loop.run(|driver, event| {
         let handler = || -> io::Result<ControlFlow> {
             // Process expired system tasks (super-passthrough, drag-snap)
@@ -336,7 +362,6 @@ where
             };
             let mut did_panic = false;
             let mut did_render = false;
-            let now = Instant::now();
             if let Some(evt) = event {
                 // Synthesized key event from bottom-panel hint click takes priority
                 let evt = app.wm().take_synthetic_event().unwrap_or(evt);
@@ -553,10 +578,21 @@ where
                 }
                 update_selection_snapshot(app);
 
+                // ── FramePacer arm ────────────────────────────────────
+                //
+                // Each call to notify_pending / try_expire / time_until_
+                // deadline passes a fresh Instant::now().  DO NOT capture
+                // `let now = Instant::now()` at the top of the handler and
+                // reuse it — notify_pending(now) sets deadline = now+16ms,
+                // and try_expire(now) checks the same `now` against it.
+                // The deadline would always be 16ms in the future and
+                // try_expire would never return true, spinning the loop
+                // at max speed until ~16ms of wall time passes.
+                //
                 // Arm the pacer when any component requested a redraw or the
                 // driver has background work (PTY data) that bypassed Some(evt).
                 if driver.take_redraw_request() || driver_has_work {
-                    frame_pacer.notify_pending(now);
+                    frame_pacer.notify_pending(Instant::now());
                 }
 
                 frame_pacer.set_interval(if app.wm().is_dragging_window() {
@@ -565,11 +601,23 @@ where
                     Duration::from_millis(16) // 60 FPS otherwise
                 });
 
-                if frame_pacer.try_expire(now) {
-                    // Gate BOTH frame init AND render together so the
-                    // HitboxRegistry survives between frames.  Running
-                    // begin_frame() without output.draw() would clear
-                    // hitboxes on every idle tick, making clicks vanish.
+                if frame_pacer.try_expire(Instant::now()) {
+                    // ── Frame render gate ─────────────────────────────
+                    //
+                    // begin_frame() clears the HitboxRegistry.  prepare_
+                    // draw() prepares layout state.  output.draw() re-
+                    // populates the HitboxRegistry during the component
+                    // traversal.  All three must execute together —
+                    // running begin_frame() without output.draw() would
+                    // empty the registry on every idle tick, making every
+                    // click and drag fall through to the background.
+                    //
+                    // The did_render flag gates take_dirty_windows() in
+                    // flush_state_changes.  If try_expire() returns false
+                    // and we skip the draw, dirty windows must NOT be
+                    // consumed — otherwise the EventSource drops to
+                    // PowerSaver (3600s poll) and sleeps through the
+                    // next FramePacer deadline.
                     app.wm().begin_frame();
                     app.wm().prepare_draw();
                     // Catch render panics (e.g. u16 subtraction overflow with a
@@ -597,7 +645,7 @@ where
                 driver,
                 ControlFlow::Continue,
                 did_render && !did_panic,
-                frame_pacer.time_until_deadline(now),
+                frame_pacer.time_until_deadline(Instant::now()),
             )
         };
 
@@ -1345,5 +1393,89 @@ mod power_calibration_tests {
 
         let second = EventSource::take_dirty_windows(&mut driver);
         assert!(second.is_empty(), "dirty keys must drain between cycles");
+    }
+
+    /// Minimal backend that satisfies the RenderBackend trait.
+    struct MockBackend;
+    impl term_wm_render::RenderBackend for MockBackend {
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+        fn acquire_mask(&mut self) -> &mut [u8] {
+            &mut []
+        }
+    }
+
+    /// Minimal output that runs the draw closure without a real terminal.
+    struct NoopOutput;
+    impl RenderTarget for NoopOutput {
+        fn enter(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+        fn exit(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+        fn draw<F>(&mut self, f: F) -> io::Result<()>
+        where
+            F: FnOnce(&mut dyn term_wm_render::RenderBackend),
+        {
+            f(&mut MockBackend);
+            Ok(())
+        }
+    }
+
+    /// App that quits after exactly one draw.
+    struct QuitOnFirstDraw<C: Component<TermWmAction>> {
+        wm: WindowManager<C, crate::components::NoopWmComponent, crate::components::NoopOverlay>,
+        draws: usize,
+    }
+    impl<C: Component<TermWmAction>>
+        WindowManagerHost<C, crate::components::NoopWmComponent, crate::components::NoopOverlay>
+        for QuitOnFirstDraw<C>
+    {
+        fn wm(
+            &mut self,
+        ) -> &mut WindowManager<C, crate::components::NoopWmComponent, crate::components::NoopOverlay>
+        {
+            &mut self.wm
+        }
+        fn quit_requested(&self) -> bool {
+            self.draws >= 1
+        }
+    }
+
+    #[test]
+    fn initial_render_fires_before_event_loop() {
+        let mut wm = crate::window::WindowManager::<crate::components::NoopComponent>::with_config(
+            crate::wm_config::WmConfig::default(),
+            std::sync::Arc::new(crate::app_context::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        wm.create_window(crate::components::NoopComponent);
+        let mut app = QuitOnFirstDraw { wm, draws: 0 };
+        let mut output = NoopOutput;
+        let mut driver = SpyEventSource {
+            captured_max_sleep: None,
+            mock_dirty_windows: std::collections::HashSet::new(),
+        };
+
+        let result = run_event_loop(
+            &mut output,
+            &mut driver,
+            &mut app,
+            crate::task_scheduler::TaskScheduler::<crate::actions::SystemTask>::new(),
+            |k| k,
+            |_backend, app| {
+                app.draws += 1;
+            },
+        );
+
+        assert!(result.is_ok(), "run_event_loop should return Ok");
+        assert_eq!(
+            app.draws, 1,
+            "draw must fire from pre-loop initial render (FramePacer never armed)"
+        );
     }
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -1,5 +1,6 @@
 use muxio_tokio_mpsc_adapter::ChannelCallerExt;
 use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+use serial_test::serial;
 use std::time::Duration;
 use term_session_muxio_service_definitions::{
     CloseSession, ListSessions, ResizePty, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID,
@@ -136,7 +137,9 @@ async fn session_osc52_in_output() {
     );
 }
 
+// Note: [serial] was added due to some Windows flakiness
 #[tokio::test]
+#[serial]
 async fn session_osc52_via_osc52extractor() {
     let mock = get_mock_bin();
     let (client, _dir) = spawn_session(vec![mock, "osc52".into()], TEST_COLS, TEST_ROWS).await;
@@ -231,7 +234,9 @@ async fn session_close_session() {
     assert!(sessions.is_empty(), "Session should be removed after close");
 }
 
+// Note: [serial] was added due to some Windows flakiness
 #[tokio::test]
+#[serial]
 async fn session_child_exit() {
     let mock = get_mock_bin();
     let (client, _dir) =

--- a/tests/panic_debug_log.rs
+++ b/tests/panic_debug_log.rs
@@ -75,7 +75,23 @@ impl RenderTarget for TestOutput {
 struct ImmediateDriver;
 
 impl EventSource for ImmediateDriver {
-    fn poll(&mut self, _timeout: Duration) -> io::Result<bool> {
+    // ── Mock poll with real-time blocking ───────────────────────────
+    //
+    // Block for the requested timeout so the FramePacer deadline has
+    // time to expire between handler iterations.  Without this sleep,
+    // poll() returns Ok(false) instantly and the event loop spins at
+    // max speed — the 16ms between notify_pending() and try_expire()
+    // never passes in wall time, try_expire() always returns false,
+    // the render never fires, and the test deadlocks.
+    //
+    // This mirrors what crossterm::event::poll(timeout) does at the
+    // OS level: block until either an event arrives or the timeout
+    // expires.  Zero-length timeouts (used in the inner drain loop)
+    // return immediately.
+    fn poll(&mut self, timeout: Duration) -> io::Result<bool> {
+        if !timeout.is_zero() {
+            std::thread::sleep(timeout);
+        }
         Ok(false)
     }
 
@@ -192,7 +208,14 @@ struct WakeupDriver {
 }
 
 impl EventSource for WakeupDriver {
-    fn poll(&mut self, _: Duration) -> io::Result<bool> {
+    // ── Mock poll with real-time blocking ───────────────────────────
+    // Same rationale as ImmediateDriver::poll: without blocking for the
+    // timeout the loop spins, the FramePacer deadline never expires in
+    // wall time, and try_expire() deadlocks.
+    fn poll(&mut self, timeout: Duration) -> io::Result<bool> {
+        if !timeout.is_zero() {
+            std::thread::sleep(timeout);
+        }
         Ok(false)
     }
     fn read(&mut self) -> io::Result<Event> {


### PR DESCRIPTION
fix: render initial frame before event loop, fix FramePacer clock capture, add regression test

Three interrelated fixes for the FramePacer integration:

1. Pre-loop initial render The FramePacer cannot produce the first frame: on the very first handler(None) call, notify_pending() sets a deadline 16ms in the future, and try_expire() checks the same instant — the deadline is always too far ahead.  Input-driven sources (ConsoleEventSource, test mocks) would park in PowerSaver and never draw until a hardware interrupt arrives.

   Fix: render unconditionally before entering the event loop, with the full frame lifecycle (begin_frame + prepare_draw + draw). Wrapped in catch_unwind + repair() so tests that intentionally panic on frame zero (render_panic test) don't abort the process.

2. FramePacer clock capture The handler captured `let now = Instant::now()` once and reused it for notify_pending(), try_expire(), and time_until_deadline(). Since notify_pending(now) sets deadline = now + 16ms and try_expire(now) checks the same now against it, the deadline was always 16ms in the future — try_expire() never returned true, causing the event loop to spin at max speed until ~16ms of wall time passed.

   Fix: pass a fresh Instant::now() at each call site.  The delta between arming and checking is now real wall time, so the pacer fires at the correct interval on the first attempt.

3. Mock driver poll blocking Both ImmediateDriver and WakeupDriver returned Ok(false) instantly from poll(), ignoring the timeout.  The event loop spun at max speed — the FramePacer deadline never expired in wall time, and try_expire() deadlocked.

   Fix: block for the requested timeout via std::thread::sleep(). Zero-length timeouts (inner drain loop) return immediately.

Also adds a regression test (initial_render_fires_before_event_loop) that proves the draw fires from the pre-loop render even with a SpyEventSource that never arms the FramePacer (PowerSaver profile, no redraw requests).