### PR TITLE
feat(core): Parameterize per-window actions with WindowKey; fix scroll sync for direct/alt screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3116,6 +3116,7 @@ version = "0.8.20-alpha"
 dependencies = [
  "criterion",
  "crossterm",
+ "insta",
  "libc",
  "ratatui",
  "term-wm-core",

--- a/crates/term-wm-console/Cargo.toml
+++ b/crates/term-wm-console/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+insta = { workspace = true }
 libc = { workspace = true }
 term-wm-pty-engine = { workspace = true }
 

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -23,7 +23,6 @@ pub struct ChromeCtx<'a> {
     pub title: &'a str,
     pub focused: bool,
     pub floating: bool,
-    pub direct_mode: bool,
     pub hover_pos: Option<(u16, u16)>,
     pub theme: term_wm_core::theme::Theme,
     pub wm_buttons: Vec<term_wm_core::window::WmButton>,
@@ -164,10 +163,9 @@ fn register_window_chrome_hitboxes(registry: &mut HitboxRegistry, params: &Chrom
                 bx.saturating_sub(CHROME_BUTTON_FLOAT_OFFSET)
             };
             let target = match btn.action {
-                TermWmAction::CloseWindow => ChromeTarget::CloseButton(*key),
-                TermWmAction::MaximizeWindow => ChromeTarget::MaximizeButton(*key),
-                TermWmAction::MinimizeWindow => ChromeTarget::MinimizeButton(*key),
-                TermWmAction::ToggleDirectMode => ChromeTarget::ToggleDirectMode(*key),
+                TermWmAction::CloseWindow(..) => ChromeTarget::CloseButton(*key),
+                TermWmAction::MaximizeWindow(..) => ChromeTarget::MaximizeButton(*key),
+                TermWmAction::MinimizeWindow(..) => ChromeTarget::MinimizeButton(*key),
                 _ => continue,
             };
             registry.register(
@@ -237,7 +235,6 @@ pub fn render_window_chrome(
             title: ctx.title,
             focused: ctx.focused,
             floating: ctx.floating,
-            direct_mode: ctx.direct_mode,
             hover_pos: ctx.hover_pos,
             theme: ctx.theme,
             wm_buttons: ctx.wm_buttons.clone(),
@@ -1092,7 +1089,7 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
         title,
         focused,
         floating,
-        direct_mode,
+
         hover_pos,
         theme,
         wm_buttons,
@@ -1202,30 +1199,27 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
                 let cell = &mut buffer.content[rel_y * buf_w + rel_x];
                 cell.set_symbol(btn.symbol);
                 let stoplight_fg = match btn.action {
-                    TermWmAction::CloseWindow => theme.error.to_ratatui(),
-                    TermWmAction::MinimizeWindow => theme.warning.to_ratatui(),
-                    TermWmAction::MaximizeWindow => theme.accent.to_ratatui(),
+                    TermWmAction::CloseWindow(..) => theme.error.to_ratatui(),
+                    TermWmAction::MinimizeWindow(..) => theme.warning.to_ratatui(),
+                    TermWmAction::MaximizeWindow(..) => theme.accent.to_ratatui(),
                     _ => theme.decorator_header_fg.to_ratatui(),
                 };
                 let is_hovered = hover_pos == Some((bx, header_y));
                 let style = if is_hovered {
                     let (hover_bg, hover_fg) = match btn.action {
-                        TermWmAction::CloseWindow => (theme.error.to_ratatui(), contrast_fg),
-                        TermWmAction::MinimizeWindow => (theme.warning.to_ratatui(), contrast_fg),
-                        TermWmAction::MaximizeWindow => (theme.accent.to_ratatui(), contrast_fg),
+                        TermWmAction::CloseWindow(..) => (theme.error.to_ratatui(), contrast_fg),
+                        TermWmAction::MinimizeWindow(..) => {
+                            (theme.warning.to_ratatui(), contrast_fg)
+                        }
+                        TermWmAction::MaximizeWindow(..) => {
+                            (theme.accent.to_ratatui(), contrast_fg)
+                        }
                         _ => (theme.accent_alt.to_ratatui(), contrast_fg),
                     };
                     Style::default()
                         .bg(hover_bg)
                         .fg(hover_fg)
                         .add_modifier(Modifier::BOLD)
-                } else if matches!(btn.action, TermWmAction::ToggleDirectMode)
-                    && direct_mode
-                    && focused
-                {
-                    Style::default()
-                        .bg(theme.decorator_header_fg.to_ratatui())
-                        .fg(theme.decorator_header_bg.to_ratatui())
                 } else {
                     Style::default().bg(header_bg.to_ratatui()).fg(stoplight_fg)
                 };
@@ -1923,24 +1917,19 @@ mod tests {
     fn test_wm_buttons() -> Vec<WmButton> {
         vec![
             WmButton {
-                action: TermWmAction::CloseWindow,
+                action: TermWmAction::CloseWindow(Default::default()),
                 label: "Close Window",
                 symbol: "X",
             },
             WmButton {
-                action: TermWmAction::MaximizeWindow,
+                action: TermWmAction::MaximizeWindow(Default::default()),
                 label: "Maximize Window",
                 symbol: "▢",
             },
             WmButton {
-                action: TermWmAction::MinimizeWindow,
+                action: TermWmAction::MinimizeWindow(Default::default()),
                 label: "Minimize Window",
                 symbol: "_",
-            },
-            WmButton {
-                action: TermWmAction::ToggleDirectMode,
-                label: "Toggle Direct Mode",
-                symbol: "D",
             },
         ]
     }
@@ -1986,7 +1975,6 @@ mod tests {
             title: "test",
             focused: false,
             floating: false,
-            direct_mode: false,
             hover_pos: None,
             theme: NOIR,
             wm_buttons: test_wm_buttons(),
@@ -2079,7 +2067,6 @@ mod tests {
             title: "test",
             focused: false,
             floating: false,
-            direct_mode: false,
             hover_pos: None,
             theme: NOIR,
             wm_buttons: test_wm_buttons(),

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -31,14 +31,12 @@ pub struct ChromeCtx<'a> {
 }
 
 use term_wm_core::chrome::{
-    LEFT_BORDER_WIDTH, RIGHT_BORDER_WIDTH, TOP_BORDER_HEIGHT, content_rect,
+    LEFT_BORDER_WIDTH, RIGHT_BORDER_WIDTH, TOP_BORDER_HEIGHT, button_x_pos, content_rect,
 };
+use term_wm_core::constants::HEADER_BUTTON_GAP;
 
 // ── Chrome layout constants (console-specific) ──────────────
-const HEADER_BUTTON_GAP: u16 = 2;
 const EDGE_INDEX_ADJUST: u16 = 1;
-/// Shift window-control buttons 1 cell left (tiled) or right (floating) for visual alignment.
-const CHROME_BUTTON_FLOAT_OFFSET: u16 = 1;
 
 /// Register chrome hitboxes for a window (resize, drag, close, maximize buttons).
 /// Parameters for chrome hitbox registration.
@@ -50,7 +48,6 @@ struct ChromeHitboxParams {
     wm_buttons: Vec<term_wm_core::window::WmButton>,
     borders_enabled: bool,
     header_enabled: bool,
-    floating: bool,
 }
 
 /// Register chrome hitboxes for a window (resize, drag, close, maximize buttons).
@@ -69,7 +66,7 @@ fn register_window_chrome_hitboxes(registry: &mut HitboxRegistry, params: &Chrom
         wm_buttons,
         borders_enabled,
         header_enabled,
-        floating,
+        ..
     } = params;
     let (width, height) = *frame_size;
     let (ox, oy) = *screen_origin;
@@ -144,24 +141,8 @@ fn register_window_chrome_hitboxes(registry: &mut HitboxRegistry, params: &Chrom
         );
 
         // Window management buttons from centralized list
-        let btn_right = if *borders_enabled {
-            outer_right.saturating_sub(RIGHT_BORDER_WIDTH)
-        } else {
-            outer_right
-        };
         for (i, btn) in wm_buttons.iter().enumerate() {
-            let bx = if *borders_enabled {
-                btn_right
-                    .saturating_sub(HEADER_BUTTON_GAP)
-                    .saturating_sub(HEADER_BUTTON_GAP * i as u16)
-            } else {
-                btn_right.saturating_sub(HEADER_BUTTON_GAP * i as u16)
-            };
-            let bx = if *floating {
-                bx.saturating_add(CHROME_BUTTON_FLOAT_OFFSET)
-            } else {
-                bx.saturating_sub(CHROME_BUTTON_FLOAT_OFFSET)
-            };
+            let bx = button_x_pos(outer_right, *borders_enabled, i);
             let target = match btn.action {
                 TermWmAction::CloseWindow(..) => ChromeTarget::CloseButton(*key),
                 TermWmAction::MaximizeWindow(..) => ChromeTarget::MaximizeButton(*key),
@@ -254,7 +235,6 @@ pub fn render_window_chrome(
             wm_buttons: ctx.wm_buttons.clone(),
             borders_enabled: ctx.borders_enabled,
             header_enabled: ctx.header_enabled,
-            floating: ctx.floating,
         },
     );
 
@@ -1183,18 +1163,7 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
             let rel_y = header_y as usize - buffer.area.y as usize;
             // Buttons are laid out right-to-left from outer_right
             for (i, btn) in wm_buttons.iter().enumerate() {
-                let bx = if borders_enabled {
-                    header_right
-                        .saturating_sub(HEADER_BUTTON_GAP)
-                        .saturating_sub(HEADER_BUTTON_GAP * i as u16)
-                } else {
-                    header_right.saturating_sub(HEADER_BUTTON_GAP * i as u16)
-                };
-                let bx = if floating {
-                    bx.saturating_add(CHROME_BUTTON_FLOAT_OFFSET)
-                } else {
-                    bx.saturating_sub(CHROME_BUTTON_FLOAT_OFFSET)
-                };
+                let bx = button_x_pos(outer_right, borders_enabled, i);
                 let rel_x = bx as usize - buffer.area.x as usize;
                 let cell = &mut buffer.content[rel_y * buf_w + rel_x];
                 cell.set_symbol(btn.symbol);
@@ -2288,5 +2257,31 @@ mod tests {
             "single cell should be REVERSED"
         );
         assert_eq!(buf.cell((0, 0)).unwrap().symbol(), "·");
+    }
+
+    // ── Window chrome snapshot tests ────────────────────────────────────
+
+    #[test]
+    fn chrome_header_buttons_snapshot() {
+        let area = RatatuiRect::new(0, 0, 30, 8);
+        let mut buffer = Buffer::empty(area);
+        let ctx = ChromeCtx {
+            title: "term-wm",
+            focused: true,
+            floating: false,
+            hover_pos: None,
+            theme: NOIR,
+            wm_buttons: test_wm_buttons(),
+            borders_enabled: true,
+            header_enabled: true,
+        };
+        let rect = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 8,
+        };
+        render_window(&mut buffer, rect, ctx);
+        insta::assert_debug_snapshot!("chrome_header_buttons", buffer);
     }
 }

--- a/crates/term-wm-console/src/snapshots/term_wm_console__draw_plan_renderer__tests__chrome_header_buttons.snap
+++ b/crates/term-wm-console/src/snapshots/term_wm_console__draw_plan_renderer__tests__chrome_header_buttons.snap
@@ -1,0 +1,38 @@
+---
+source: crates/term-wm-console/src/draw_plan_renderer.rs
+expression: buffer
+---
+Buffer {
+    area: Rect { x: 0, y: 0, width: 30, height: 8 },
+    content: [
+        "┌────────────────────────────┐",
+        "│          term-wm     _ ▢ X │",
+        "│                            │",
+        "│                            │",
+        "│                            │",
+        "│                            │",
+        "│                            │",
+        "└────────────────────────────┘",
+    ],
+    styles: [
+        x: 0, y: 0, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 1, fg: Rgb(225, 225, 235), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 23, y: 1, fg: Rgb(255, 193, 7), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 24, y: 1, fg: Rgb(225, 225, 235), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 25, y: 1, fg: Rgb(0, 230, 118), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 26, y: 1, fg: Rgb(225, 225, 235), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 27, y: 1, fg: Rgb(255, 61, 61), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 28, y: 1, fg: Rgb(225, 225, 235), bg: Rgb(38, 42, 58), underline: Reset, modifier: BOLD,
+        x: 29, y: 1, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 2, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 29, y: 2, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 3, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 29, y: 3, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 4, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 29, y: 4, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 5, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 29, y: 5, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 6, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 29, y: 6, fg: Rgb(110, 118, 140), bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}

--- a/crates/term-wm-core/src/actions.rs
+++ b/crates/term-wm-core/src/actions.rs
@@ -84,13 +84,13 @@ pub enum TermWmAction {
     // WM-level actions from WmMenuAction
     CloseMenu,
     Help,
-    CloseWindow,
+    CloseWindow(WindowKey),
     ToggleMouseCapture,
     ToggleClipboardMode,
     ToggleWindowSelection,
-    MinimizeWindow,
-    MaximizeWindow,
-    ToggleDirectMode,
+    MinimizeWindow(WindowKey),
+    MaximizeWindow(WindowKey),
+    ToggleDirectMode(WindowKey),
     ToggleMonocle,
     ToggleTiling,
     ToggleDebugWindow,
@@ -204,13 +204,13 @@ impl TermWmAction {
             | TermWmAction::HintToggle
             | TermWmAction::CloseMenu
             | TermWmAction::Help
-            | TermWmAction::CloseWindow
+            | TermWmAction::CloseWindow(_)
             | TermWmAction::ToggleMouseCapture
             | TermWmAction::ToggleClipboardMode
             | TermWmAction::ToggleWindowSelection
-            | TermWmAction::MinimizeWindow
-            | TermWmAction::MaximizeWindow
-            | TermWmAction::ToggleDirectMode
+            | TermWmAction::MinimizeWindow(_)
+            | TermWmAction::MaximizeWindow(_)
+            | TermWmAction::ToggleDirectMode(_)
             | TermWmAction::ToggleMonocle
             | TermWmAction::ToggleTiling
             | TermWmAction::ToggleDebugWindow
@@ -316,13 +316,13 @@ impl fmt::Display for TermWmAction {
             TermWmAction::ScrollToBottom => "Scroll view to bottom",
             TermWmAction::CloseMenu => "Close menu",
             TermWmAction::Help => "Help",
-            TermWmAction::CloseWindow => "Close window",
+            TermWmAction::CloseWindow(_) => "Close window",
             TermWmAction::ToggleMouseCapture => "Toggle mouse capture",
             TermWmAction::ToggleClipboardMode => "Toggle clipboard mode",
             TermWmAction::ToggleWindowSelection => "Toggle window selection",
-            TermWmAction::MinimizeWindow => "Minimize window",
-            TermWmAction::MaximizeWindow => "Maximize window",
-            TermWmAction::ToggleDirectMode => "Toggle direct mode",
+            TermWmAction::MinimizeWindow(_) => "Minimize window",
+            TermWmAction::MaximizeWindow(_) => "Maximize window",
+            TermWmAction::ToggleDirectMode(_) => "Toggle direct mode",
             TermWmAction::ToggleMonocle => "Toggle monocle mode",
             TermWmAction::ToggleTiling => "Toggle tiling",
             TermWmAction::ToggleDebugWindow => "Toggle debug window",

--- a/crates/term-wm-core/src/chrome/metrics.rs
+++ b/crates/term-wm-core/src/chrome/metrics.rs
@@ -1,4 +1,27 @@
 use crate::Rect;
+use crate::constants::{CHROME_BUTTON_INSET_RIGHT, HEADER_BUTTON_GAP};
+
+/// Compute the x-position of a title button in window-chrome coordinates.
+///
+/// `outer_right` is the rightmost column of the full window frame.
+/// `borders_enabled` determines whether the right-border width is subtracted.
+/// `button_index` is the 0-based index into the window-management buttons
+/// (0 = rightmost button, 1 = next to the left, etc.).
+///
+/// Both rendering (`render_window`) and hitbox registration
+/// (`register_window_chrome_hitboxes`) call this so the visual positions
+/// always match the click targets. Tests in `mod.rs` also use this to
+/// place extra hitboxes (e.g. the D button) at the correct coordinate.
+pub fn button_x_pos(outer_right: u16, borders_enabled: bool, button_index: usize) -> u16 {
+    let header_right = if borders_enabled {
+        outer_right.saturating_sub(RIGHT_BORDER_WIDTH)
+    } else {
+        outer_right
+    };
+    header_right
+        .saturating_sub(CHROME_BUTTON_INSET_RIGHT)
+        .saturating_sub(HEADER_BUTTON_GAP * button_index as u16)
+}
 
 pub const LEFT_BORDER_WIDTH: u16 = 1;
 pub const RIGHT_BORDER_WIDTH: u16 = 1;
@@ -68,9 +91,23 @@ pub fn content_rect(full: Rect, borders_enabled: bool, header_enabled: bool) -> 
     }
 }
 
+/// Verify that the chrome geometry constants match the specification in
+/// `docs/WINDOW-BORDERS.txt`.
+///
+/// For a standard 80×24 terminal with two side-by-side tiled windows
+/// separated by a 1-column split handle:
+///
+/// | Window     | Frame   | Content     | Chrome  |
+/// |------------|---------|-------------|---------|
+/// | A          | 39×24   | 37×21 = 777 | 159     |
+/// | B          | 40×24   | 38×21 = 798 | 162     |
+/// | Split      | 1×24    | —           | 24      |
+/// | **Total**  | 80×24   | 1,575       | 345     |
+/// | **Grand**  |         | 1,920       |         |
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::*;
 
     #[test]
     fn no_borders_no_header_returns_full() {
@@ -187,5 +224,59 @@ mod tests {
         let inner = content_rect(full, true, false);
         assert_eq!(inner.width, 1);
         assert_eq!(inner.height, 0);
+    }
+
+    #[test]
+    fn chrome_geometry_matches_specification() {
+        // 80x24 terminal, 2 side-by-side tiled windows, 1-col split handle.
+        let total_cols = 80u16;
+        let total_rows = 24u16;
+        let handle_cols = SPLIT_HANDLE_WIDTH;
+
+        let usable_cols = total_cols.saturating_sub(handle_cols);
+        let win_a_w = usable_cols / 2;
+        let win_b_w = usable_cols.saturating_sub(win_a_w);
+
+        assert_eq!(win_a_w, 39);
+        assert_eq!(win_b_w, 40);
+
+        for (w, expected_content_w, expected_chrome) in
+            [(win_a_w, 37, 159u16), (win_b_w, 38, 162u16)]
+        {
+            let full = Rect {
+                x: 0,
+                y: 0,
+                width: w,
+                height: total_rows,
+            };
+            let inner = content_rect(full, true, true);
+
+            assert_eq!(
+                inner.width, expected_content_w,
+                "content width for {w}x{total_rows} window"
+            );
+            assert_eq!(inner.height, total_rows.saturating_sub(CHROME_ROWS_TOTAL));
+
+            let content_cells = u32::from(inner.width) * u32::from(inner.height);
+            let chrome_cells = u32::from(w) * u32::from(total_rows) - content_cells;
+            assert_eq!(
+                chrome_cells,
+                u32::from(expected_chrome),
+                "chrome cells for {w}x{total_rows} window"
+            );
+        }
+
+        // Verify grand total
+        let win_a_content = 777u32;
+        let win_b_content = 798u32;
+        let win_a_chrome = 159u32;
+        let win_b_chrome = 162u32;
+        let split_cells = u32::from(handle_cols) * u32::from(total_rows);
+        let grand_total = win_a_content + win_b_content + win_a_chrome + win_b_chrome + split_cells;
+        assert_eq!(
+            grand_total,
+            u32::from(total_cols) * u32::from(total_rows),
+            "every cell accounted for in 80x24 layout"
+        );
     }
 }

--- a/crates/term-wm-core/src/chrome/mod.rs
+++ b/crates/term-wm-core/src/chrome/mod.rs
@@ -6,5 +6,6 @@ pub use metrics::HEADER_HEIGHT;
 pub use metrics::LEFT_BORDER_WIDTH;
 pub use metrics::RIGHT_BORDER_WIDTH;
 pub use metrics::TOP_BORDER_HEIGHT;
+pub use metrics::button_x_pos;
 pub use metrics::content_rect;
 pub use target::ChromeTarget;

--- a/crates/term-wm-core/src/components.rs
+++ b/crates/term-wm-core/src/components.rs
@@ -211,6 +211,12 @@ pub trait Component<Msg>: std::any::Any {
         None
     }
 
+    /// Returns `Some(bool)` exactly once when the pane's alternate screen state changes.
+    /// `None` means no change since the last poll.
+    fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+        None
+    }
+
     /// Extract child process and reader handles for the Reaper during teardown.
     /// Called during close_window, before the component is dropped.
     /// Default implementation returns None.

--- a/crates/term-wm-core/src/constants.rs
+++ b/crates/term-wm-core/src/constants.rs
@@ -81,3 +81,31 @@ pub const INITIAL_WINDOW_CAPACITY: usize = 32;
 
 /// Initial allocation capacity for the component slot map.
 pub const INITIAL_COMPONENT_CAPACITY: usize = 32;
+
+// ── Chrome geometry (single source of truth for WINDOW-BORDERS.txt) ─────
+
+/// Width of the left border in terminal columns.
+pub const CHROME_LEFT_COL: u16 = 1;
+/// Width of the right border in terminal columns.
+pub const CHROME_RIGHT_COL: u16 = 1;
+/// Height of the top border in terminal rows.
+pub const CHROME_TOP_ROW: u16 = 1;
+/// Height of the header row in terminal rows.
+pub const CHROME_HEADER_ROW: u16 = 1;
+/// Height of the bottom border in terminal rows.
+pub const CHROME_BOTTOM_ROW: u16 = 1;
+
+/// Total chrome columns consumed per window (left + right borders).
+pub const CHROME_COLS_TOTAL: u16 = CHROME_LEFT_COL + CHROME_RIGHT_COL;
+/// Total chrome rows consumed per window when borders + header are enabled
+/// (top border + header + bottom border).
+pub const CHROME_ROWS_TOTAL: u16 = CHROME_TOP_ROW + CHROME_HEADER_ROW + CHROME_BOTTOM_ROW;
+
+/// Width of a single split handle gap (between adjacent tiled windows).
+pub const SPLIT_HANDLE_WIDTH: u16 = 1;
+
+/// Horizontal inset from the right border to the first title button.
+pub const CHROME_BUTTON_INSET_RIGHT: u16 = 1;
+
+/// Spacing between adjacent title buttons (button cell + 1 gap column).
+pub const HEADER_BUTTON_GAP: u16 = 2;

--- a/crates/term-wm-core/src/macros.rs
+++ b/crates/term-wm-core/src/macros.rs
@@ -78,6 +78,9 @@ macro_rules! impl_component_delegate {
             fn take_pending_title(&mut self) -> Option<String> {
                 match self { $(Self::$variant(c) => c.take_pending_title(),)* }
             }
+            fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+                match self { $(Self::$variant(c) => c.take_alternate_screen_transition(),)* }
+            }
             fn take_teardown_parts(&mut self) -> Option<(Box<dyn std::any::Any + Send + Sync>, std::thread::JoinHandle<()>)> {
                 match self { $(Self::$variant(c) => c.take_teardown_parts(),)* }
             }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -438,24 +438,20 @@ where
                             TermWmAction::Quit | TermWmAction::ExitUi => {
                                 app.open_exit_confirm();
                             }
-                            TermWmAction::CloseWindow => {
-                                let id = app.wm().focused_window();
-                                app.wm().close_window(id);
+                            TermWmAction::CloseWindow(key) => {
+                                app.wm().close_window(key);
                             }
                             TermWmAction::NewWindow => {
                                 app.wm_new_window()?;
                             }
-                            TermWmAction::MinimizeWindow => {
-                                let id = app.wm().focused_window();
-                                app.wm().minimize_window(id);
+                            TermWmAction::MinimizeWindow(key) => {
+                                app.wm().minimize_window(key);
                             }
-                            TermWmAction::MaximizeWindow => {
-                                let id = app.wm().focused_window();
-                                app.wm().toggle_maximize(id);
+                            TermWmAction::MaximizeWindow(key) => {
+                                app.wm().toggle_maximize(key);
                             }
-                            TermWmAction::ToggleDirectMode => {
-                                let id = app.wm().focused_window();
-                                app.wm().toggle_direct_mode(id);
+                            TermWmAction::ToggleDirectMode(key) => {
+                                app.wm().toggle_direct_mode(key);
                             }
                             TermWmAction::ToggleMonocle => {
                                 app.wm().toggle_monocle();
@@ -788,7 +784,7 @@ pub fn auto_layout_for_windows(windows: &[WindowKey]) -> Option<TilingLayout<Win
     let first = *windows_iter.next().unwrap();
     let mut root: BspNode<WindowKey> = BspNode::leaf(first);
 
-    for (depth, &id) in windows_iter.enumerate() {
+    for (depth, &key) in windows_iter.enumerate() {
         let orientation = heuristic.choose(default_area, depth);
         let position = match orientation {
             term_wm_layout_engine::Orientation::Horizontal => {
@@ -803,7 +799,7 @@ pub fn auto_layout_for_windows(windows: &[WindowKey]) -> Option<TilingLayout<Win
         if let Some(&last) = all_ids.last() {
             let _ = root.insert_leaf(
                 last,
-                id,
+                key,
                 position,
                 default_area,
                 &term_wm_layout_engine::SizeConstraints {

--- a/crates/term-wm-core/src/window/test_component.rs
+++ b/crates/term-wm-core/src/window/test_component.rs
@@ -74,6 +74,9 @@ impl Component<TermWmAction> for ActionRecorder {
     fn take_pending_title(&mut self) -> Option<String> {
         None
     }
+    fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+        None
+    }
     fn set_selection_enabled(&mut self, _enabled: bool) {}
     fn paste(&mut self, _text: &str) -> bool {
         false
@@ -188,6 +191,9 @@ impl Component<TermWmAction> for KeyRecorder {
     fn take_pending_title(&mut self) -> Option<String> {
         None
     }
+    fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+        None
+    }
     fn set_selection_enabled(&mut self, _enabled: bool) {}
     fn paste(&mut self, _text: &str) -> bool {
         false
@@ -297,6 +303,9 @@ impl Component<TermWmAction> for SelComponent {
         0
     }
     fn take_pending_title(&mut self) -> Option<String> {
+        None
+    }
+    fn take_alternate_screen_transition(&mut self) -> Option<bool> {
         None
     }
     fn set_selection_enabled(&mut self, enabled: bool) {

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -76,7 +76,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .into_iter()
             .filter(|item| {
                 supported.contains(&item.action)
-                    || matches!(item.action, crate::actions::TermWmAction::FocusWindow(_))
+                    || matches!(
+                        item.action,
+                        crate::actions::TermWmAction::FocusWindow(_)
+                            | crate::actions::TermWmAction::MaximizeWindow(_)
+                            | crate::actions::TermWmAction::MinimizeWindow(_)
+                            | crate::actions::TermWmAction::CloseWindow(_)
+                            | crate::actions::TermWmAction::ToggleDirectMode(_)
+                    )
             })
             .collect();
 

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -4991,17 +4991,14 @@ mod tests {
 
         let win_key = keys[1];
 
-        // The K button position must match what hit_test computes
-        // using the full window rect (not the inset header rect).
+        // The D button position uses the same formula as `render_window`:
+        // index 3 (right after Close(0), Maximize(1), Minimize(2)).
         let full_rect = wm.full_region_for_key(win_key);
         let outer_right = full_rect
             .x
             .saturating_add(i32::from(full_rect.width))
             .saturating_sub(1);
-        let close_x = outer_right.saturating_sub(2);
-        let max_x = close_x.saturating_sub(2);
-        let min_x = max_x.saturating_sub(2);
-        let kb_x = min_x.saturating_sub(2) as u16;
+        let kb_x = crate::chrome::button_x_pos(outer_right as u16, true, 3);
         let kb_y = full_rect.y.saturating_add(1) as u16; // header row
         assert!(!wm.direct_mode(win_key), "starts off");
 
@@ -5402,15 +5399,13 @@ mod tests {
         wm.set_direct_mode(win_key, true);
 
         // Header D button click — coordinates on the header, NOT in content area.
+        // Uses `button_x_pos` so it stays in sync with `render_window`.
         let full_rect = wm.full_region_for_key(win_key);
         let outer_right = full_rect
             .x
             .saturating_add(i32::from(full_rect.width))
             .saturating_sub(1);
-        let close_x = outer_right.saturating_sub(2);
-        let max_x = close_x.saturating_sub(2);
-        let min_x = max_x.saturating_sub(2);
-        let kb_x = min_x.saturating_sub(2) as u16;
+        let kb_x = crate::chrome::button_x_pos(outer_right as u16, true, 3);
         let kb_y = full_rect.y.saturating_add(1) as u16; // header row
         wm.hitbox_registry_mut().register(
             crate::hitbox_registry::HitboxId::new(),

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -629,17 +629,20 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     pub fn set_direct_mode(&mut self, key: WindowKey, value: bool) {
         let title = self.window_title(key);
-        if let Some(w) = self.windows.get_mut(key) {
+        if let Some(w) = self.windows.get_mut(key)
+            && w.direct_mode != value
+        {
             w.direct_mode = value;
             if value && let Some(c) = self.components.get_mut(w.component_key) {
                 c.clear_selection();
             }
+            self.mark_layout_dirty();
+            let status = if value { "enabled" } else { "disabled" };
+            self.push_notification(
+                format!("Direct mode {} for {}", status, title),
+                Duration::from_secs(3),
+            );
         }
-        let status = if value { "enabled" } else { "disabled" };
-        self.push_notification(
-            format!("Direct mode {status} for {title}"),
-            Duration::from_secs(3),
-        );
     }
 
     pub fn toggle_direct_mode(&mut self, key: WindowKey) {
@@ -734,10 +737,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 TermWmAction::ToggleSystemPanel,
                 TermWmAction::Help,
                 TermWmAction::ExitUi,
-                TermWmAction::MaximizeWindow,
-                TermWmAction::MinimizeWindow,
-                TermWmAction::CloseWindow,
-                TermWmAction::ToggleDirectMode,
                 TermWmAction::ToggleMonocle,
                 TermWmAction::ToggleTiling,
             ]
@@ -2189,6 +2188,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .and_then(|c| c.take_pending_title())
     }
 
+    /// Returns `Some(bool)` when the pane's alternate screen state transitions.
+    pub fn take_alternate_screen_transition(&mut self, key: WindowKey) -> Option<bool> {
+        self.component_for_key_mut(key)
+            .and_then(|c| c.take_alternate_screen_transition())
+    }
+
     pub fn overlay_for_key_mut(&mut self, key: OverlayKey) -> Option<&mut O> {
         self.overlays.get_mut(key)
     }
@@ -2452,20 +2457,19 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// the focused window fills the screen). All window-specific buttons are
     /// excluded when there is no focused window.
     pub fn window_management_buttons(&self) -> Vec<WmButton> {
-        let has_focused = self.window(self.focused_window()).is_some();
-        if !has_focused {
+        let focused = self.focused_window();
+        if !self.windows.contains_key(focused) {
             return Vec::new();
         }
+        let is_maxed = self.window(focused).is_some_and(|w| w.is_maximized);
         let mut btns = vec![WmButton {
-            action: TermWmAction::CloseWindow,
+            action: TermWmAction::CloseWindow(focused),
             label: "Close Window",
             symbol: "X",
         }];
         if !self.is_monocle() {
-            let focused = self.focused_window();
-            let is_maxed = self.window(focused).is_some_and(|w| w.is_maximized);
             btns.push(WmButton {
-                action: TermWmAction::MaximizeWindow,
+                action: TermWmAction::MaximizeWindow(focused),
                 label: if is_maxed {
                     "Restore Window"
                 } else {
@@ -2474,16 +2478,11 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 symbol: if is_maxed { "─" } else { "▢" },
             });
             btns.push(WmButton {
-                action: TermWmAction::MinimizeWindow,
+                action: TermWmAction::MinimizeWindow(focused),
                 label: "Minimize Window",
                 symbol: "_",
             });
         }
-        btns.push(WmButton {
-            action: TermWmAction::ToggleDirectMode,
-            label: "Toggle Direct Mode",
-            symbol: "D",
-        });
         btns
     }
 
@@ -2579,8 +2578,20 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             },
         ];
 
-        let has_focused_window = self.window_count() > 0;
-        if has_focused_window {
+        let focused = self.focused_window();
+        let has_active = self.windows.contains_key(focused);
+
+        items.push(MenuItem {
+            label: {
+                let on = has_active && self.direct_mode(focused);
+                format!("Toggle Direct Mode: {}", if on { "On" } else { "Off" }).into()
+            },
+            icon: Some("D"),
+            action: crate::actions::TermWmAction::ToggleDirectMode(focused),
+            disabled: !has_active,
+        });
+
+        if has_active {
             // Window management buttons from centralized list
             for btn in self.window_management_buttons() {
                 items.push(MenuItem {
@@ -2591,7 +2602,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 });
             }
             // Switch-to navigation for all windows
-            let focused = *self.focus.current();
             for (key, title) in self.window_titles() {
                 items.push(MenuItem {
                     label: format!("Switch to: {}", title).into(),
@@ -2601,6 +2611,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 });
             }
         }
+
         items
     }
 }
@@ -2672,7 +2683,7 @@ fn map_layout_node(node: &LayoutNode<WindowKey>) -> LayoutNode<WindowKey> {
             weights: weights.clone(),
             resizable: *resizable,
         },
-        LayoutNode::Void(id) => LayoutNode::Void(*id),
+        LayoutNode::Void(key) => LayoutNode::Void(*key),
     }
 }
 
@@ -6774,5 +6785,131 @@ mod tests {
             r0.x,
             r0.width,
         );
+    }
+
+    #[test]
+    fn set_direct_mode_marks_layout_dirty_on_change() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.clear_layout_dirty();
+        assert!(!wm.layout_dirty(), "cleared after setup");
+        wm.set_direct_mode(keys[0], true);
+        assert!(wm.layout_dirty(), "marked dirty on enable");
+        wm.clear_layout_dirty();
+        wm.set_direct_mode(keys[0], false);
+        assert!(wm.layout_dirty(), "marked dirty on disable");
+    }
+
+    #[test]
+    fn set_direct_mode_skips_notification_when_unchanged() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.clear_layout_dirty();
+        wm.set_direct_mode(keys[0], true);
+        assert!(
+            !wm.notifications().is_empty(),
+            "notification pushed on enable"
+        );
+        let count_before = wm.notifications().len();
+        wm.set_direct_mode(keys[0], true);
+        assert_eq!(
+            wm.notifications().len(),
+            count_before,
+            "no duplicate notification when unchanged"
+        );
+    }
+
+    #[test]
+    fn set_direct_mode_pushes_enabled_notification() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.clear_layout_dirty();
+        wm.set_direct_mode(keys[0], true);
+        assert!(!wm.notifications().is_empty(), "notification pushed");
+    }
+
+    #[test]
+    fn set_direct_mode_pushes_disabled_notification() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.clear_layout_dirty();
+        wm.set_direct_mode(keys[0], true);
+        // Clear notification queue: create a new one
+        wm.notification_queue = Default::default();
+        wm.set_direct_mode(keys[0], false);
+        assert!(
+            !wm.notifications().is_empty(),
+            "notification pushed on disable"
+        );
+    }
+
+    #[test]
+    fn set_direct_mode_invalid_key_is_noop() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        wm.clear_layout_dirty();
+        let bogus = WindowKey::default();
+        assert!(!wm.layout_dirty(), "initially not dirty");
+        wm.set_direct_mode(bogus, true);
+        assert!(!wm.layout_dirty(), "no-op: layout not dirty");
+        assert!(wm.notifications().is_empty(), "no-op: no notification");
+    }
+
+    #[test]
+    fn take_alternate_screen_transition_no_component() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let bogus = WindowKey::default();
+        let result = wm.take_alternate_screen_transition(bogus);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn take_alternate_screen_transition_delegates() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        // ActionRecorder returns None by default
+        let result = wm.take_alternate_screen_transition(keys[0]);
+        assert_eq!(result, None);
     }
 }

--- a/crates/term-wm-sys-ui-components/src/wm_command_palette.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_command_palette.rs
@@ -381,7 +381,7 @@ mod tests {
             MenuItem {
                 icon: None,
                 label: "Close".into(),
-                action: TermWmAction::CloseWindow,
+                action: TermWmAction::CloseWindow(Default::default()),
                 disabled: false,
             },
         ]);
@@ -434,7 +434,7 @@ mod tests {
             MenuItem {
                 icon: None,
                 label: "Disabled".into(),
-                action: TermWmAction::CloseWindow,
+                action: TermWmAction::CloseWindow(Default::default()),
                 disabled: true,
             },
         ]);

--- a/crates/term-wm-sys-ui-components/src/wm_top_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_top_panel.rs
@@ -217,13 +217,13 @@ impl WmTopPanelComponent {
             let text = truncate_to_width(status, available as usize);
             safe_set_string(buffer, bounds, x as u16, y as u16, &text, Style::default());
         } else {
-            for id in display_order.iter().copied() {
-                let focused = id == focus_current;
+            for key in display_order.iter().copied() {
+                let focused = key == focus_current;
                 let mut label = self
                     .window_labels
-                    .get(&id)
+                    .get(&key)
                     .cloned()
-                    .unwrap_or_else(|| format!("{id:?}"));
+                    .unwrap_or_else(|| format!("{key:?}"));
                 let max_label = (max_x.saturating_sub(x).saturating_sub(2)) as usize;
                 if label.chars().count() > max_label {
                     label = truncate_to_width(&label, max_label);
@@ -243,7 +243,7 @@ impl WmTopPanelComponent {
                 };
                 safe_set_string(buffer, bounds, x as u16, y as u16, &chunk, item_style);
                 self.list.window_hits.push(PanelWindowHit {
-                    id,
+                    id: key,
                     rect: LayoutRect {
                         x,
                         y,

--- a/crates/term-wm-ui-components/src/command_palette.rs
+++ b/crates/term-wm-ui-components/src/command_palette.rs
@@ -457,7 +457,7 @@ mod tests {
                 stable_id: "core:close_window".to_string(),
                 display_name: "Close Window".to_string(),
                 description: String::new(),
-                action: TermWmAction::CloseWindow,
+                action: TermWmAction::CloseWindow(WindowKey::default()),
                 icon: Some("x"),
                 disabled: false,
             },

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -601,6 +601,10 @@ impl<C: Component<TermWmAction>> Component<TermWmAction> for ScrollViewComponent
         self.content.borrow_mut().take_pending_title()
     }
 
+    fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+        self.content.borrow_mut().take_alternate_screen_transition()
+    }
+
     fn clear_selection(&mut self) {
         self.content.borrow_mut().clear_selection();
     }
@@ -1389,5 +1393,24 @@ mod tests {
             90,
             "should stay at old bottom when sticky_bottom is false"
         );
+    }
+
+    #[test]
+    fn delegates_alternate_screen_transition_to_child() {
+        let child = term_wm_core::window::test_component::ActionRecorder::default();
+        let mut sv = ScrollViewComponent::new(child);
+        // ActionRecorder returns None by default
+        let result = Component::<TermWmAction>::take_alternate_screen_transition(&mut sv);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn delegates_alternate_screen_transition_returns_none() {
+        let child = term_wm_core::window::test_component::ActionRecorder::default();
+        let mut sv = ScrollViewComponent::new(child);
+        let r1 = Component::<TermWmAction>::take_alternate_screen_transition(&mut sv);
+        assert_eq!(r1, None);
+        let r2 = Component::<TermWmAction>::take_alternate_screen_transition(&mut sv);
+        assert_eq!(r2, None);
     }
 }

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -92,6 +92,8 @@ pub struct TerminalComponent {
     selection_enabled: bool,
     last_scrollback: Cell<usize>,
     last_max_scrollback: Cell<usize>,
+    last_mode_suppressed_scroll: Cell<bool>,
+    reported_alt_screen: Cell<bool>,
     window_key: Option<term_wm_core::window::WindowKey>,
 }
 
@@ -357,6 +359,16 @@ impl Component<TermWmAction> for TerminalComponent {
         self.pane.get_mut().take_pending_title()
     }
 
+    fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+        let current = self.pane.get_mut().alternate_screen();
+        if current != self.reported_alt_screen.get() {
+            self.reported_alt_screen.set(current);
+            Some(current)
+        } else {
+            None
+        }
+    }
+
     fn set_selection_enabled(&mut self, enabled: bool) {
         if self.selection_enabled == enabled {
             return;
@@ -403,6 +415,8 @@ impl TerminalComponent {
             selection_enabled: false,
             last_scrollback: Cell::new(0),
             last_max_scrollback: Cell::new(0),
+            last_mode_suppressed_scroll: Cell::new(false),
+            reported_alt_screen: Cell::new(false),
             window_key: None,
         }
     }
@@ -426,6 +440,8 @@ impl TerminalComponent {
             selection_enabled: false,
             last_scrollback: Cell::new(0),
             last_max_scrollback: Cell::new(0),
+            last_mode_suppressed_scroll: Cell::new(false),
+            reported_alt_screen: Cell::new(false),
             window_key: None,
         };
         Ok(comp)
@@ -492,6 +508,11 @@ impl TerminalComponent {
     }
 
     #[cfg(test)]
+    pub fn last_mode_suppressed_scroll(&self) -> bool {
+        self.last_mode_suppressed_scroll.get()
+    }
+
+    #[cfg(test)]
     pub fn pane_mut(&mut self) -> &mut Box<dyn Pane> {
         self.pane.get_mut()
     }
@@ -513,31 +534,44 @@ impl TerminalComponent {
         let sb_before_drag = {
             let clipped = layout_rect_to_clipped_rect(area);
             let mut pane = self.pane.borrow_mut();
-            if !pane.alternate_screen()
-                && let Some(handle) = ctx.scroll_handle()
-            {
-                let used = pane.max_scrollback();
-                handle.set_content_size(clipped.width as usize, used + clipped.height as usize);
 
-                let current_sb = pane.scrollback();
-                let view_offset = ctx.viewport().offset_y;
-                if current_sb == 0 {
-                    if view_offset < self.last_max_scrollback.get().saturating_sub(1) {
-                        let target_sb = used.saturating_sub(view_offset);
-                        pane.set_scrollback(target_sb);
-                    } else {
-                        handle.scroll_vertical_to(usize::MAX);
-                    }
-                } else if current_sb != self.last_scrollback.get() {
-                    let new_offset = used.saturating_sub(current_sb);
-                    handle.scroll_vertical_to(new_offset);
+            if let Some(handle) = ctx.scroll_handle() {
+                let suppress_scroll = ctx.direct_mode() || pane.alternate_screen();
+
+                if suppress_scroll {
+                    handle.set_content_size(clipped.width as usize, clipped.height as usize);
+                    pane.set_scrollback(0);
+                    self.last_mode_suppressed_scroll.set(true);
                 } else {
-                    let target_sb = used.saturating_sub(view_offset);
-                    if target_sb != current_sb {
-                        pane.set_scrollback(target_sb);
+                    let used = pane.max_scrollback();
+                    handle.set_content_size(clipped.width as usize, used + clipped.height as usize);
+
+                    if self.last_mode_suppressed_scroll.get() {
+                        self.last_mode_suppressed_scroll.set(false);
+                        pane.set_scrollback(0);
+                        handle.scroll_vertical_to(usize::MAX);
+                    } else {
+                        let current_sb = pane.scrollback();
+                        let view_offset = ctx.viewport().offset_y;
+                        if current_sb == 0 {
+                            if view_offset < self.last_max_scrollback.get().saturating_sub(1) {
+                                let target_sb = used.saturating_sub(view_offset);
+                                pane.set_scrollback(target_sb);
+                            } else {
+                                handle.scroll_vertical_to(usize::MAX);
+                            }
+                        } else if current_sb != self.last_scrollback.get() {
+                            let new_offset = used.saturating_sub(current_sb);
+                            handle.scroll_vertical_to(new_offset);
+                        } else {
+                            let target_sb = used.saturating_sub(view_offset);
+                            if target_sb != current_sb {
+                                pane.set_scrollback(target_sb);
+                            }
+                        }
                     }
+                    self.last_max_scrollback.set(used);
                 }
-                self.last_max_scrollback.set(used);
             }
             pane.scrollback()
         };
@@ -1490,7 +1524,7 @@ mod tests {
             &mut term_wm_core::hitbox_registry::HitboxRegistry::new(),
         );
         let sb = term.pane_mut().scrollback();
-        assert_eq!(sb, 50, "scrollback should be unchanged during alt screen");
+        assert_eq!(sb, 0, "scrollback cleared during alt screen");
         assert!(
             shared.borrow().pending_offset_y.is_none(),
             "viewport should NOT be touched during alt screen"
@@ -1498,7 +1532,7 @@ mod tests {
         assert_eq!(
             shared.borrow().content_height,
             24,
-            "content size should NOT have been set during alt screen"
+            "content size set to viewport height during alt screen"
         );
     }
 
@@ -2631,5 +2665,114 @@ mod tests {
             Some(176),
             "ClipboardPaste must scroll viewport to bottom"
         );
+    }
+
+    #[test]
+    fn transition_returns_some_true_on_enter() {
+        let mut pane = TestPane::new(200);
+        pane.alt_screen = true;
+        let mut term = TerminalComponent::from_pane(Box::new(pane));
+        let result = Component::<TermWmAction>::take_alternate_screen_transition(&mut term);
+        assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn transition_returns_some_false_on_exit() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(200)));
+        term.reported_alt_screen.set(true);
+        // Alt screen is false by default on TestPane
+        let result = Component::<TermWmAction>::take_alternate_screen_transition(&mut term);
+        assert_eq!(result, Some(false));
+    }
+
+    #[test]
+    fn transition_returns_none_when_unchanged() {
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(200)));
+        // reported_alt_screen is false, TestPane alt_screen is false
+        let r1 = Component::<TermWmAction>::take_alternate_screen_transition(&mut term);
+        assert_eq!(r1, None);
+        let r2 = Component::<TermWmAction>::take_alternate_screen_transition(&mut term);
+        assert_eq!(r2, None);
+    }
+
+    #[test]
+    fn render_screen_entering_direct_mode_suppresses_scroll() {
+        let (handle, shared) = make_handle();
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(200)));
+        let ctx = make_ctx(0, handle).with_direct_mode(true);
+        let area = Rect::new(0, 0, 80, 24);
+        let buffer = Buffer::empty(area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
+        term.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            &ctx,
+            &mut term_wm_core::hitbox_registry::HitboxRegistry::new(),
+        );
+        assert_eq!(shared.borrow().content_height, 24, "content = viewport");
+        assert_eq!(term.pane_mut().scrollback(), 0, "scrollback cleared");
+        assert!(term.last_mode_suppressed_scroll(), "suppress flag set");
+    }
+
+    #[test]
+    fn render_screen_entering_alt_screen_suppresses_scroll() {
+        let (handle, shared) = make_handle();
+        let mut pane = TestPane::new(200);
+        pane.alt_screen = true;
+        let mut term = TerminalComponent::from_pane(Box::new(pane));
+        let ctx = make_ctx(0, handle);
+        let area = Rect::new(0, 0, 80, 24);
+        let buffer = Buffer::empty(area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
+        term.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            &ctx,
+            &mut term_wm_core::hitbox_registry::HitboxRegistry::new(),
+        );
+        assert_eq!(shared.borrow().content_height, 24, "content = viewport");
+        assert_eq!(term.pane_mut().scrollback(), 0, "scrollback cleared");
+        assert!(term.last_mode_suppressed_scroll(), "suppress flag set");
+    }
+
+    #[test]
+    fn render_screen_exit_suppressed_mode_anchors_to_bottom() {
+        let (handle, shared) = make_handle();
+        let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(200)));
+        term.last_mode_suppressed_scroll.set(true);
+        term.set_last_max_scrollback(200);
+        // Normal mode, no alt screen, no direct mode
+        let ctx = make_ctx(0, handle);
+        let area = Rect::new(0, 0, 80, 24);
+        let buffer = Buffer::empty(area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
+        term.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+            &ctx,
+            &mut term_wm_core::hitbox_registry::HitboxRegistry::new(),
+        );
+        assert_eq!(
+            shared.borrow().pending_offset_y,
+            Some(200),
+            "scroll to bottom"
+        );
+        assert_eq!(term.pane_mut().scrollback(), 0, "scrollback at bottom");
+        assert!(!term.last_mode_suppressed_scroll(), "suppress flag cleared");
     }
 }

--- a/docs/WINDOW-BORDERS.txt
+++ b/docs/WINDOW-BORDERS.txt
@@ -11,32 +11,32 @@ difference between the two modes is how their resize and drag handles appear.
 Every window gets a 1-cell-thick border drawn around it with:
 
   ┌───────────────────────────────┐
-  │terminal window title  _ ▢ ✖ │   <- header row (1 cell tall)
-  ├───────────────────────────────┤   <- separator
+  │terminal window title    _ ▢ ✖ │   <- header row (1 cell tall)
   │                               │
   │         content area          │
   │                               │
   └───────────────────────────────┘
 
   - Top edge:      ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐   (1 cell tall)
-  - Header row:     │          title        _ ▢ ✖ │   (1 cell tall)
-  - Separator:     ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┤   (1 cell tall)
-  - Side edges:    │                               │   (1 cell wide)
+  - Header row:    │          title          _ ▢ ✖ │   (1 cell tall)
+  - Side edges:    │                               │   (1 cell wide, from header row down to bottom border)
   - Bottom edge:   └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘   (1 cell tall)
 
-Total chrome overhead PER WINDOW:
-  - Top + header + separator:  3 rows
-  - Bottom:                    1 row
-  - Left:                      1 column
-  - Right:                     1 column
-  Total: 2 columns x 4 rows occupied by chrome per window
+Total chrome overhead PER WINDOW (with borders + header enabled):
+  - Top border:    1 row
+  - Header:        1 row
+  - Bottom border: 1 row
+  - Left:          1 column
+  - Right:         1 column
+  Total: 2 columns x 3 rows occupied by chrome per window
+  (Side borders span the full height minus top + bottom borders.)
 
-Content area = window_rect - (2 columns, 4 rows)
+Content area = window_rect - (2 columns, 3 rows)
 
 1a. Focused vs. Unfocused Colors
 ---------------------------------
 
-  BORDER CORNERS & EDGES (┌ ┐ └ ┘ ─ │ ├ ┤):
+  BORDER CORNERS & EDGES (┌ ┐ └ ┘ ─ │):
     Focused:   decorator_border_active  (RGB 110, 118, 140)  -- brighter gray
     Unfocused: decorator_border         (RGB 105, 110, 125)  -- muted gray
 
@@ -54,15 +54,17 @@ Content area = window_rect - (2 columns, 4 rows)
 1b. Title Buttons (right-aligned on the header row)
 ---------------------------------------------------
 
-  LEFT TO RIGHT on the header:  _   ▢   ✖
-                                 |   |   +-- Close
-                                 |   +------ Maximize
-                                 +---------- Minimize
+   LEFT TO RIGHT on the header:  _   ▢   ✖
+                                  |   |   +-- Close
+                                  |   +------ Maximize
+                                  +---------- Minimize
 
-  RIGHT TO LEFT (from the border):  ✖  ▢  _
+   RIGHT TO LEFT (from the border):  ✖  ▢  _
 
-  4 cells on the header row, inset 1 column from the right border, with
-  1 empty column between each button.
+   3 cells on the header row (one per button), inset 1 column from the
+   right border, with 1 empty column between each button.
+   The gap constant is `HEADER_BUTTON_GAP` (= 2), which accounts for the
+   button itself plus one empty buffer column between adjacent buttons.
 
   DEFAULT STATE (not hovered):
     Close (✖):    fg = error_bg   (red,   RGB 255, 61, 61)
@@ -75,7 +77,7 @@ Content area = window_rect - (2 columns, 4 rows)
     Maximize (▢): bg = accent     (green), fg = menu_selected_fg (dark)
     Minimize (_): bg = warning_bg (amber), fg = menu_selected_fg (dark)
 
-  The "D" cell also inverts fg <-> bg when direct mode is active (focused window).
+  (Note: The direct mode toggle is accessed via the menu, not as a header button.)
 
 ===============================================================================
 2. FLOATING WINDOW DRAG & RESIZE HANDLES
@@ -90,11 +92,10 @@ Content area = window_rect - (2 columns, 4 rows)
     rect.x + 1            rect.x + rect.width - 1
          |                       |
          v                       v
-    ┌─────┬────────────────────┬────────┐
-    │     │  <- drag handle ->  _ ▢ ✖ │
-    ├─────┴────────────────────┴────────┤
-   │                                   │
-   │                                   │
+     ┌─────┬──────────────────────┬───────┐
+     │     │  <- drag handle ->   │ _ ▢ ✖ │
+     │     │                      │       │
+     │     │                      │       │
 
   Dimensions: (window_width - 2) cells wide x 1 cell tall
   Occupies:   1 row (the header row), spanning the full width between borders
@@ -110,12 +111,11 @@ Content area = window_rect - (2 columns, 4 rows)
 
   ┌─────┬─────────────────────────┬─────┐
   │ TL  │        Top              │ TR  │     TL = TopLeft  (1x1 corner)
-  ├─────┴─────────────────────────┴─────┤
-  │                                     │     L   = Left     (1 x height-2)
-  │ L                                   │
-  │                                     │     R   = Right    (1 x height-2)
-  │                                     │
-  ├─────┬─────────────────────────┬─────┤
+  │     │                         │     │
+  │ L   │                         │  R  │     L   = Left     (1 x height-2)
+  │     │                         │     │     R   = Right    (1 x height-2)
+  │     │                         │     │
+  ├─────┼─────────────────────────┼─────┤
   │ BL  │       Bottom            │ BR  │     BL = BottomLeft  (1x1 corner)
   └─────┴─────────────────────────┴─────┘     BR = BottomRight (1x1 corner)
 
@@ -140,8 +140,8 @@ Content area = window_rect - (2 columns, 4 rows)
                                  ║
     BottomLeft: ║
                 ╚══════════
-    BottomRight:                 ╝
-                                 ║
+    BottomRight:                 ║
+                              ════╝
 
   Characters used: ═ ║ ╔ ╗ ╚ ╝
   These are double-line variants of the single-line border characters.
@@ -211,10 +211,10 @@ Content area = window_rect - (2 columns, 4 rows)
 5. VISUAL SUMMARY BY MODE
 ===============================================================================
 
-                        TILED                       FLOATING
+                         TILED                       FLOATING
   --------------------  ------------------------  --------------------------
   Border style          ┌┐└┘─│ (single-line)      Same box-drawing
-  Chrome overhead       2 cols x 4 rows            2 cols x 4 rows
+  Chrome overhead       2 cols x 3 rows            2 cols x 3 rows
   Per-window chrome     All have it                All have it
   Drag handle           Header (detaches to        Header (moves in place)
                           floating on drag)
@@ -236,33 +236,40 @@ Content area = window_rect - (2 columns, 4 rows)
   ┌ ┐ └ ┘   Border corners          (single-line)
   ─         Horizontal border edge
   │         Vertical border edge
-  ├ ┤       Header separator
   ·         Split handle background  (middle dot)
   o         Split handle indicator   (normal)
   O         Split handle indicator   (hovered)
   + - |     Split handle hover frame
   ═ ║      Resize outline edge      (double-line)
   ╔ ╗ ╚ ╝  Resize outline corners   (double-line)
-  _ ▢ ✖  Title buttons
+  _ ▢ ✖  Title buttons (Minimize, Maximize, Close)
   (space)   Header fill
 
 ===============================================================================
 7. CELL COUNT SUMMARY PER WINDOW
 ===============================================================================
 
-  Element             Cells
-  ------------------- -----
-  Top border          1 row x (width) cols
-  Header row          1 row x (width) cols
-  Separator           1 row x (width) cols
-  Bottom border       1 row x (width) cols
-  Left border         (height - 4) rows x 1 col
-  Right border        (height - 4) rows x 1 col
-                      ----------
-  Total chrome:       2 columns + 4 rows per window
+   Element             Cells
+   ------------------- -----
+   Top border          1 row x (width) cols
+   Header row          1 row x (width) cols
+   Bottom border       1 row x (width) cols
+   Left border         (height - 3) rows x 1 col
+   Right border        (height - 3) rows x 1 col
+                       ----------
+   Total chrome:       2 columns + 3 rows per window
 
-  For a standard 80x24 terminal with 2 side-by-side tiled windows:
-    Each window:     (40-2) x (24-4) = 38 x 20 = 760 cells of content
-    Chrome total:    2 x (2x40 + 4x24 - 2x4) = 256 cells of chrome
-    Split handle:    1 x 24 = 24 cells
-    Total:           760 + 760 + 256 + 24 = 1800 cells used out of 1920
+   For a standard 80x24 terminal with 2 side-by-side tiled windows
+   (separated by a 1-column split handle, usable width = 79 columns):
+
+     Window A (39x24):
+       Content: (39-2) x (24-3) = 37 x 21 = 777 cells
+       Chrome:  39 x 24 - 777 = 159 cells
+
+     Window B (40x24):
+       Content: (40-2) x (24-3) = 38 x 21 = 798 cells
+       Chrome:  40 x 24 - 798 = 162 cells
+
+     Split handle: 1 x 24 = 24 cells
+
+     Total used: 777 + 798 + 159 + 162 + 24 = 1,920 / 1,920 ✓

--- a/docs/WINDOW-BORDERS.txt
+++ b/docs/WINDOW-BORDERS.txt
@@ -11,7 +11,7 @@ difference between the two modes is how their resize and drag handles appear.
 Every window gets a 1-cell-thick border drawn around it with:
 
   ┌───────────────────────────────┐
-  │terminal window title  D _ ▢ ✖ │   <- header row (1 cell tall)
+  │terminal window title  _ ▢ ✖ │   <- header row (1 cell tall)
   ├───────────────────────────────┤   <- separator
   │                               │
   │         content area          │
@@ -19,7 +19,7 @@ Every window gets a 1-cell-thick border drawn around it with:
   └───────────────────────────────┘
 
   - Top edge:      ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐   (1 cell tall)
-  - Header row:    │          title        D _ ▢ ✖ │   (1 cell tall)
+  - Header row:     │          title        _ ▢ ✖ │   (1 cell tall)
   - Separator:     ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┤   (1 cell tall)
   - Side edges:    │                               │   (1 cell wide)
   - Bottom edge:   └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘   (1 cell tall)
@@ -54,13 +54,12 @@ Content area = window_rect - (2 columns, 4 rows)
 1b. Title Buttons (right-aligned on the header row)
 ---------------------------------------------------
 
-  LEFT TO RIGHT on the header:  D   _   ▢   ✖
-                                 |   |   |   +-- Close
-                                 |   |   +------ Maximize
-                                 |   +---------- Minimize
-                                 +-------------- Toggle direct mode
+  LEFT TO RIGHT on the header:  _   ▢   ✖
+                                 |   |   +-- Close
+                                 |   +------ Maximize
+                                 +---------- Minimize
 
-  RIGHT TO LEFT (from the border):  ✖  ▢  _  D
+  RIGHT TO LEFT (from the border):  ✖  ▢  _
 
   4 cells on the header row, inset 1 column from the right border, with
   1 empty column between each button.
@@ -69,14 +68,12 @@ Content area = window_rect - (2 columns, 4 rows)
     Close (✖):    fg = error_bg   (red,   RGB 255, 61, 61)
     Maximize (▢): fg = accent     (green, RGB   0,230,118)
     Minimize (_): fg = warning_bg (amber, RGB 255,193,  7)
-    Direct  (D):  fg = header_style (same as title); when active inverts fg/bg
 
   HOVER STATE:
     All buttons gain BOLD modifier.
     Close (✖):    bg = error_bg   (red),   fg = menu_selected_fg (dark)
     Maximize (▢): bg = accent     (green), fg = menu_selected_fg (dark)
     Minimize (_): bg = warning_bg (amber), fg = menu_selected_fg (dark)
-    Direct  (D):  bg = accent_alt (amber), fg = menu_selected_fg (dark)
 
   The "D" cell also inverts fg <-> bg when direct mode is active (focused window).
 
@@ -93,9 +90,9 @@ Content area = window_rect - (2 columns, 4 rows)
     rect.x + 1            rect.x + rect.width - 1
          |                       |
          v                       v
-   ┌─────┬────────────────────┬────────┐
-   │     │  <- drag handle ->  D _ ▢ ✖ │
-   ├─────┴────────────────────┴────────┤
+    ┌─────┬────────────────────┬────────┐
+    │     │  <- drag handle ->  _ ▢ ✖ │
+    ├─────┴────────────────────┴────────┤
    │                                   │
    │                                   │
 
@@ -246,7 +243,7 @@ Content area = window_rect - (2 columns, 4 rows)
   + - |     Split handle hover frame
   ═ ║      Resize outline edge      (double-line)
   ╔ ╗ ╚ ╝  Resize outline corners   (double-line)
-  D _ ▢ ✖  Title buttons
+  _ ▢ ✖  Title buttons
   (space)   Header fill
 
 ===============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub fn render_app<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmA
         if let Some(title) = wm.window_pane_title(key) {
             wm.set_window_title(key, title);
         }
+        if let Some(is_alt) = wm.take_alternate_screen_transition(key) {
+            wm.set_direct_mode(key, is_alt);
+        }
     }
 
     wm.register_managed_layout(area);
@@ -137,7 +140,6 @@ pub fn render_app<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmA
                     title,
                     focused,
                     floating,
-                    direct_mode: wm.direct_mode(*key),
                     hover_pos: wm.hover_pos(),
                     theme: wm.config().theme,
                     wm_buttons: wm.window_management_buttons(),

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -295,7 +295,14 @@ impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for T
             .into_iter()
             .filter(|item| {
                 supported.contains(&item.action)
-                    || matches!(item.action, TermWmAction::FocusWindow(_))
+                    || matches!(
+                        item.action,
+                        TermWmAction::FocusWindow(_)
+                            | TermWmAction::MaximizeWindow(_)
+                            | TermWmAction::MinimizeWindow(_)
+                            | TermWmAction::CloseWindow(_)
+                            | TermWmAction::ToggleDirectMode(_)
+                    )
             })
             .collect();
         palette.set_items(items);


### PR DESCRIPTION
Parameterize window actions with explicit WindowKey --------------------------------------------------- MaximizeWindow, MinimizeWindow, CloseWindow, ToggleDirectMode now carry a WindowKey payload captured at menu-construction time instead of resolving focused_window() at dispatch. This prevents the action from targeting the wrong window if focus shifts while the command palette is open.

Changes across actions.rs (enum + category/Display patterns), window_manager/mod.rs (constructors pass focused key, remove parameterized variants from supported_menu_actions default vec), runner.rs (dispatch extracts key from variant, no focused_window() call), focus.rs + term_wm_app.rs (filter predicates use variant-discriminant match for all 5 parameterized actions), draw_plan_renderer.rs (match patterns + test fixture keys), command_palette.rs + wm_command_palette.rs (test fixture keys).

Auto-detect alternate screen → set per-window direct_mode ---------------------------------------------------------- Applications entering the alternate screen (vim, less, etc.) now automatically put the window into direct mode so scroll capture doesn't fight the terminal's native scroll region.

Adds Component trait method take_alternate_screen_transition(). TerminalComponent compares pane's alternate_screen() against last-reported value, returning Some(true/false) on transition. ScrollViewComponent delegates to child. The render loop polls every mapped window and calls set_direct_mode(key, is_alt).

Fix scroll sync during direct mode and alternate screen --------------------------------------------------------- When a window is in direct mode or alternate screen, scroll capture is suppressed: content size clamped to viewport, scrollback cleared. On exit from suppressed mode, anchor resets to bottom of full content. Tracks state with last_mode_suppressed_scroll flag.

Chrome: remove ToggleDirectMode header button
-----------------------------------------------
Direct mode now only accessible via command palette (where it shows per-window On/Off state). Remove "D" chrome header button, inverted-fg/bg hover style, and direct_mode field from ChromeCtx.

select_fallback_focus: reset to default on empty ring ------------------------------------------------------- When the last window closes and the focus ring empties, reset current to WindowKey::default() instead of leaving a dangling stale pointer. Downstream callers safely return false via is_some_and.

Naming: rename WindowKey locals from "id" to "key" --------------------------------------------------- runner.rs auto_layout loop, mod.rs map_layout_node Void match, wm_top_panel.rs display_order loop.