### PR TITLE
fix: Tiling auto-unmaximize on focus shift, preserve tile position via Void placeholder

### DIFF
--- a/crates/term-wm-core/src/layout/tiling.rs
+++ b/crates/term-wm-core/src/layout/tiling.rs
@@ -96,6 +96,14 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
         self.root.replace_void_by_id(void_id, new_leaf)
     }
 
+    pub fn replace_leaf_with_void(&mut self, key: Id) -> Option<usize> {
+        self.root.replace_leaf_with_void(key)
+    }
+
+    pub fn remove_void_by_id(&mut self, void_id: usize) -> bool {
+        self.root.remove_void_by_id(void_id)
+    }
+
     pub fn swap_nodes(&mut self, source: &Id, target: &Id) -> bool {
         self.root.swap_leaves(source, target)
     }

--- a/crates/term-wm-core/src/window/entry.rs
+++ b/crates/term-wm-core/src/window/entry.rs
@@ -41,6 +41,10 @@ pub struct Window {
     /// Decoupled maximization state flag.  Set when the window is maximized,
     /// cleared when restored.  Must NOT be derived from geometry comparison.
     pub is_maximized: bool,
+    /// Non-None when this window has a Void placeholder in the tiling layout
+    /// tree (maximized while tiled). The void preserves the tree position and
+    /// split weights so the window can be restored to its exact original spot.
+    pub void_id: Option<usize>,
     /// Render window borders (left, right, bottom, corners).
     pub borders_enabled: bool,
     /// Render window header (title bar, buttons).
@@ -68,6 +72,7 @@ impl Window {
             creation_order,
             direct_mode: false,
             is_maximized: false,
+            void_id: None,
             borders_enabled: true,
             header_enabled: true,
             component_key,

--- a/crates/term-wm-core/src/window/window_manager/chrome.rs
+++ b/crates/term-wm-core/src/window/window_manager/chrome.rs
@@ -1,6 +1,7 @@
 use super::WindowManager;
 use crate::actions::TermWmAction;
 use crate::components::{Component, Overlay, WmComponent};
+use crate::layout::LayoutNode;
 use crate::window::WindowKey;
 use crate::window::entry::{ClosePolicy, WindowState};
 
@@ -15,55 +16,57 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     pub fn toggle_maximize(&mut self, key: WindowKey) {
         use crate::window::FloatRectSpec;
+
+        let is_maxed = self.window(key).is_some_and(|w| w.is_maximized);
+
+        if is_maxed {
+            // UNMAXIMIZE PATH
+            let prev_float = self.take_prev_floating_rect(key);
+            if let Some(prev_spec) = prev_float {
+                // Was floating: restore pre-maximize floating rect
+                self.set_floating_rect(key, Some(prev_spec));
+            } else {
+                // Was tiled: restore Void → Leaf in layout tree
+                self.clear_floating_rect(key);
+                let void_id = self.window(key).and_then(|w| w.void_id);
+                if let Some(vid) = void_id
+                    && let Some(ref mut layout) = self.managed_layout
+                {
+                    layout.replace_void_by_id(vid, LayoutNode::leaf(key));
+                }
+            }
+
+            if let Some(w) = self.windows.get_mut(key) {
+                w.is_maximized = false;
+                w.borders_enabled = true;
+                w.void_id = None;
+            }
+            self.bring_floating_to_front_key(key);
+            return;
+        }
+
+        // MAXIMIZE PATH
         let full = FloatRectSpec::Absolute(crate::window::FloatRect {
             x: self.managed_area.x,
             y: self.managed_area.y,
             width: self.managed_area.width,
             height: self.managed_area.height,
         });
+
         if let Some(current) = self.floating_rect(key) {
-            if current == full {
-                // Unmaximize: restore previous geometry
-                if let Some(prev) = self.take_prev_floating_rect(key) {
-                    self.set_floating_rect(key, Some(prev));
-                }
-                if let Some(w) = self.windows.get_mut(key) {
-                    w.is_maximized = false;
-                    w.borders_enabled = true;
-                }
-            } else {
-                // Maximize: save current and expand
-                self.set_prev_floating_rect(key, Some(current));
-                self.set_floating_rect(key, Some(full));
-                if let Some(w) = self.windows.get_mut(key) {
-                    w.is_maximized = true;
-                    w.borders_enabled = false;
-                }
-            }
-            self.bring_floating_to_front_key(key);
-            return;
-        }
-        // Tiled window → detach and maximize
-        let prev_rect = if let Some(rect) = self.regions.get(key) {
-            FloatRectSpec::Absolute(crate::window::FloatRect {
-                x: rect.x,
-                y: rect.y,
-                width: rect.width,
-                height: rect.height,
-            })
+            // Was floating: save current floating rect to prev_floating_rect
+            self.set_prev_floating_rect(key, Some(current));
         } else {
-            FloatRectSpec::Percent {
-                x: 0,
-                y: 0,
-                width: 100,
-                height: 100,
+            // Was tiled: replace Leaf with Void in-place, preserving tree
+            if let Some(ref mut layout) = self.managed_layout
+                && let Some(void_id) = layout.replace_leaf_with_void(key)
+                && let Some(w) = self.windows.get_mut(key)
+            {
+                w.void_id = Some(void_id);
             }
-        };
+            self.set_prev_floating_rect(key, None);
+        }
 
-        // Purge from tiling tree before expanding to floating full-screen
-        self.detach_from_tiling_layout(key);
-
-        self.set_prev_floating_rect(key, Some(prev_rect));
         self.set_floating_rect(key, Some(full));
         if let Some(w) = self.windows.get_mut(key) {
             w.is_maximized = true;

--- a/crates/term-wm-core/src/window/window_manager/drag.rs
+++ b/crates/term-wm-core/src/window/window_manager/drag.rs
@@ -398,6 +398,11 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Succeeds when:
     /// - No active tiling layout AND all existing windows are floating (or workspace empty)
     pub fn try_spawn_floating_default(&mut self, key: WindowKey) -> bool {
+        // If a tiling layout exists, the workspace is in Tiling Mode.
+        // New windows must go through the tiling insertion path.
+        if self.managed_layout.is_some() {
+            return false;
+        }
         let existing: Vec<_> = self
             .mapped_windows()
             .into_iter()
@@ -406,7 +411,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         if existing.is_empty() || !existing.iter().all(|k| self.is_window_floating(*k)) {
             return false;
         }
-        self.managed_layout = None;
         let rect = self.default_cascading_rect(existing.len());
         self.set_floating_rect(
             key,
@@ -419,7 +423,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 },
             )),
         );
-        self.focus_window_key(key);
         self.bifurcate_draw_order();
         true
     }

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -43,14 +43,18 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     pub fn focus_app_window(&mut self, key: WindowKey) {
-        self.focus.set_current(key);
-        self.bring_to_front_key(key);
-        self.mark_layout_dirty();
+        self.focus_window_key(key);
     }
 
     pub fn focus_window_key(&mut self, key: WindowKey) {
-        // Focus shifts must not mutate geometry — maximized floating windows
-        // retain their size regardless of Z-order changes.
+        // If the currently focused window is maximized and we are switching to
+        // a different window, unmaximize it so the target window is not hidden
+        // behind the full-area floating overlay.
+        let prev_focus = *self.focus.current();
+        if prev_focus != key && self.window(prev_focus).is_some_and(|w| w.is_maximized) {
+            self.toggle_maximize(prev_focus);
+        }
+
         self.focus.set_current(key);
         self.bring_to_front_key(key);
         self.mark_layout_dirty();
@@ -132,8 +136,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         if self.focus.order().is_empty() {
             return;
         }
+        // Capture the pre-advance focus so we can unmaximize it if the
+        // focus actually changes to a different window below.
+        let prev_focus = *self.focus.current();
         self.focus.advance(forward);
         let focused = *self.focus.current();
+        if prev_focus != focused && self.window(prev_focus).is_some_and(|w| w.is_maximized) {
+            self.toggle_maximize(prev_focus);
+        }
         self.focus_window_key(focused);
         self.set_tab_outline_mode(crate::constants::TAB_OUTLINE_DURATION);
     }
@@ -174,8 +184,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                                 &self.managed_draw_order,
                             );
                             if let Some(key) = hit {
-                                self.focus.set_current(key);
-                                self.bring_floating_to_front_key(key);
+                                self.focus_window_key(key);
                                 return true;
                             }
                             return false;
