### PR TITLE
refactor: Unify keyboard event translation into term-wm-crossterm-adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,6 +3017,7 @@ dependencies = [
  "portable-pty",
  "term-session-muxio-service-definitions",
  "term-wm-core",
+ "term-wm-crossterm-adapter",
  "term-wm-pty-engine",
  "tokio",
  "tracing",
@@ -3078,6 +3079,7 @@ dependencies = [
  "term-session-server",
  "term-wm-console",
  "term-wm-core",
+ "term-wm-crossterm-adapter",
  "term-wm-layout-engine",
  "term-wm-pty-engine",
  "term-wm-render",
@@ -3099,6 +3101,7 @@ dependencies = [
  "libc",
  "ratatui",
  "term-wm-core",
+ "term-wm-crossterm-adapter",
  "term-wm-layout-engine",
  "term-wm-pty-engine",
  "term-wm-render",
@@ -3123,6 +3126,14 @@ dependencies = [
  "term-wm-render",
  "textwrap",
  "tracing",
+]
+
+[[package]]
+name = "term-wm-crossterm-adapter"
+version = "0.8.20-alpha"
+dependencies = [
+ "crossterm",
+ "term-wm-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/term-session-server",
     "crates/term-wm-console",
     "crates/term-wm-core",
+    "crates/term-wm-crossterm-adapter",
     "crates/term-wm-layout-engine",
     "crates/term-wm-pty-engine",
     "crates/term-wm-render",
@@ -77,6 +78,7 @@ term-session-server = { path = "crates/term-session-server", version = "0.8.20-a
 term-wm = { path = ".", version = "0.8.20-alpha" }
 term-wm-console = { path = "crates/term-wm-console", version = "0.8.20-alpha" }
 term-wm-core = { path = "crates/term-wm-core", version = "0.8.20-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.8.20-alpha" }
 term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.8.20-alpha" }
 term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.8.20-alpha" }
 term-wm-render = { path = "crates/term-wm-render", version = "0.8.20-alpha" }
@@ -109,6 +111,7 @@ portable-pty = { workspace = true }
 ratatui = { workspace = true }
 term-wm-console = { workspace = true }
 term-wm-core = { workspace = true }
+term-wm-crossterm-adapter = { workspace = true }
 term-wm-layout-engine = { workspace = true }
 term-wm-pty-engine = { workspace = true }
 term-wm-render = { workspace = true }

--- a/crates/term-session-client/Cargo.toml
+++ b/crates/term-session-client/Cargo.toml
@@ -22,6 +22,7 @@ muxio-tokio-rpc-ipc-client = { workspace = true }
 portable-pty = { workspace = true }
 term-session-muxio-service-definitions = { workspace = true }
 term-wm-core = { workspace = true }
+term-wm-crossterm-adapter = { workspace = true }
 term-wm-pty-engine = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 
 use crossterm::QueueableCommand;
 use crossterm::cursor::{Hide, Show};
-use crossterm::event as crossterm_event;
 use crossterm::event::{DisableBracketedPaste, EnableBracketedPaste};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -21,10 +20,10 @@ use portable_pty::PtySize;
 use term_session_muxio_service_definitions::{
     STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, Spawn,
 };
-use term_wm_core::events::{Event, KeyKind, MouseEventKind};
+use term_wm_core::events::{Event, KeyKind};
 use term_wm_pty_engine::Pane;
 use term_wm_pty_engine::clipboard::{Clipboard, Osc52Extractor};
-use term_wm_pty_engine::input_encoding::{key_to_bytes, mouse_event_to_bytes};
+use term_wm_pty_engine::input_encoding::mouse_event_to_bytes;
 use term_wm_pty_engine::signal::install_sigint_handler;
 use vt100::{MouseProtocolEncoding, MouseProtocolMode};
 
@@ -137,105 +136,7 @@ impl<W: Write> Drop for TerminalGuard<W> {
 
 /// Convert a crossterm event into a core Event for use in the event-driven loop.
 fn convert_crossterm_event(evt: crossterm::event::Event) -> Option<Event> {
-    use term_wm_core::events::KeyCode;
-    match evt {
-        crossterm_event::Event::Key(key) => Some(Event::Key(term_wm_core::events::KeyEvent {
-            code: match key.code {
-                crossterm_event::KeyCode::Char(c) => KeyCode::Char(c),
-                crossterm_event::KeyCode::Enter => KeyCode::Enter,
-                crossterm_event::KeyCode::Tab => KeyCode::Tab,
-                crossterm_event::KeyCode::Backspace => KeyCode::Backspace,
-                crossterm_event::KeyCode::Esc => KeyCode::Esc,
-                crossterm_event::KeyCode::Left => KeyCode::Left,
-                crossterm_event::KeyCode::Right => KeyCode::Right,
-                crossterm_event::KeyCode::Up => KeyCode::Up,
-                crossterm_event::KeyCode::Down => KeyCode::Down,
-                crossterm_event::KeyCode::Home => KeyCode::Home,
-                crossterm_event::KeyCode::End => KeyCode::End,
-                crossterm_event::KeyCode::PageUp => KeyCode::PageUp,
-                crossterm_event::KeyCode::PageDown => KeyCode::PageDown,
-                crossterm_event::KeyCode::Delete => KeyCode::Delete,
-                crossterm_event::KeyCode::Insert => KeyCode::Insert,
-                crossterm_event::KeyCode::F(n) => KeyCode::F(n),
-                _ => return None,
-            },
-            modifiers: term_wm_core::events::KeyModifiers {
-                shift: key.modifiers.contains(crossterm_event::KeyModifiers::SHIFT),
-                control: key
-                    .modifiers
-                    .contains(crossterm_event::KeyModifiers::CONTROL),
-                alt: key.modifiers.contains(crossterm_event::KeyModifiers::ALT),
-            },
-            kind: match key.kind {
-                crossterm_event::KeyEventKind::Press => KeyKind::Press,
-                crossterm_event::KeyEventKind::Repeat => KeyKind::Repeat,
-                crossterm_event::KeyEventKind::Release => KeyKind::Release,
-            },
-        })),
-        crossterm_event::Event::Mouse(mouse) => {
-            Some(Event::Mouse(term_wm_core::events::MouseEvent {
-                kind: match mouse.kind {
-                    crossterm_event::MouseEventKind::Down(btn) => {
-                        MouseEventKind::Press(match btn {
-                            crossterm_event::MouseButton::Left => {
-                                term_wm_core::events::MouseButton::Left
-                            }
-                            crossterm_event::MouseButton::Right => {
-                                term_wm_core::events::MouseButton::Right
-                            }
-                            crossterm_event::MouseButton::Middle => {
-                                term_wm_core::events::MouseButton::Middle
-                            }
-                        })
-                    }
-                    crossterm_event::MouseEventKind::Up(btn) => {
-                        MouseEventKind::Release(match btn {
-                            crossterm_event::MouseButton::Left => {
-                                term_wm_core::events::MouseButton::Left
-                            }
-                            crossterm_event::MouseButton::Right => {
-                                term_wm_core::events::MouseButton::Right
-                            }
-                            crossterm_event::MouseButton::Middle => {
-                                term_wm_core::events::MouseButton::Middle
-                            }
-                        })
-                    }
-                    crossterm_event::MouseEventKind::Drag(btn) => MouseEventKind::Drag(match btn {
-                        crossterm_event::MouseButton::Left => {
-                            term_wm_core::events::MouseButton::Left
-                        }
-                        crossterm_event::MouseButton::Right => {
-                            term_wm_core::events::MouseButton::Right
-                        }
-                        crossterm_event::MouseButton::Middle => {
-                            term_wm_core::events::MouseButton::Middle
-                        }
-                    }),
-                    crossterm_event::MouseEventKind::Moved => MouseEventKind::Moved,
-                    crossterm_event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
-                    crossterm_event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
-                    crossterm_event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
-                    crossterm_event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
-                },
-                modifiers: term_wm_core::events::KeyModifiers {
-                    shift: mouse
-                        .modifiers
-                        .contains(crossterm_event::KeyModifiers::SHIFT),
-                    control: mouse
-                        .modifiers
-                        .contains(crossterm_event::KeyModifiers::CONTROL),
-                    alt: mouse.modifiers.contains(crossterm_event::KeyModifiers::ALT),
-                },
-                column: mouse.column,
-                row: mouse.row,
-            }))
-        }
-        crossterm_event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
-        crossterm_event::Event::FocusGained => Some(Event::FocusGained),
-        crossterm_event::Event::FocusLost => Some(Event::FocusLost),
-        crossterm_event::Event::Paste(text) => Some(Event::Paste(text)),
-    }
+    term_wm_crossterm_adapter::try_translate_event(evt)
 }
 
 /// Connect to a term-session-server and run the TUI viewer.
@@ -454,65 +355,7 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                 Event::Key(ref key)
                     if key.kind == KeyKind::Press || key.kind == KeyKind::Repeat =>
                 {
-                    let pty_key = term_wm_pty_engine::input_encoding::KeyEvent {
-                        code: match key.code {
-                            term_wm_core::events::KeyCode::Char(c) => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Char(c)
-                            }
-                            term_wm_core::events::KeyCode::Enter => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Enter
-                            }
-                            term_wm_core::events::KeyCode::Tab => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Tab
-                            }
-                            term_wm_core::events::KeyCode::Backspace => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Backspace
-                            }
-                            term_wm_core::events::KeyCode::Esc => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Esc
-                            }
-                            term_wm_core::events::KeyCode::Left => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Left
-                            }
-                            term_wm_core::events::KeyCode::Right => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Right
-                            }
-                            term_wm_core::events::KeyCode::Up => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Up
-                            }
-                            term_wm_core::events::KeyCode::Down => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Down
-                            }
-                            term_wm_core::events::KeyCode::Home => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Home
-                            }
-                            term_wm_core::events::KeyCode::End => {
-                                term_wm_pty_engine::input_encoding::KeyCode::End
-                            }
-                            term_wm_core::events::KeyCode::PageUp => {
-                                term_wm_pty_engine::input_encoding::KeyCode::PageUp
-                            }
-                            term_wm_core::events::KeyCode::PageDown => {
-                                term_wm_pty_engine::input_encoding::KeyCode::PageDown
-                            }
-                            term_wm_core::events::KeyCode::Delete => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Delete
-                            }
-                            term_wm_core::events::KeyCode::Insert => {
-                                term_wm_pty_engine::input_encoding::KeyCode::Insert
-                            }
-                            term_wm_core::events::KeyCode::F(n) => {
-                                term_wm_pty_engine::input_encoding::KeyCode::F(n)
-                            }
-                            _ => continue,
-                        },
-                        modifiers: term_wm_pty_engine::input_encoding::KeyModifiers {
-                            shift: key.modifiers.shift,
-                            control: key.modifiers.control,
-                            alt: key.modifiers.alt,
-                        },
-                    };
-                    let bytes = key_to_bytes(&pty_key);
+                    let bytes = key.to_pty_bytes();
                     if !bytes.is_empty() {
                         let _ = pane.write_bytes(&bytes);
                     }