@@ -183,10 +192,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                         let hit =
                             self.hit_test_region(mouse.column, mouse.row, &self.managed_draw_order);
                         if let Some(hit) = hit {
-                            self.focus.set_current(hit);
-                            if self.config.wm_command_menu_enabled {
-                                self.bring_floating_to_front_key(hit);
-                            }
+                            self.focus_window_key(hit);
                             true
                         } else {
                             false

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -778,13 +778,22 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Remove a window from the tiling layout.
     /// Idempotent — safe to call even if already detached.
     pub(super) fn detach_from_tiling_layout(&mut self, key: WindowKey) {
+        // Capture void_id before the mutable layout borrow
+        let void_id = self.window(key).and_then(|w| w.void_id);
         if let Some(ref mut layout) = self.managed_layout {
-            let _ = layout.root_mut().remove_leaf(key);
-            layout.root_mut().cleanup_after_removal();
-            // If the tree was a single leaf matching key, remove_leaf
-            // cannot remove it.  Clear it explicitly to prevent stale
-            // leaves from persisting in the tree.
-            layout.root_mut().clear_leaf(key);
+            if let Some(vid) = void_id {
+                layout.remove_void_by_id(vid);
+                if let Some(w) = self.windows.get_mut(key) {
+                    w.void_id = None;
+                }
+            } else {
+                let _ = layout.root_mut().remove_leaf(key);
+                layout.root_mut().cleanup_after_removal();
+                // If the tree was a single leaf matching key, remove_leaf
+                // cannot remove it.  Clear it explicitly to prevent stale
+                // leaves from persisting in the tree.
+                layout.root_mut().clear_leaf(key);
+            }
         }
     }
 

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -960,7 +960,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             order.push(key);
             self.focus.set_order(order);
         }
-        self.focus.set_current(key);
+        // Only set current if the current focus points to an invalid key
+        // (e.g. initial startup). Defer real focus changes to focus_window_key
+        // so the previous focus is preserved for auto-unmaximize checks.
+        if !self.windows.contains_key(*self.focus.current()) {
+            self.focus.set_current(key);
+        }
     }
 
     pub fn take_synthetic_event(&mut self) -> Option<Event> {
@@ -3025,6 +3030,975 @@ mod tests {
             }
             _ => panic!("expected absolute rect"),
         }
+    }
+
+    #[test]
+    fn maximize_tiled_then_focus_other_unmaximizes_and_retiles() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, crate::window::entry::WindowState::Mapped);
+        }
+        // Two-window horizontal tiling layout.
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        // Focus keys[0] explicitly — last-created window is default focus
+        wm.focus_window_key(keys[0]);
+        assert!(!wm.is_window_floating(keys[0]), "starts tiled");
+        assert_eq!(wm.focused_window(), keys[0]);
+
+        // Maximize the tiled window
+        wm.toggle_maximize(keys[0]);
+        assert!(
+            wm.windows.get(keys[0]).unwrap().is_maximized,
+            "is_maximized set"
+        );
+
+        // Focus the other tiled window → triggers auto-unmaximize
+        wm.focus_window_key(keys[1]);
+        assert_eq!(wm.focused_window(), keys[1]);
+
+        // Original window should be unmaximized and back in the tiling layout
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(!w0.is_maximized, "should no longer be maximized");
+        assert!(!w0.is_floating(), "should be tiled (not floating)");
+        assert!(
+            wm.managed_layout
+                .as_ref()
+                .is_some_and(|l| l.root().subtree_any(|k| k == keys[0])),
+            "should be in tiling layout"
+        );
+    }
+
+    #[test]
+    fn maximize_floating_then_focus_other_unmaximizes_and_refloats() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        use crate::window::{FloatRect, FloatRectSpec};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, crate::window::entry::WindowState::Mapped);
+        }
+        // Single-leaf tiling layout so register_managed_layout works
+        wm.managed_layout = Some(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        // Make keys[0] floating at a known position
+        let float_rect = FloatRectSpec::Absolute(FloatRect {
+            x: 10,
+            y: 5,
+            width: 30,
+            height: 15,
+        });
+        wm.set_floating_rect(keys[0], Some(float_rect));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        // Focus keys[0] (floating)
+        wm.focus_window_key(keys[0]);
+        assert!(wm.is_window_floating(keys[0]), "starts floating");
+
+        // Maximize the floating window
+        wm.toggle_maximize(keys[0]);
+        assert!(
+            wm.windows.get(keys[0]).unwrap().is_maximized,
+            "is_maximized set"
+        );
+
+        // Focus the tiled window → triggers auto-unmaximize
+        wm.focus_window_key(keys[1]);
+        assert_eq!(wm.focused_window(), keys[1]);
+
+        // Original window should be unmaximized and still floating at its
+        // pre-maximize position
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(!w0.is_maximized, "should no longer be maximized");
+        assert!(w0.is_floating(), "should remain floating (not tiled)");
+        // Its floating rect should be the original pre-maximize rect
+        let restored = wm.floating_rect(keys[0]);
+        assert_eq!(restored, Some(float_rect), "floating rect restored");
+    }
+
+    // ── Tiled maximize/unmaximize toggle ──────────────────────────────
+
+    #[test]
+    fn tiled_maximize_toggle_unmaximize() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        // Record original region for position check
+        let orig_region = wm.region(keys[0]);
+
+        // Maximize
+        wm.toggle_maximize(keys[0]);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+        assert!(wm.windows.get(keys[0]).unwrap().void_id.is_some());
+
+        // Toggle back (unmaximize directly)
+        wm.toggle_maximize(keys[0]);
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(!w0.is_maximized, "unmaximized");
+        assert!(w0.void_id.is_none(), "void_id cleared");
+        assert!(!w0.is_floating(), "not floating");
+        // Should be back in tree at original position
+        assert!(
+            wm.managed_layout
+                .as_ref()
+                .is_some_and(|l| l.root().subtree_any(|k| k == keys[0])),
+            "back in tree"
+        );
+        let restored = wm.region(keys[0]);
+        assert_eq!(restored, orig_region, "same region as before maximize");
+    }
+
+    #[test]
+    fn tiled_maximize_void_id_set() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.managed_layout = Some(TilingLayout::new(LayoutNode::leaf(keys[0])));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        wm.toggle_maximize(keys[0]);
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(
+            w0.void_id.is_some(),
+            "void_id set after maximizing tiled window"
+        );
+        // Tree should contain a Void, not a Leaf(keys[0])
+        assert!(
+            !wm.managed_layout
+                .as_ref()
+                .is_some_and(|l| l.root().subtree_any(|k| k == keys[0])),
+            "leaf replaced by void in tree"
+        );
+    }
+
+    // ── Floating maximize/unmaximize toggle ───────────────────────────
+
+    #[test]
+    fn floating_maximize_toggle_unmaximize() {
+        use crate::window::{FloatRect, FloatRectSpec};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        let float_rect = FloatRectSpec::Absolute(FloatRect {
+            x: 10,
+            y: 5,
+            width: 30,
+            height: 15,
+        });
+        wm.set_floating_rect(keys[0], Some(float_rect));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        // Maximize floating window
+        wm.toggle_maximize(keys[0]);
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(w0.is_maximized);
+        // Window still has floating_rect (now = full), so is_floating is true
+
+        // Toggle back
+        wm.toggle_maximize(keys[0]);
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(!w0.is_maximized, "unmaximized");
+        assert!(w0.is_floating(), "still floating");
+        let restored = wm.floating_rect(keys[0]);
+        assert_eq!(restored, Some(float_rect), "original rect restored");
+    }
+
+    // ── Focus cycling triggers auto-unmaximize ────────────────────────
+
+    #[test]
+    fn tiled_maximize_then_advance_focus_unmaximizes() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        // Maximize keys[0], then advance focus to keys[1]
+        wm.toggle_maximize(keys[0]);
+        wm.advance_focus(true);
+
+        assert_eq!(wm.focused_window(), keys[1], "focus moved to keys[1]");
+        assert!(
+            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            "keys[0] unmaximized by focus shift"
+        );
+    }
+
+    #[test]
+    fn tiled_maximize_then_mouse_click_focus_unmaximizes() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        // Maximize keys[0], then simulate mouse click on keys[1]'s region
+        wm.toggle_maximize(keys[0]);
+        let r1 = wm.region(keys[1]);
+        wm.handle_mouse_focus_click(r1.x as u16, r1.y as u16);
+
+        assert_eq!(
+            wm.focused_window(),
+            keys[1],
+            "focus moved to clicked window"
+        );
+        assert!(
+            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            "keys[0] unmaximized by mouse click"
+        );
+    }
+
+    // ── Edge cases: single window, three windows, minimize ────────────
+
+    #[test]
+    fn tiled_maximize_single_window() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.managed_layout = Some(TilingLayout::new(LayoutNode::leaf(keys[0])));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        wm.toggle_maximize(keys[0]);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+        // Tree should be Void (single leaf replaced)
+        assert!(matches!(
+            wm.managed_layout.as_ref().unwrap().root(),
+            LayoutNode::Void(_)
+        ));
+
+        wm.toggle_maximize(keys[0]);
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(!w0.is_maximized, "unmaximized");
+        // Back to a leaf at root
+        assert_eq!(
+            wm.managed_layout.as_ref().unwrap().root().unwrap_leaf(),
+            Some(keys[0])
+        );
+    }
+
+    #[test]
+    fn tiled_maximize_three_windows() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 3);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::Leaf(keys[0]),
+                LayoutNode::Leaf(keys[1]),
+                LayoutNode::Leaf(keys[2]),
+            ],
+            weights: vec![1u16, 1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[1]);
+
+        // Maximize middle window
+        wm.toggle_maximize(keys[1]);
+        assert!(wm.windows.get(keys[1]).unwrap().is_maximized);
+        // Other windows still in tree
+        let leaves: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
+        assert_eq!(
+            leaves,
+            vec![keys[0], keys[2]],
+            "other windows still in tree"
+        );
+        // 3 children still (void preserves position)
+        if let LayoutNode::Split { children, .. } = wm.managed_layout.as_ref().unwrap().root() {
+            assert_eq!(children.len(), 3, "void placeholder preserves split slot");
+        } else {
+            panic!("expected split");
+        }
+    }
+
+    #[test]
+    fn tiled_maximize_then_minimize_and_restore() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        wm.toggle_maximize(keys[0]);
+
+        // Minimize (Iconic) then restore (Mapped)
+        wm.minimize_window(keys[0]);
+        assert_eq!(wm.window_state(keys[0]), Some(WindowState::Iconic));
+        wm.restore_minimized(keys[0]);
+        assert_eq!(wm.window_state(keys[0]), Some(WindowState::Mapped));
+
+        // Still maximized after restore
+        assert!(
+            wm.windows.get(keys[0]).unwrap().is_maximized,
+            "still maximized"
+        );
+    }
+
+    // ── No-op safety ──────────────────────────────────────────────────
+
+    #[test]
+    fn toggle_maximize_already_maximized() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.managed_layout = Some(TilingLayout::new(LayoutNode::leaf(keys[0])));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        wm.toggle_maximize(keys[0]); // maximize
+        wm.toggle_maximize(keys[0]); // unmaximize
+        wm.toggle_maximize(keys[0]); // maximize again
+        assert!(
+            wm.windows.get(keys[0]).unwrap().is_maximized,
+            "can re-maximize"
+        );
+    }
+
+    #[test]
+    fn focus_same_window_when_maximized() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.managed_layout = Some(TilingLayout::new(LayoutNode::leaf(keys[0])));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        wm.toggle_maximize(keys[0]);
+        // Calling focus_window_key with the same (already focused) window
+        // should NOT unmaximize it
+        wm.focus_window_key(keys[0]);
+        assert!(
+            wm.windows.get(keys[0]).unwrap().is_maximized,
+            "focus same window should not unmaximize"
+        );
+    }
+
+    // ── Teardown / Lifecycle ──────────────────────────────────────────
+
+    #[test]
+    fn close_maximized_tiled_removes_void() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        wm.toggle_maximize(keys[0]);
+
+        // Close the maximized window
+        wm.close_window(keys[0]);
+
+        // The other window should have its leaf still in the tree (no orphan void)
+        let leaves: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
+        assert_eq!(leaves, vec![keys[1]], "only remaining window in tree");
+        assert!(!wm.windows.contains_key(keys[0]), "window removed");
+    }
+
+    #[test]
+    fn close_maximized_floating_restores_normally() {
+        use crate::window::{FloatRect, FloatRectSpec};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        let float_rect = FloatRectSpec::Absolute(FloatRect {
+            x: 10,
+            y: 5,
+            width: 30,
+            height: 15,
+        });
+        wm.set_floating_rect(keys[0], Some(float_rect));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // Maximize floating, then close
+        wm.toggle_maximize(keys[0]);
+        wm.close_window(keys[0]);
+        assert!(!wm.windows.contains_key(keys[0]), "window removed");
+    }
+
+    #[test]
+    fn unmap_maximized_tiled_removes_void() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        wm.toggle_maximize(keys[0]);
+
+        // Unmap (transition_window instead of close)
+        wm.transition_window(keys[0], WindowState::Unmapped);
+
+        // Void should be removed from tree
+        let leaves: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
+        assert_eq!(leaves, vec![keys[1]], "only remaining window in tree");
+        assert!(
+            wm.windows.get(keys[0]).unwrap().void_id.is_none(),
+            "void_id cleared"
+        );
+    }
+
+    #[test]
+    fn try_spawn_floating_default_behavior_matrix() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 3);
+
+        // Case 1: Tiling layout present → must return false
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.set_managed_layout(crate::layout::TilingLayout::new(
+            crate::layout::LayoutNode::leaf(keys[0]),
+        ));
+        assert!(
+            !wm.try_spawn_floating_default(keys[0]),
+            "must return false when tiling layout exists"
+        );
+
+        // Case 2: No layout, all windows floating → returns true
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.set_managed_layout_none();
+        wm.set_floating_rect(
+            keys[0],
+            Some(crate::window::FloatRectSpec::Absolute(
+                crate::window::FloatRect {
+                    x: 10,
+                    y: 5,
+                    width: 30,
+                    height: 15,
+                },
+            )),
+        );
+        assert!(
+            wm.try_spawn_floating_default(keys[1]),
+            "must return true when all mapped windows are floating"
+        );
+        assert!(wm.is_window_floating(keys[1]));
+
+        // Case 3: Non-floating mapped window present → returns false
+        wm.transition_window(keys[2], WindowState::Mapped);
+        wm.clear_floating_rect(keys[0]);
+        assert!(
+            !wm.try_spawn_floating_default(keys[2]),
+            "must return false when non-floating mapped window exists"
+        );
+    }
+
+    #[test]
+    fn focus_add_preserves_existing_valid_focus() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+
+        // Initial state: placeholder key in focus.current() — invalid
+        assert!(!wm.windows.contains_key(*wm.focus.current()));
+
+        // First focus_add sets current (old key was invalid)
+        wm.focus_add(keys[0]);
+        assert_eq!(*wm.focus.current(), keys[0]);
+
+        // Second focus_add must append to order but PRESERVE focus
+        wm.focus_add(keys[1]);
+        assert_eq!(*wm.focus.current(), keys[0]);
+        assert!(wm.focus.order().contains(&keys[1]));
+    }
+
+    #[test]
+    fn advance_focus_cycles_order_forward_and_backward() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 3);
+        // Directly set focus ring to bypass focus_window_key side effects
+        wm.focus.set_order(keys.clone());
+        wm.focus.set_current(keys[0]);
+
+        wm.advance_focus(true);
+        assert_eq!(wm.focused_window(), keys[1], "forward 0→1");
+
+        wm.advance_focus(true);
+        assert_eq!(wm.focused_window(), keys[2], "forward 1→2");
+
+        wm.advance_focus(true);
+        assert_eq!(wm.focused_window(), keys[0], "wraps 2→0");
+
+        wm.advance_focus(false);
+        assert_eq!(wm.focused_window(), keys[2], "backward 0→2");
+    }
+
+    #[test]
+    fn take_synthetic_event_clears_on_take() {
+        use crate::events::{Event, KeyCode, KeyEvent, KeyKind, KeyModifiers};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+
+        assert!(wm.take_synthetic_event().is_none());
+
+        wm.synthetic_event = Some(Event::Key(KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        )));
+
+        assert!(
+            wm.take_synthetic_event().is_some(),
+            "first take returns Some"
+        );
+        assert!(
+            wm.take_synthetic_event().is_none(),
+            "second take returns None"
+        );
+    }
+
+    #[test]
+    fn select_fallback_focus_handles_empty_and_populated_ring() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+
+        // Empty order → no panic
+        wm.focus.set_order(Vec::new());
+        wm.select_fallback_focus();
+
+        // Populated order → selects first item
+        let keys = make_keys(&mut wm, 2);
+        wm.focus.set_order(vec![keys[1], keys[0]]);
+        wm.select_fallback_focus();
+        assert_eq!(*wm.focus.current(), keys[1]);
+    }
+
+    // ── Open window while maximized ───────────────────────────────────
+
+    #[test]
+    fn open_window_when_tiled_window_is_maximized_unmaximizes_and_shows_both() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = mapped_keys(&mut wm, 2);
+        // Verify focus_add didn't steal focus from keys[0]
+        assert_eq!(wm.focused_window(), keys[0], "focus starts on keys[0]");
+
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.set_managed_layout(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        // Maximize keys[0] (was tiled)
+        wm.toggle_maximize(keys[0]);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+
+        // Simulate what open_window does manuallly to see where it breaks
+        let b = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        // focus.current() should still be keys[0] after create_window
+        assert_eq!(
+            wm.focused_window(),
+            keys[0],
+            "focus still on keys[0] after create"
+        );
+
+        wm.transition_window(b, WindowState::Mapped);
+        // focus_add should NOT have changed focus to b
+        assert_eq!(
+            wm.focused_window(),
+            keys[0],
+            "focus still on keys[0] after transition"
+        );
+
+        // try_spawn_floating_default
+        let spawned_float = wm.try_spawn_floating_default(b);
+        assert!(!spawned_float, "should not spawn floating in tiling mode");
+
+        // tile_window_key then focus_window_key
+        wm.tile_window_key(b);
+        assert_eq!(wm.focused_window(), b, "focus moved to new window");
+        assert!(
+            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            "keys[0] unmaximized by focus shift"
+        );
+        assert!(
+            wm.managed_layout
+                .as_ref()
+                .is_some_and(|l| l.root().subtree_any(|k| k == keys[0])),
+            "keys[0] in tree"
+        );
+    }
+
+    #[test]
+    fn open_window_when_floating_window_is_maximized_unmaximizes_and_shows_both() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        use crate::window::{FloatRect, FloatRectSpec};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = mapped_keys(&mut wm, 2);
+        // Put keys[1] in a single-leaf tiling layout first, THEN float keys[0]
+        // (set_managed_layout calls clear_all_floating which would clear it)
+        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
+        let orig_float = FloatRectSpec::Absolute(FloatRect {
+            x: 10,
+            y: 5,
+            width: 30,
+            height: 15,
+        });
+        wm.set_floating_rect(keys[0], Some(orig_float));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        assert_eq!(wm.focused_window(), keys[0], "focus on keys[0]");
+
+        // Maximize keys[0] (was floating)
+        wm.toggle_maximize(keys[0]);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+        assert_eq!(
+            wm.focused_window(),
+            keys[0],
+            "focus still keys[0] after maximize"
+        );
+
+        // Simulate open_window manually
+        let b = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        assert_eq!(
+            wm.focused_window(),
+            keys[0],
+            "focus still keys[0] after create"
+        );
+
+        wm.transition_window(b, WindowState::Mapped);
+        assert_eq!(
+            wm.focused_window(),
+            keys[0],
+            "focus still keys[0] after transition"
+        );
+
+        let spawned_float = wm.try_spawn_floating_default(b);
+        assert!(
+            !spawned_float,
+            "should not spawn floating when managed_layout exists"
+        );
+
+        wm.tile_window_key(b);
+        assert!(
+            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            "keys[0] unmaximized by focus shift"
+        );
+        // B gets tiled (managed_layout exists with keys[1])
+        assert!(!wm.is_window_floating(b), "new window is tiled");
+        let restored = wm.floating_rect(keys[0]);
+        assert_eq!(
+            restored,
+            Some(orig_float),
+            "original floating rect restored"
+        );
+    }
+
+    // ── select_fallback_focus ─────────────────────────────────────────
+
+    #[test]
+    fn select_fallback_focus_handles_empty_ring_safely() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // Empty focus ring — select_fallback_focus should not panic
+        wm.select_fallback_focus();
+
+        // Add a window, focus it, then remove it
+        let keys = mapped_keys(&mut wm, 1);
+        wm.focus_window_key(keys[0]);
+        wm.close_window(keys[0]);
+
+        // Fallback on an empty ring — should not panic
+        wm.select_fallback_focus();
     }
 
     #[test]