--- a/crates/term-wm-console/Cargo.toml
+++ b/crates/term-wm-console/Cargo.toml
@@ -12,6 +12,7 @@ publish.workspace = true
 crossterm = { workspace = true, features = ["bracketed-paste"] }
 ratatui = { workspace = true }
 term-wm-core = { workspace = true }
+term-wm-crossterm-adapter = { workspace = true }
 term-wm-layout-engine = { workspace = true }
 term-wm-render = { workspace = true }
 tracing = { workspace = true }

--- a/crates/term-wm-console/src/console_event_source.rs
+++ b/crates/term-wm-console/src/console_event_source.rs
@@ -2,102 +2,25 @@ use std::collections::VecDeque;
 use std::io;
 use std::time::{Duration, Instant};
 
-use term_wm_core::events::{
-    Event, KeyCode, KeyEvent, KeyKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
-};
+use term_wm_core::events::{Event, KeyEvent, MouseEvent};
 use term_wm_core::io::EventSource;
 use term_wm_core::power_profile::PowerProfile;
 use term_wm_core::utils::KeyboardNormalizer;
+use term_wm_crossterm_adapter;
 
 /// Translate a crossterm event to a core-owned event.
 fn translate_crossterm_event(evt: crossterm::event::Event) -> Option<Event> {
     match evt {
-        crossterm::event::Event::Key(key) => Some(Event::Key(translate_key_event(key))),
-        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(translate_mouse_event(mouse))),
+        crossterm::event::Event::Key(key) => Some(Event::Key(
+            term_wm_crossterm_adapter::translate_key_event(key),
+        )),
+        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(
+            term_wm_crossterm_adapter::translate_mouse_event(mouse),
+        )),
         crossterm::event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
         crossterm::event::Event::FocusGained => Some(Event::FocusGained),
         crossterm::event::Event::FocusLost => Some(Event::FocusLost),
         crossterm::event::Event::Paste(text) => Some(Event::Paste(text)),