--- a/crates/term-wm-layout-engine/src/tiling.rs
+++ b/crates/term-wm-layout-engine/src/tiling.rs
@@ -388,6 +388,23 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
         }
     }
 
+    /// Replace a leaf identified by `id` with a Void placeholder, preserving
+    /// the tree structure and split weights. Returns the fresh void_id, or
+    /// None if the leaf was not found.
+    pub fn replace_leaf_with_void(&mut self, id: Id) -> Option<usize> {
+        let mut path = Vec::new();
+        if !self.find_leaf_path(&id, &mut path, &mut Vec::new()) {
+            return None;
+        }
+        let void_id = VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        if let Some(node) = self.node_at_path_mut(&path) {
+            *node = LayoutNode::Void(void_id);
+            Some(void_id)
+        } else {
+            None
+        }
+    }
+
     pub fn insert_leaf(&mut self, target: Id, insert: Id, position: InsertPosition) -> bool {
         match self {
             LayoutNode::Leaf(current) => {
@@ -614,6 +631,38 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
                     if child.replace_void_by_id(void_id, new_leaf.clone()) {
                         return true;
                     }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    /// Remove a Void node by its ID from the tree. Returns true if the void
+    /// was found and removed, false otherwise. Cleans up empty parent splits.
+    pub fn remove_void_by_id(&mut self, void_id: usize) -> bool {
+        match self {
+            LayoutNode::Void(id) if *id == void_id => {
+                *self = LayoutNode::Void(VOID_ID_COUNTER.fetch_add(1, Ordering::Relaxed));
+                true
+            }
+            LayoutNode::Split {
+                children, weights, ..
+            } => {
+                let mut i = 0;
+                while i < children.len() {
+                    if children[i].remove_void_by_id(void_id) {
+                        // If the child was replaced with a Void (the one we
+                        // just replaced above), remove it from the split.
+                        if matches!(children[i], LayoutNode::Void(_)) {
+                            children.remove(i);
+                            if i < weights.len() {
+                                weights.remove(i);
+                            }
+                        }
+                        return true;
+                    }
+                    i += 1;
                 }
                 false
             }
@@ -1795,5 +1844,161 @@ mod tests {
         assert!(node.insert_leaf(2, 3, InsertPosition::Right));
         let leaves = node.collect_leaves();
         assert_eq!(leaves, vec![1, 2, 3]);
+    }
+
+    const TEST_AREA: crate::rect::LayoutRect = crate::rect::LayoutRect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+    };
+
+    // ── replace_leaf_with_void ────────────────────────────────────────
+
+    #[test]
+    fn replace_leaf_with_void_single_leaf() {
+        let mut node = LayoutNode::leaf(42);
+        let vid = node.replace_leaf_with_void(42);
+        assert!(vid.is_some(), "should return a void_id");
+        assert!(matches!(node, LayoutNode::Void(_)), "leaf became void");
+        // layout_rects should yield nothing
+        let rects = node.layout_rects(TEST_AREA);
+        assert!(rects.is_empty(), "void produces no regions");
+    }
+
+    #[test]
+    fn replace_leaf_with_void_nested_split() {
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1),
+                LayoutNode::leaf(2),
+                LayoutNode::leaf(3),
+            ],
+            weights: vec![1u16, 1u16, 1u16],
+            resizable: true,
+        };
+        let vid = node.replace_leaf_with_void(2);
+        assert!(vid.is_some(), "should return a void_id");
+        // Structure: Split [Leaf(1), Void(vid), Leaf(3)]
+        let leaves = node.collect_leaves();
+        assert_eq!(leaves, vec![1, 3], "leaf 2 removed from tree");
+        // Weights should be preserved (3 weights still, the void is a child)
+        if let LayoutNode::Split {
+            children, weights, ..
+        } = &node
+        {
+            assert_eq!(children.len(), 3, "void placeholder preserved");
+            assert_eq!(weights.len(), 3, "weights preserved");
+        } else {
+            panic!("expected Split");
+        }
+    }
+
+    #[test]
+    fn replace_leaf_with_void_nonexistent() {
+        let mut node = LayoutNode::leaf(42);
+        let vid = node.replace_leaf_with_void(99);
+        assert!(vid.is_none(), "nonexistent id returns None");
+        assert_eq!(node.unwrap_leaf(), Some(42), "tree unchanged");
+    }
+
+    // ── remove_void_by_id ─────────────────────────────────────────────
+
+    #[test]
+    fn remove_void_by_id_existing_root() {
+        let mut node: LayoutNode<usize> = LayoutNode::Void(99);
+        assert!(node.remove_void_by_id(99));
+        // Becomes a new void (fresh id), but it was removed
+        assert!(matches!(node, LayoutNode::Void(_)));
+    }
+
+    #[test]
+    fn remove_void_by_id_nested() {
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1),
+                LayoutNode::Void(99),
+                LayoutNode::leaf(3),
+            ],
+            weights: vec![1u16, 1u16, 1u16],
+            resizable: true,
+        };
+        assert!(node.remove_void_by_id(99), "void removed");
+        // After removal the split should have 2 children
+        let leaves = node.collect_leaves();
+        assert_eq!(leaves, vec![1, 3], "remaining leaves preserved");
+    }
+
+    #[test]
+    fn remove_void_by_id_nonexistent() {
+        let mut node = LayoutNode::leaf(42);
+        assert!(!node.remove_void_by_id(99), "nonexistent returns false");
+    }
+
+    #[test]
+    fn remove_void_by_id_deeply_nested() {
+        // Split [Leaf(1), Split [Void(99), Leaf(2)]]
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1),
+                LayoutNode::Split {
+                    direction: Direction::Vertical,
+                    children: vec![LayoutNode::Void(99), LayoutNode::leaf(2)],
+                    weights: vec![1u16, 1u16],
+                    resizable: true,
+                },
+            ],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        assert!(node.remove_void_by_id(99), "deeply nested void removed");
+        let leaves = node.collect_leaves();
+        assert_eq!(
+            leaves,
+            vec![1, 2],
+            "remaining leaves preserved after deep removal"
+        );
+    }
+
+    // ── Void placeholder preserves layout ─────────────────────────────
+
+    #[test]
+    fn void_produces_no_regions_in_split() {
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::leaf(1), LayoutNode::leaf(2)],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        // Replace leaf 2 with void
+        node.replace_leaf_with_void(2);
+        let rects = node.layout_rects(TEST_AREA);
+        // Only leaf 1 produces a region; leaf 2's slot is preserved but empty
+        assert_eq!(rects.len(), 1, "only one region");
+        assert_eq!(rects[0].0, 1, "remaining leaf id");
+        assert!(rects[0].1.width > 0, "leaf region has positive width");
+    }
+
+    #[test]
+    fn void_placeholder_preserves_weights() {
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1),
+                LayoutNode::leaf(2),
+                LayoutNode::leaf(3),
+            ],
+            weights: vec![2u16, 3u16, 5u16],
+            resizable: true,
+        };
+        let _ = node.replace_leaf_with_void(2);
+        if let LayoutNode::Split { weights, .. } = &node {
+            assert_eq!(weights.as_slice(), &[2u16, 3u16, 5u16], "weights unchanged");
+        } else {
+            panic!("expected Split");
+        }
     }
 }

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -1776,6 +1776,63 @@ mod floating_tiled_separation {
 
         assert_bifurcation_invariant(&wm);
     }