-    }
-}
-
-fn translate_key_event(key: crossterm::event::KeyEvent) -> KeyEvent {
-    let mut modifiers = translate_key_modifiers(key.modifiers);
-    // macOS sends BackTab for Shift+Tab — set shift
-    if matches!(key.code, crossterm::event::KeyCode::BackTab) {
-        modifiers.shift = true;
-    }
-    KeyEvent {
-        code: translate_key_code(key.code),
-        modifiers,
-        kind: match key.kind {
-            crossterm::event::KeyEventKind::Press => KeyKind::Press,
-            crossterm::event::KeyEventKind::Repeat => KeyKind::Repeat,
-            crossterm::event::KeyEventKind::Release => KeyKind::Release,
-        },
-    }
-}
-
-fn translate_key_code(code: crossterm::event::KeyCode) -> KeyCode {
-    match code {
-        crossterm::event::KeyCode::Char(c) => KeyCode::Char(c),
-        crossterm::event::KeyCode::Enter => KeyCode::Enter,
-        crossterm::event::KeyCode::Tab => KeyCode::Tab,
-        crossterm::event::KeyCode::BackTab => KeyCode::Tab,
-        crossterm::event::KeyCode::Backspace => KeyCode::Backspace,
-        crossterm::event::KeyCode::Esc => KeyCode::Esc,
-        crossterm::event::KeyCode::Left => KeyCode::Left,
-        crossterm::event::KeyCode::Right => KeyCode::Right,
-        crossterm::event::KeyCode::Up => KeyCode::Up,
-        crossterm::event::KeyCode::Down => KeyCode::Down,
-        crossterm::event::KeyCode::Home => KeyCode::Home,
-        crossterm::event::KeyCode::End => KeyCode::End,
-        crossterm::event::KeyCode::PageUp => KeyCode::PageUp,
-        crossterm::event::KeyCode::PageDown => KeyCode::PageDown,
-        crossterm::event::KeyCode::Delete => KeyCode::Delete,
-        crossterm::event::KeyCode::Insert => KeyCode::Insert,
-        crossterm::event::KeyCode::F(n) => KeyCode::F(n),
-        _ => KeyCode::Esc, // Fallback for unrecognized keys
-    }
-}
-
-fn translate_key_modifiers(mods: crossterm::event::KeyModifiers) -> KeyModifiers {
-    KeyModifiers {
-        shift: mods.contains(crossterm::event::KeyModifiers::SHIFT),
-        control: mods.contains(crossterm::event::KeyModifiers::CONTROL),
-        alt: mods.contains(crossterm::event::KeyModifiers::ALT),
-    }
-}
-
-fn translate_mouse_event(mouse: crossterm::event::MouseEvent) -> MouseEvent {
-    MouseEvent {
-        kind: match mouse.kind {
-            crossterm::event::MouseEventKind::Down(btn) => {
-                MouseEventKind::Press(translate_button(btn))
-            }
-            crossterm::event::MouseEventKind::Up(btn) => {
-                MouseEventKind::Release(translate_button(btn))
-            }
-            crossterm::event::MouseEventKind::Drag(btn) => {
-                MouseEventKind::Drag(translate_button(btn))
-            }
-            crossterm::event::MouseEventKind::Moved => MouseEventKind::Moved,
-            crossterm::event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
-            crossterm::event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
-            crossterm::event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
-            crossterm::event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
-        },
-        modifiers: translate_key_modifiers(mouse.modifiers),
-        column: mouse.column,
-        row: mouse.row,
-    }
-}
-
-fn translate_button(btn: crossterm::event::MouseButton) -> MouseButton {
-    match btn {
-        crossterm::event::MouseButton::Left => MouseButton::Left,
-        crossterm::event::MouseButton::Right => MouseButton::Right,
-        crossterm::event::MouseButton::Middle => MouseButton::Middle,
     }
 }
 
@@ -232,6 +155,7 @@ impl EventSource for ConsoleEventSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use term_wm_core::events::{KeyCode, KeyKind, KeyModifiers, MouseButton, MouseEventKind};
 
     #[test]
     fn next_key_from_queue() {

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -38,6 +38,8 @@ use term_wm_core::chrome::{
 // ── Chrome layout constants (console-specific) ──────────────
 const HEADER_BUTTON_GAP: u16 = 2;
 const EDGE_INDEX_ADJUST: u16 = 1;
+/// Shift window-control buttons 1 cell left (tiled) or right (floating) for visual alignment.
+const CHROME_BUTTON_FLOAT_OFFSET: u16 = 1;
 
 /// Register chrome hitboxes for a window (resize, drag, close, maximize buttons).
 /// Parameters for chrome hitbox registration.
@@ -49,6 +51,7 @@ struct ChromeHitboxParams {
     wm_buttons: Vec<term_wm_core::window::WmButton>,
     borders_enabled: bool,
     header_enabled: bool,
+    floating: bool,
 }
 
 /// Register chrome hitboxes for a window (resize, drag, close, maximize buttons).
@@ -67,6 +70,7 @@ fn register_window_chrome_hitboxes(registry: &mut HitboxRegistry, params: &Chrom
         wm_buttons,
         borders_enabled,
         header_enabled,
+        floating,
     } = params;
     let (width, height) = *frame_size;
     let (ox, oy) = *screen_origin;
@@ -153,6 +157,11 @@ fn register_window_chrome_hitboxes(registry: &mut HitboxRegistry, params: &Chrom
                     .saturating_sub(HEADER_BUTTON_GAP * i as u16)
             } else {
                 btn_right.saturating_sub(HEADER_BUTTON_GAP * i as u16)
+            };
+            let bx = if *floating {
+                bx.saturating_add(CHROME_BUTTON_FLOAT_OFFSET)
+            } else {
+                bx.saturating_sub(CHROME_BUTTON_FLOAT_OFFSET)
             };
             let target = match btn.action {
                 TermWmAction::CloseWindow => ChromeTarget::CloseButton(*key),
@@ -248,6 +257,7 @@ pub fn render_window_chrome(
             wm_buttons: ctx.wm_buttons.clone(),
             borders_enabled: ctx.borders_enabled,
             header_enabled: ctx.header_enabled,
+            floating: ctx.floating,
         },
     );
 
@@ -1182,6 +1192,11 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
                         .saturating_sub(HEADER_BUTTON_GAP * i as u16)
                 } else {
                     header_right.saturating_sub(HEADER_BUTTON_GAP * i as u16)
+                };
+                let bx = if floating {
+                    bx.saturating_add(CHROME_BUTTON_FLOAT_OFFSET)
+                } else {
+                    bx.saturating_sub(CHROME_BUTTON_FLOAT_OFFSET)
                 };
                 let rel_x = bx as usize - buffer.area.x as usize;
                 let cell = &mut buffer.content[rel_y * buf_w + rel_x];

--- a/crates/term-wm-core/src/events.rs
+++ b/crates/term-wm-core/src/events.rs
@@ -22,6 +22,45 @@ impl KeyEvent {
             kind,
         }
     }
+
+    /// Serialize this key event to the byte sequence to send to a PTY.
+    /// Shift+Tab produces `\x1b[Z` (CSI backtab) per ANSI terminal standard.
+    pub fn to_pty_bytes(&self) -> Vec<u8> {
+        use term_wm_pty_engine::input_encoding::{
+            self, KeyCode as PtyKeyCode, KeyModifiers as PtyKeyModifiers, key_to_bytes,
+        };
+        let pty_key = input_encoding::KeyEvent {
+            code: match self.code {
+                KeyCode::Char(c) => PtyKeyCode::Char(c),
+                KeyCode::Enter => PtyKeyCode::Enter,
+                KeyCode::Tab => PtyKeyCode::Tab,
+                KeyCode::Backspace => PtyKeyCode::Backspace,
+                KeyCode::Esc => PtyKeyCode::Esc,
+                KeyCode::Left => PtyKeyCode::Left,
+                KeyCode::Right => PtyKeyCode::Right,
+                KeyCode::Up => PtyKeyCode::Up,
+                KeyCode::Down => PtyKeyCode::Down,
+                KeyCode::Home => PtyKeyCode::Home,
+                KeyCode::End => PtyKeyCode::End,
+                KeyCode::PageUp => PtyKeyCode::PageUp,
+                KeyCode::PageDown => PtyKeyCode::PageDown,
+                KeyCode::Delete => PtyKeyCode::Delete,
+                KeyCode::Insert => PtyKeyCode::Insert,
+                KeyCode::F(n) => PtyKeyCode::F(n),
+                _ => return Vec::new(),
+            },
+            modifiers: PtyKeyModifiers {
+                shift: self.modifiers.shift,
+                control: self.modifiers.control,
+                alt: self.modifiers.alt,
+            },
+        };
+        if pty_key.code == PtyKeyCode::Tab && pty_key.modifiers.shift {
+            b"\x1b[Z".to_vec()
+        } else {
+            key_to_bytes(&pty_key)
+        }
+    }
 }
 
 /// Core-owned key code (independent of crossterm)