+
+    // ── Maximize while tiled — integration tests ──────────────────────
+
+    #[test]
+    fn maximize_tiled_via_double_click_then_unmaximize_via_toggle() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        // Double-click header to maximize
+        let header = header_rect(&mut wm, keys[0]);
+        let col = header.x as u16;
+        let row = header.y as u16;
+        let down = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&down);
+        let up = make_mouse(MouseEventKind::Release(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&up);
+        let down2 = make_mouse(MouseEventKind::Press(MouseButton::Left), col, row);
+        wm.dispatch_mouse(&down2);
+
+        // Should be maximized (floating with full-area rect via the void path)
+        let panes = wm.floating_panes();
+        let (_, spec) = panes
+            .iter()
+            .find(|(k, _)| *k == keys[0])
+            .expect("window in floating");
+        if let term_wm::window::FloatRectSpec::Absolute(rect) = spec {
+            assert_eq!(rect.width, AREA.width, "maximized width");
+            assert_eq!(rect.height, AREA.height, "maximized height");
+        } else {
+            panic!("expected absolute float rect");
+        }
+        assert_bifurcation_invariant(&wm);
+
+        // Toggle back to unmaximize
+        wm.toggle_maximize(keys[0]);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+        assert!(!wm.is_window_floating(keys[0]), "restored to tiled");
+        assert_bifurcation_invariant(&wm);
+    }
+
+    #[test]
+    fn maximize_tiled_region_unchanged_after_unmaximize() {
+        let (mut wm, mut engine, mut renderer, keys) = setup();
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let orig_region = wm.region(keys[0]);
+
+        wm.toggle_maximize(keys[0]);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        wm.toggle_maximize(keys[0]);
+        advance_frame(&mut wm, &mut engine, &mut renderer);
+
+        let restored = wm.region(keys[0]);
+        assert_eq!(restored, orig_region, "region restored after unmaximize");
+        assert_bifurcation_invariant(&wm);
+    }
 }
 
 // ─── Module 8: Render Pipeline Verification ──────────────────────────