@@ -389,5 +428,37 @@ mod tests {
         let m = mouse(15, 8, MouseEventKind::Press(MouseButton::Left));
         let result = m.to_local_offset(make_screen(), 10, 5, 80, 24);
         assert_eq!(result.map(|r| (r.column, r.row)), Some((15, 8)));
+    }
+
+    // ── KeyEvent::to_pty_bytes ─────────────────────────────────────────
+
+    fn key(code: KeyCode, shift: bool) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers {
+                shift,
+                control: false,
+                alt: false,
+            },
+            kind: KeyKind::Press,
+        }
+    }
+
+    #[test]
+    fn test_to_pty_bytes_csi_backtab() {
+        let ev = key(KeyCode::Tab, true);
+        assert_eq!(ev.to_pty_bytes(), b"\x1b[Z");
+    }
+
+    #[test]
+    fn test_to_pty_bytes_standard_delegation() {
+        let ev = key(KeyCode::Char('a'), false);
+        assert_eq!(ev.to_pty_bytes(), b"a");
+    }
+
+    #[test]
+    fn test_to_pty_bytes_unmappable_returns_empty() {
+        let ev = key(KeyCode::MediaPlayPause, false);
+        assert!(ev.to_pty_bytes().is_empty());
     }
 }

--- a/crates/term-wm-core/src/utils/keyboard_normalizer.rs
+++ b/crates/term-wm-core/src/utils/keyboard_normalizer.rs
@@ -1,9 +1,13 @@
 // NOTE: This file provides `KeyboardNormalizer`, a lightweight helper for
-// normalizing raw keyboard `Event`s (e.g., converting Shift+Tab to BackTab
-// and filtering key-release events). It is _not_ a standalone keyboard
-// driver. The actual input driver behavior (queueing, `next_key`, and
+// normalizing raw keyboard `Event`s (e.g., filtering key-release events).
+// The BackTab → Tab+shift conversion is handled centrally in
+// `term-wm-crossterm-adapter` so that all input sources apply the same
+// normalization. Shift+Tab passes through here unchanged — the FocusPrev
+// keybinding matches Tab+Shift directly.
+// The actual input driver behavior (queueing, `next_key`, and
 // combined keyboard/mouse handling) is implemented in
 // `src/io/console_event_source.rs` under the consolidated `EventSource` trait.
+#[allow(unused_imports)]
 use crate::events::{Event, KeyCode, KeyKind};
 
 #[derive(Default)]
@@ -17,10 +21,8 @@ impl KeyboardNormalizer {
     pub fn normalize(&mut self, evt: Event) -> Option<Event> {
         match evt {
             Event::Key(key) => {
-                // Convert Shift+Tab to BackTab
-                if key.code == KeyCode::Tab && key.modifiers.shift {
-                    // Pass through as-is — FocusPrev keybinding matches Tab+Shift.
-                }
+                // Shift+Tab passes through — FocusPrev keybinding matches Tab+Shift.
+                // BackTab normalization is handled in term-wm-crossterm-adapter.
                 if cfg!(windows) {
                     match key.kind {
                         KeyKind::Release => return None,

--- a/crates/term-wm-crossterm-adapter/Cargo.toml
+++ b/crates/term-wm-crossterm-adapter/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "term-wm-crossterm-adapter"
+description = "Crossterm-to-core event translation adapter for term-wm."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+crossterm = { workspace = true }
+term-wm-core = { workspace = true }

--- a/crates/term-wm-crossterm-adapter/README.md
+++ b/crates/term-wm-crossterm-adapter/README.md
@@ -1,0 +1,5 @@
+# term-wm-crossterm-adapter
+
+[Crossterm](https://crates.io/crates/crossterm)-to-core event translation adapter for [term-wm](https://crates.io/crates/term-wm). Not intended for direct use.
+
+See the main [term-wm](https://crates.io/crates/term-wm) crate for documentation.

--- a/crates/term-wm-crossterm-adapter/src/lib.rs
+++ b/crates/term-wm-crossterm-adapter/src/lib.rs
@@ -1,0 +1,168 @@
+use term_wm_core::events::{
+    Event, KeyCode, KeyEvent, KeyKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
+
+// ── Low-level building blocks ───────────────────────────────────────────────
+
+/// Returns `None` for unrecognized codes.
+pub fn translate_key_code(code: crossterm::event::KeyCode) -> Option<KeyCode> {
+    match code {
+        crossterm::event::KeyCode::Char(c) => Some(KeyCode::Char(c)),
+        crossterm::event::KeyCode::Enter => Some(KeyCode::Enter),
+        crossterm::event::KeyCode::Tab => Some(KeyCode::Tab),
+        crossterm::event::KeyCode::BackTab => Some(KeyCode::Tab),
+        crossterm::event::KeyCode::Backspace => Some(KeyCode::Backspace),
+        crossterm::event::KeyCode::Esc => Some(KeyCode::Esc),
+        crossterm::event::KeyCode::Left => Some(KeyCode::Left),
+        crossterm::event::KeyCode::Right => Some(KeyCode::Right),
+        crossterm::event::KeyCode::Up => Some(KeyCode::Up),
+        crossterm::event::KeyCode::Down => Some(KeyCode::Down),
+        crossterm::event::KeyCode::Home => Some(KeyCode::Home),
+        crossterm::event::KeyCode::End => Some(KeyCode::End),
+        crossterm::event::KeyCode::PageUp => Some(KeyCode::PageUp),
+        crossterm::event::KeyCode::PageDown => Some(KeyCode::PageDown),
+        crossterm::event::KeyCode::Delete => Some(KeyCode::Delete),
+        crossterm::event::KeyCode::Insert => Some(KeyCode::Insert),
+        crossterm::event::KeyCode::F(n) => Some(KeyCode::F(n)),
+        _ => None,
+    }
+}
+
+pub fn translate_key_modifiers(mods: crossterm::event::KeyModifiers) -> KeyModifiers {
+    KeyModifiers {
+        shift: mods.contains(crossterm::event::KeyModifiers::SHIFT),
+        control: mods.contains(crossterm::event::KeyModifiers::CONTROL),
+        alt: mods.contains(crossterm::event::KeyModifiers::ALT),
+    }
+}
+
+// ── Key event translation ──────────────────────────────────────────────────
+
+/// Fallible: handles BackTab → Tab + shift. Returns `None` for unrecognized keys.
+pub fn try_translate_key_event(key: crossterm::event::KeyEvent) -> Option<KeyEvent> {
+    let code = translate_key_code(key.code)?;
+    let mut modifiers = translate_key_modifiers(key.modifiers);
+    if matches!(key.code, crossterm::event::KeyCode::BackTab) {
+        modifiers.shift = true;
+    }
+    Some(KeyEvent {
+        code,
+        modifiers,
+        kind: match key.kind {
+            crossterm::event::KeyEventKind::Press => KeyKind::Press,
+            crossterm::event::KeyEventKind::Repeat => KeyKind::Repeat,
+            crossterm::event::KeyEventKind::Release => KeyKind::Release,
+        },
+    })
+}
+
+/// Infallible: wraps `try_translate_key_event`, maps unknown keys to `KeyCode::Esc`.
+pub fn translate_key_event(key: crossterm::event::KeyEvent) -> KeyEvent {
+    let modifiers = translate_key_modifiers(key.modifiers);
+    try_translate_key_event(key).unwrap_or(KeyEvent {
+        code: KeyCode::Esc,
+        modifiers,
+        kind: KeyKind::Press,
+    })
+}
+
+// ── Mouse event translation ────────────────────────────────────────────────
+
+pub fn translate_mouse_event(mouse: crossterm::event::MouseEvent) -> MouseEvent {
+    MouseEvent {
+        kind: match mouse.kind {
+            crossterm::event::MouseEventKind::Down(btn) => {
+                MouseEventKind::Press(translate_button(btn))
+            }
+            crossterm::event::MouseEventKind::Up(btn) => {
+                MouseEventKind::Release(translate_button(btn))
+            }
+            crossterm::event::MouseEventKind::Drag(btn) => {
+                MouseEventKind::Drag(translate_button(btn))
+            }
+            crossterm::event::MouseEventKind::Moved => MouseEventKind::Moved,
+            crossterm::event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
+            crossterm::event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
+            crossterm::event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
+            crossterm::event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
+        },
+        modifiers: translate_key_modifiers(mouse.modifiers),
+        column: mouse.column,
+        row: mouse.row,
+    }
+}
+
+fn translate_button(btn: crossterm::event::MouseButton) -> MouseButton {
+    match btn {
+        crossterm::event::MouseButton::Left => MouseButton::Left,
+        crossterm::event::MouseButton::Right => MouseButton::Right,
+        crossterm::event::MouseButton::Middle => MouseButton::Middle,
+    }
+}
+
+// ── Top-level event routing ────────────────────────────────────────────────
+
+/// Translate any crossterm event. Key events use `try_translate_key_event`
+/// (unknown key codes → `None` → the whole event is dropped).
+/// Mouse, Resize, Focus, Paste are translated directly.
+pub fn try_translate_event(evt: crossterm::event::Event) -> Option<Event> {
+    match evt {
+        crossterm::event::Event::Key(key) => try_translate_key_event(key).map(Event::Key),
+        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(translate_mouse_event(mouse))),
+        crossterm::event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
+        crossterm::event::Event::FocusGained => Some(Event::FocusGained),
+        crossterm::event::Event::FocusLost => Some(Event::FocusLost),
+        crossterm::event::Event::Paste(text) => Some(Event::Paste(text)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_key(
+        code: crossterm::event::KeyCode,
+        mods: crossterm::event::KeyModifiers,
+    ) -> crossterm::event::KeyEvent {
+        crossterm::event::KeyEvent {
+            code,
+            modifiers: mods,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_try_translate_drops_unknown() {
+        let key = make_key(
+            crossterm::event::KeyCode::CapsLock,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        assert!(try_translate_key_event(key).is_none());
+    }
+
+    #[test]
+    fn test_try_translate_mutates_backtab() {
+        let key = make_key(
+            crossterm::event::KeyCode::BackTab,
+            crossterm::event::KeyModifiers::NONE,
+        );
+        let result = try_translate_key_event(key).unwrap();
+        assert_eq!(result.code, KeyCode::Tab);
+        assert!(result.modifiers.shift);
+        assert!(!result.modifiers.control);
+        assert!(!result.modifiers.alt);
+    }
+
+    #[test]
+    fn test_infallible_translate_fallback_preserves_modifiers() {
+        let mods =
+            crossterm::event::KeyModifiers::CONTROL.union(crossterm::event::KeyModifiers::ALT);
+        let key = make_key(crossterm::event::KeyCode::CapsLock, mods);
+        let result = translate_key_event(key);
+        assert_eq!(result.code, KeyCode::Esc);
+        assert!(result.modifiers.control);
+        assert!(result.modifiers.alt);
+        assert!(!result.modifiers.shift);
+    }
+}

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -21,7 +21,7 @@ use term_wm_core::utils::selectable_text::{
 };
 use term_wm_core::window::WindowKey;
 use term_wm_layout_engine::LayoutRect;
-use term_wm_pty_engine::input_encoding::{key_to_bytes, mouse_event_allowed, mouse_event_to_bytes};
+use term_wm_pty_engine::input_encoding::{mouse_event_allowed, mouse_event_to_bytes};
 use term_wm_pty_engine::{Pane, PtyStatus};
 
 // This controls the scrollback buffer size in the vt100 parser.
@@ -125,37 +125,7 @@ impl Component<TermWmAction> for TerminalComponent {
                     };
                     return EventResult::Action(TermWmAction::Scroll(delta));
                 }
-                // TODO: Refactor?
-                // Convert core-owned KeyEvent to pty-engine KeyEvent for key_to_bytes
-                let pty_key = term_wm_pty_engine::input_encoding::KeyEvent {
-                    code: match key.code {
-                        KeyCode::Char(c) => term_wm_pty_engine::input_encoding::KeyCode::Char(c),
-                        KeyCode::Enter => term_wm_pty_engine::input_encoding::KeyCode::Enter,
-                        KeyCode::Tab => term_wm_pty_engine::input_encoding::KeyCode::Tab,
-                        KeyCode::Backspace => {
-                            term_wm_pty_engine::input_encoding::KeyCode::Backspace
-                        }
-                        KeyCode::Esc => term_wm_pty_engine::input_encoding::KeyCode::Esc,
-                        KeyCode::Left => term_wm_pty_engine::input_encoding::KeyCode::Left,
-                        KeyCode::Right => term_wm_pty_engine::input_encoding::KeyCode::Right,
-                        KeyCode::Up => term_wm_pty_engine::input_encoding::KeyCode::Up,
-                        KeyCode::Down => term_wm_pty_engine::input_encoding::KeyCode::Down,
-                        KeyCode::Home => term_wm_pty_engine::input_encoding::KeyCode::Home,
-                        KeyCode::End => term_wm_pty_engine::input_encoding::KeyCode::End,
-                        KeyCode::PageUp => term_wm_pty_engine::input_encoding::KeyCode::PageUp,
-                        KeyCode::PageDown => term_wm_pty_engine::input_encoding::KeyCode::PageDown,
-                        KeyCode::Delete => term_wm_pty_engine::input_encoding::KeyCode::Delete,
-                        KeyCode::Insert => term_wm_pty_engine::input_encoding::KeyCode::Insert,
-                        KeyCode::F(n) => term_wm_pty_engine::input_encoding::KeyCode::F(n),
-                        _ => return EventResult::Ignored, // Media keys not supported
-                    },
-                    modifiers: term_wm_pty_engine::input_encoding::KeyModifiers {
-                        shift: key.modifiers.shift,
-                        control: key.modifiers.control,
-                        alt: key.modifiers.alt,
-                    },
-                };
-                let bytes = key_to_bytes(&pty_key);
+                let bytes = key.to_pty_bytes();
                 if bytes.is_empty() {
                     return EventResult::Ignored;
                 }

--- a/src/unified_event_source.rs
+++ b/src/unified_event_source.rs
@@ -9,14 +9,13 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::{Receiver, Sender, bounded};
 
-use term_wm_core::events::{
-    Event, KeyCode, KeyEvent, KeyKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
-};
+use term_wm_core::events::{Event, KeyEvent, MouseEvent};
 use term_wm_core::io::EventSource;
 use term_wm_core::io::frame_pacer::FramePacer;
 use term_wm_core::power_profile::PowerProfile;
 use term_wm_core::utils::KeyboardNormalizer;
 use term_wm_core::window::WindowKey;
+use term_wm_crossterm_adapter;
 
 /// Capacity of the crossbeam channel between event producers and the event
 /// loop. Generous capacity since wakeup gating (dirty.swap) prevents flooding.
@@ -193,92 +192,16 @@ impl UnifiedEventSource {
 /// Translate a crossterm event to a core-owned event.
 fn translate_crossterm_event(evt: crossterm::event::Event) -> Option<Event> {
     match evt {
-        crossterm::event::Event::Key(key) => Some(Event::Key(translate_key_event(key))),
-        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(translate_mouse_event(mouse))),
+        crossterm::event::Event::Key(key) => Some(Event::Key(
+            term_wm_crossterm_adapter::translate_key_event(key),
+        )),
+        crossterm::event::Event::Mouse(mouse) => Some(Event::Mouse(
+            term_wm_crossterm_adapter::translate_mouse_event(mouse),
+        )),
         crossterm::event::Event::Resize(w, h) => Some(Event::Resize(w, h)),
         crossterm::event::Event::FocusGained => Some(Event::FocusGained),
         crossterm::event::Event::FocusLost => Some(Event::FocusLost),
         crossterm::event::Event::Paste(text) => Some(Event::Paste(text)),
-    }
-}
-
-fn translate_key_event(key: crossterm::event::KeyEvent) -> KeyEvent {
-    let mut modifiers = translate_key_modifiers(key.modifiers);
-    // macOS sends BackTab for Shift+Tab — set shift
-    if matches!(key.code, crossterm::event::KeyCode::BackTab) {
-        modifiers.shift = true;
-    }
-    KeyEvent {
-        code: translate_key_code(key.code),
-        modifiers,
-        kind: match key.kind {
-            crossterm::event::KeyEventKind::Press => KeyKind::Press,
-            crossterm::event::KeyEventKind::Repeat => KeyKind::Repeat,
-            crossterm::event::KeyEventKind::Release => KeyKind::Release,
-        },
-    }
-}
-
-fn translate_key_code(code: crossterm::event::KeyCode) -> KeyCode {
-    match code {
-        crossterm::event::KeyCode::Char(c) => KeyCode::Char(c),
-        crossterm::event::KeyCode::Enter => KeyCode::Enter,
-        crossterm::event::KeyCode::Tab => KeyCode::Tab,
-        crossterm::event::KeyCode::BackTab => KeyCode::Tab,
-        crossterm::event::KeyCode::Backspace => KeyCode::Backspace,
-        crossterm::event::KeyCode::Esc => KeyCode::Esc,
-        crossterm::event::KeyCode::Left => KeyCode::Left,
-        crossterm::event::KeyCode::Right => KeyCode::Right,
-        crossterm::event::KeyCode::Up => KeyCode::Up,
-        crossterm::event::KeyCode::Down => KeyCode::Down,
-        crossterm::event::KeyCode::Home => KeyCode::Home,
-        crossterm::event::KeyCode::End => KeyCode::End,
-        crossterm::event::KeyCode::PageUp => KeyCode::PageUp,
-        crossterm::event::KeyCode::PageDown => KeyCode::PageDown,
-        crossterm::event::KeyCode::Delete => KeyCode::Delete,
-        crossterm::event::KeyCode::Insert => KeyCode::Insert,
-        crossterm::event::KeyCode::F(n) => KeyCode::F(n),
-        _ => KeyCode::Esc, // Fallback for unrecognized keys
-    }
-}
-
-fn translate_key_modifiers(mods: crossterm::event::KeyModifiers) -> KeyModifiers {
-    KeyModifiers {
-        shift: mods.contains(crossterm::event::KeyModifiers::SHIFT),
-        control: mods.contains(crossterm::event::KeyModifiers::CONTROL),
-        alt: mods.contains(crossterm::event::KeyModifiers::ALT),
-    }
-}
-
-fn translate_mouse_event(mouse: crossterm::event::MouseEvent) -> MouseEvent {
-    MouseEvent {
-        kind: match mouse.kind {
-            crossterm::event::MouseEventKind::Down(btn) => {
-                MouseEventKind::Press(translate_button(btn))
-            }
-            crossterm::event::MouseEventKind::Up(btn) => {
-                MouseEventKind::Release(translate_button(btn))
-            }
-            crossterm::event::MouseEventKind::Drag(btn) => {
-                MouseEventKind::Drag(translate_button(btn))
-            }
-            crossterm::event::MouseEventKind::Moved => MouseEventKind::Moved,
-            crossterm::event::MouseEventKind::ScrollUp => MouseEventKind::ScrollUp,
-            crossterm::event::MouseEventKind::ScrollDown => MouseEventKind::ScrollDown,
-            crossterm::event::MouseEventKind::ScrollLeft => MouseEventKind::ScrollLeft,
-            crossterm::event::MouseEventKind::ScrollRight => MouseEventKind::ScrollRight,
-        },
-        modifiers: translate_key_modifiers(mouse.modifiers),
-        column: mouse.column,
-        row: mouse.row,
-    }
-}
-
-fn translate_button(btn: crossterm::event::MouseButton) -> MouseButton {
-    match btn {
-        crossterm::event::MouseButton::Left => MouseButton::Left,
-        crossterm::event::MouseButton::Right => MouseButton::Right,
-        crossterm::event::MouseButton::Middle => MouseButton::Middle,
     }
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+# term-wm Integration Tests
+
+This directory contains some common integration tests.
+
+Most unit tests are localized to the functions they are testing throughout the codebase.

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -118,6 +118,7 @@ async fn session_mouse_bytes_forwarded() {
 }
 
 #[tokio::test]
+#[serial]
 async fn session_osc52_in_output() {
     let mock = get_mock_bin();
     let (client, _dir) = spawn_session(vec![mock, "osc52".into()], TEST_COLS, TEST_ROWS).await;


### PR DESCRIPTION
Extract three nearly identical copies of crossterm-to-core event translation into a single shared adapter crate, and centralize PTY byte encoding as KeyEvent::to_pty_bytes().

Changes:
- Create crates/term-wm-crossterm-adapter with translate_key_code, try_translate_key_event, translate_key_event, translate_mouse_event, and try_translate_event — the single source of truth for BackTab → Tab+shift normalization and modifier translation.
- Add KeyEvent::to_pty_bytes() inherent method in term-wm-core that produces \x1b[Z (CSI backtab) for Shift+Tab per ANSI standard.
- Replace 280 lines of duplicated match arms in unified_event_source.rs, console_event_source.rs, terminal.rs, and session-client lib.rs with adapter calls and key.to_pty_bytes().
- Fix session-client Shift+Tab regression: BackTab no longer silently dropped; encoded as CSI Z for remote PTY.
- Apply uniform Shift+Tab encoding to local terminal component (previously sent \t, same as plain Tab).
- Fix KeyboardNormalizer doc comment (claimed to convert Shift+Tab but is a no-op pass-through).
- Add unit tests for adapter translation paths and to_pty_bytes serialization.