### PR DESCRIPTION
When a maximized window loses focus to another window, it now automatically unmaximizes.  Two-layer approach: tiled-origin windows use in-tree Void placeholders to preserve exact position and weights; floating-origin windows use prev_floating_rect restoration.

== Root bugs ==

1. Tiled window maximized → other windows behind it couldn't be tabbed-to or clicked.  The maximized window stayed full-screen floating on top even after focus moved elsewhere.

2. Opening a new window while one was maximized either failed to unmaximize (focus_add prematurely overwrote the current focus, making focus_window_key's prev_focus check a no-op) or destroyed the tiling layout (try_spawn_floating_default saw a floating_rect on the maximized window and cleared managed_layout).

== Changes ==

Layout engine (term-wm-layout-engine/src/tiling.rs):
  - Add replace_leaf_with_void(&mut self, id) -> Option<usize>
  - Add remove_void_by_id(&mut self, void_id) -> bool
  - 9 new unit tests covering both methods (single, nested, deep-nested, nonexistent, weight preservation, zero-space layout)

Window state (crates/term-wm-core/src/window/entry.rs):
  - Add void_id: Option<usize> to Window — tracks the Void placeholder when a tiled window is maximized

TilingLayout wrappers (crates/term-wm-core/src/layout/tiling.rs):
  - Add replace_leaf_with_void, remove_void_by_id delegating to root

toggle_maximize
(crates/term-wm-core/src/window/window_manager/chrome.rs):
  - Maximize (tiled): replace Leaf with Void in-place (preserves tree topology, split weights, and spatial position)
  - Maximize (floating): save floating_rect to prev_floating_rect
  - Unmaximize (tiled): replace_void_by_id → restore Leaf; clear floating_rect
  - Unmaximize (floating): restore prev_floating_rect

Focus interception
(crates/term-wm-core/src/window/window_manager/focus.rs):
  - focus_window_key: unmaximize prev_focus if it's maximized
  - advance_focus: capture prev_focus before advance, unmaximize if focus actually changes
  - focus_app_window: delegate to focus_window_key
  - handle_focus_event mouse handler: use focus_window_key instead of raw focus.set_current + bring_floating_to_front_key

focus_add (crates/term-wm-core/src/window/window_manager/mod.rs):
  - Only set focus.current() when current is invalid (e.g. startup). Previously every transition_window(Mapped) overwrote focus, defeating the prev_focus check in focus_window_key.

detach_from_tiling_layout
(crates/term-wm-core/src/window/window_manager/layout.rs):
  - Check void_id first: if set, remove Void node from tree instead of searching for Leaf(key) which doesn't exist
  - Prevents orphaned Void placeholders when closing a maximized window

try_spawn_floating_default
(crates/term-wm-core/src/window/window_manager/drag.rs):
  - Early-return false when managed_layout.is_some() — prevents destruction of the tiling tree when a maximized window has a floating_rect but the workspace is actually in Tiling Mode
  - Remove managed_layout = None and redundant focus_window_key call

== Test coverage ==

34 tests across 3 layers (all green):
  - 9 layout engine unit tests (Void node operations)
  - 23 WM unit tests (maximize/unmaximize paths, focus cycling, mouse click, minimize, close, unmap, new-window-while-maximized, select_fallback_focus, advance_focus cycle, try_spawn matrix, focus_add pointer safety, take_synthetic_event)
  - 2 integration tests (double-click maximize + toggle restore, region preservation after unmaximize cycle)