### PR TITLE
refactor(core): Encapsulate Window fields behind getters/setters

### DIFF
--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -710,7 +710,7 @@ pub fn render_panels<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Term
             .mapped_windows()
             .iter()
             .any(|k| !wm.is_window_floating(*k));
-        let label = if any_tiled { "[ tiled ]" } else { "[ float ]" };
+        let label = if any_tiled { "▢ float" } else { "⊞ tile" };
         Some((label, TermWmAction::ToggleTiling))
     } else {
         None

--- a/crates/term-wm-core/src/window/entry.rs
+++ b/crates/term-wm-core/src/window/entry.rs
@@ -27,38 +27,96 @@ pub enum WindowState {
     Shaded,
 }
 
+/// Presentation rules for window chrome (borders, headers) in a specific layout mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChromeRules {
+    pub show_borders: bool,
+    pub show_header: bool,
+}
+
+/// Chrome presentation rules mapped across layout modes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModeChromeConfig {
+    pub tiled: ChromeRules,
+    pub floating: ChromeRules,
+    pub monocle: ChromeRules,
+    pub maximized: ChromeRules,
+}
+
+impl Default for ModeChromeConfig {
+    fn default() -> Self {
+        Self {
+            tiled: ChromeRules {
+                show_borders: false,
+                show_header: true,
+            },
+            floating: ChromeRules {
+                show_borders: true,
+                show_header: true,
+            },
+            monocle: ChromeRules {
+                show_borders: false,
+                show_header: true,
+            },
+            maximized: ChromeRules {
+                show_borders: false,
+                show_header: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowMode {
+    Tiled,
+    Floating,
+    Monocle,
+    Maximized,
+}
+
+impl ModeChromeConfig {
+    /// Returns the chrome rules corresponding to the active mode.
+    pub fn rules_for(&self, mode: WindowMode) -> &ChromeRules {
+        match mode {
+            WindowMode::Monocle => &self.monocle,
+            WindowMode::Maximized => &self.maximized,
+            WindowMode::Floating => &self.floating,
+            WindowMode::Tiled => &self.tiled,
+        }
+    }
+}
+
 /// A window entry in the SlotMap — the single source of truth for all
 /// window data, including the renderable component.
 /// Process teardown is handled by the `Reaper`, not by `Drop`.
 pub struct Window {
-    pub title: Option<String>,
-    pub title_set_order: Option<usize>,
-    pub state: WindowState,
-    pub floating_rect: Option<FloatRectSpec>,
-    pub prev_floating_rect: Option<FloatRectSpec>,
-    pub creation_order: usize,
-    pub direct_mode: bool,
-    /// Decoupled maximization state flag.  Set when the window is maximized,
-    /// cleared when restored.  Must NOT be derived from geometry comparison.
-    pub is_maximized: bool,
-    /// Non-None when this window has a Void placeholder in the tiling layout
-    /// tree (maximized while tiled). The void preserves the tree position and
-    /// split weights so the window can be restored to its exact original spot.
-    pub void_id: Option<usize>,
-    /// Render window borders (left, right, bottom, corners).
-    pub borders_enabled: bool,
-    /// Render window header (title bar, buttons).
-    pub header_enabled: bool,
-    /// Key into the WindowManager's component arena.
-    pub component_key: ComponentKey,
+    title: Option<String>,
+    title_set_order: Option<usize>,
+
+    /// Canonical lifecycle state (Realized, Mapped, Unmapped, Iconic, Shaded).
+    state: WindowState,
+
+    floating_rect: Option<FloatRectSpec>,
+    prev_floating_rect: Option<FloatRectSpec>,
+    creation_order: usize,
+    direct_mode: bool,
+
+    /// Layout mode flag.
+    is_maximized: bool,
+    void_id: Option<usize>,
+
+    /// Visual chrome rules across layout modes.
+    chrome_config: ModeChromeConfig,
+
+    component_key: ComponentKey,
     /// What happens when this window is closed.
-    pub close_policy: ClosePolicy,
+    close_policy: ClosePolicy,
     /// Persistent HitboxId for the window's content area.
-    pub content_hitbox_id: HitboxId,
+    content_hitbox_id: HitboxId,
     /// Which leaf component within this window currently holds keyboard focus.
     /// Set when a component returns `TermWmAction::RequestKeyboardFocus`.
     /// Cleared automatically when `FocusRing` switches to a different window.
-    pub active_keyboard_focus: Option<HitboxId>,
+    active_keyboard_focus: Option<HitboxId>,
 }
 
 impl Window {
@@ -73,8 +131,7 @@ impl Window {
             direct_mode: false,
             is_maximized: false,
             void_id: None,
-            borders_enabled: true,
-            header_enabled: true,
+            chrome_config: ModeChromeConfig::default(),
             component_key,
             close_policy: ClosePolicy::default(),
             content_hitbox_id: HitboxId::new(),
@@ -82,11 +139,165 @@ impl Window {
         }
     }
 
+    // ── Title ─────────────────────────────────────────────────────────────────
+
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    pub fn set_title(&mut self, title: Option<String>) {
+        self.title = title;
+    }
+
+    pub fn title_set_order(&self) -> Option<usize> {
+        self.title_set_order
+    }
+
+    pub fn set_title_set_order(&mut self, order: Option<usize>) {
+        self.title_set_order = order;
+    }
+
     pub fn title_or_default(&self, key: super::WindowKey) -> String {
         self.title.clone().unwrap_or_else(|| format!("{:?}", key))
     }
 
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    pub fn state(&self) -> WindowState {
+        self.state
+    }
+
+    pub fn set_state(&mut self, state: WindowState) {
+        self.state = state;
+    }
+
+    // ── Floating ──────────────────────────────────────────────────────────────
+
     pub fn is_floating(&self) -> bool {
         self.floating_rect.is_some()
+    }
+
+    pub fn floating_rect(&self) -> Option<FloatRectSpec> {
+        self.floating_rect
+    }
+
+    pub fn set_floating_rect(&mut self, rect: Option<FloatRectSpec>) {
+        self.floating_rect = rect;
+    }
+
+    pub fn take_floating_rect(&mut self) -> Option<FloatRectSpec> {
+        self.floating_rect.take()
+    }
+
+    pub fn prev_floating_rect(&self) -> Option<FloatRectSpec> {
+        self.prev_floating_rect
+    }
+
+    pub fn set_prev_floating_rect(&mut self, rect: Option<FloatRectSpec>) {
+        self.prev_floating_rect = rect;
+    }
+
+    pub fn take_prev_floating_rect(&mut self) -> Option<FloatRectSpec> {
+        self.prev_floating_rect.take()
+    }
+
+    // ── Creation Order ────────────────────────────────────────────────────────
+
+    pub fn creation_order(&self) -> usize {
+        self.creation_order
+    }
+
+    // ── Direct Mode ───────────────────────────────────────────────────────────
+
+    pub fn direct_mode(&self) -> bool {
+        self.direct_mode
+    }
+
+    pub fn set_direct_mode(&mut self, value: bool) {
+        self.direct_mode = value;
+    }
+
+    // ── Maximized ─────────────────────────────────────────────────────────────
+
+    /// Returns whether the window is currently in a maximized layout state.
+    pub fn is_maximized(&self) -> bool {
+        self.is_maximized
+    }
+
+    /// Mutates the maximized layout state flag.
+    pub fn set_maximized(&mut self, maximized: bool) {
+        self.is_maximized = maximized;
+    }
+
+    // ── Void ──────────────────────────────────────────────────────────────────
+
+    pub fn void_id(&self) -> Option<usize> {
+        self.void_id
+    }
+
+    pub fn set_void_id(&mut self, id: Option<usize>) {
+        self.void_id = id;
+    }
+
+    pub fn clear_void_id(&mut self) {
+        self.void_id = None;
+    }
+
+    // ── Component Key ─────────────────────────────────────────────────────────
+
+    pub fn component_key(&self) -> ComponentKey {
+        self.component_key
+    }
+
+    // ── Close Policy ──────────────────────────────────────────────────────────
+
+    pub fn close_policy(&self) -> ClosePolicy {
+        self.close_policy
+    }
+
+    pub fn set_close_policy(&mut self, policy: ClosePolicy) {
+        self.close_policy = policy;
+    }
+
+    // ── Hitbox ────────────────────────────────────────────────────────────────
+
+    pub fn content_hitbox_id(&self) -> HitboxId {
+        self.content_hitbox_id
+    }
+
+    // ── Keyboard Focus ────────────────────────────────────────────────────────
+
+    pub fn active_keyboard_focus(&self) -> Option<HitboxId> {
+        self.active_keyboard_focus
+    }
+
+    pub fn set_active_keyboard_focus(&mut self, id: Option<HitboxId>) {
+        self.active_keyboard_focus = id;
+    }
+
+    // ── Chrome Presentation Evaluation ────────────────────────────────────────
+
+    /// Evaluates local window chrome rules based on window mode.
+    pub fn borders_enabled(&self, mode: WindowMode) -> bool {
+        self.active_chrome_rules(mode).show_borders
+    }
+
+    pub fn header_enabled(&self, mode: WindowMode) -> bool {
+        self.active_chrome_rules(mode).show_header
+    }
+
+    pub fn chrome_config(&self) -> &ModeChromeConfig {
+        &self.chrome_config
+    }
+
+    // ── Rule Resolution ───────────────────────────────────────────────────────
+
+    pub fn active_chrome_rules(&self, mode: WindowMode) -> &ChromeRules {
+        match mode {
+            WindowMode::Tiled => &self.chrome_config.tiled,
+            WindowMode::Floating => &self.chrome_config.floating,
+            WindowMode::Monocle => &self.chrome_config.monocle,
+            WindowMode::Maximized => &self.chrome_config.maximized,
+        }
     }
 }

--- a/crates/term-wm-core/src/window/mod.rs
+++ b/crates/term-wm-core/src/window/mod.rs
@@ -43,6 +43,12 @@ pub enum FloatRectSpec {
     },
 }
 
+impl Default for FloatRectSpec {
+    fn default() -> Self {
+        FloatRectSpec::Absolute(LayoutRect::default())
+    }
+}
+
 impl FloatRectSpec {
     pub fn resolve(&self, bounds: Rect) -> Rect {
         let fr = self.resolve_signed(bounds);

--- a/crates/term-wm-core/src/window/mod.rs
+++ b/crates/term-wm-core/src/window/mod.rs
@@ -21,7 +21,7 @@ slotmap::new_key_type! {
     pub struct ComponentKey;
 }
 
-pub use entry::{ClosePolicy, WindowState};
+pub use entry::{ClosePolicy, WindowMode, WindowState};
 
 pub use window_manager::layer_manager::{ComponentTag, LayerId, LayerManager, MacroFocus, ZPlane};
 pub use window_manager::{

--- a/crates/term-wm-core/src/window/window_manager/chrome.rs
+++ b/crates/term-wm-core/src/window/window_manager/chrome.rs
@@ -89,7 +89,10 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     ///   stay alive so the window can be re-shown via `transition_window`.
     pub fn close_window(&mut self, key: WindowKey) {
         tracing::debug!(window_key = ?key, "closing window");
-        let policy = self.window(key).map(|w| w.close_policy()).unwrap_or_default();
+        let policy = self
+            .window(key)
+            .map(|w| w.close_policy())
+            .unwrap_or_default();
         self.transition_window(key, WindowState::Unmapped);
 
         if policy == ClosePolicy::Destroy {

--- a/crates/term-wm-core/src/window/window_manager/chrome.rs
+++ b/crates/term-wm-core/src/window/window_manager/chrome.rs
@@ -17,7 +17,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     pub fn toggle_maximize(&mut self, key: WindowKey) {
         use crate::window::FloatRectSpec;
 
-        let is_maxed = self.window(key).is_some_and(|w| w.is_maximized);
+        let is_maxed = self.window(key).is_some_and(|w| w.is_maximized());
 
         if is_maxed {
             // UNMAXIMIZE PATH
@@ -28,7 +28,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             } else {
                 // Was tiled: restore Void → Leaf in layout tree
                 self.clear_floating_rect(key);
-                let void_id = self.window(key).and_then(|w| w.void_id);
+                let void_id = self.window(key).and_then(|w| w.void_id());
                 if let Some(vid) = void_id
                     && let Some(ref mut layout) = self.managed_layout
                 {
@@ -37,9 +37,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             }
 
             if let Some(w) = self.windows.get_mut(key) {
-                w.is_maximized = false;
-                w.borders_enabled = true;
-                w.void_id = None;
+                w.set_maximized(false);
+                w.clear_void_id();
             }
             self.bring_floating_to_front_key(key);
             return;
@@ -62,15 +61,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 && let Some(void_id) = layout.replace_leaf_with_void(key)
                 && let Some(w) = self.windows.get_mut(key)
             {
-                w.void_id = Some(void_id);
+                w.set_void_id(Some(void_id));
             }
             self.set_prev_floating_rect(key, None);
         }
 
         self.set_floating_rect(key, Some(full));
         if let Some(w) = self.windows.get_mut(key) {
-            w.is_maximized = true;
-            w.borders_enabled = false;
+            w.set_maximized(true);
         }
         self.bring_floating_to_front_key(key);
     }
@@ -91,15 +89,15 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     ///   stay alive so the window can be re-shown via `transition_window`.
     pub fn close_window(&mut self, key: WindowKey) {
         tracing::debug!(window_key = ?key, "closing window");
-        let policy = self.window(key).map(|w| w.close_policy).unwrap_or_default();
+        let policy = self.window(key).map(|w| w.close_policy()).unwrap_or_default();
         self.transition_window(key, WindowState::Unmapped);
 
         if policy == ClosePolicy::Destroy {
             if let Some(w) = self.windows.get_mut(key) {
-                if let Some(c) = self.components.get_mut(w.component_key) {
+                if let Some(c) = self.components.get_mut(w.component_key()) {
                     c.destroy();
                 }
-                self.components.remove(w.component_key);
+                self.components.remove(w.component_key());
             }
             self.windows.remove(key);
         }

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -51,7 +51,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         // a different window, unmaximize it so the target window is not hidden
         // behind the full-area floating overlay.
         let prev_focus = *self.focus.current();
-        if prev_focus != key && self.window(prev_focus).is_some_and(|w| w.is_maximized) {
+        if prev_focus != key && self.window(prev_focus).is_some_and(|w| w.is_maximized()) {
             self.toggle_maximize(prev_focus);
         }
 
@@ -110,8 +110,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 self.clear_floating_rect(key);
             }
             if let Some(w) = self.windows.get_mut(key) {
-                w.is_maximized = false;
-                w.borders_enabled = true;
+                w.set_maximized(true);
             }
         }
     }
@@ -148,7 +147,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         let prev_focus = *self.focus.current();
         self.focus.advance(forward);
         let focused = *self.focus.current();
-        if prev_focus != focused && self.window(prev_focus).is_some_and(|w| w.is_maximized) {
+        if prev_focus != focused && self.window(prev_focus).is_some_and(|w| w.is_maximized()) {
             self.toggle_maximize(prev_focus);
         }
         self.focus_window_key(focused);

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -8,6 +8,8 @@ use crate::events::Event;
 use super::WindowManager;
 use crate::keybindings::ActionLayer;
 use crate::layout::{InsertPosition, LayoutNode, LayoutPlan, RegionMap, SplitHandle, TilingLayout};
+use crate::window::entry::WindowMode;
+use crate::window::window_manager::Window;
 use crate::window::{FloatRectSpec, WindowKey, WindowState};
 
 impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> WindowManager<C, L, O> {
@@ -144,6 +146,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     /// Update borders and store terminal width for monocle auto-detection.
     /// Called every render frame.
+    /// Update borders and store terminal width for monocle auto-detection.
+    /// Called every render frame.
     pub fn update_monocle_mode(&mut self, terminal_width: u16) {
         let old_monocle = self.is_monocle();
         self.last_terminal_width = terminal_width;
@@ -158,16 +162,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 format!("Monocle mode (auto): {status}"),
                 Duration::from_secs(3),
             );
-        }
-
-        for (_, window) in self.windows.iter_mut() {
-            if monocle {
-                window.borders_enabled = false;
-            } else if self.managed_layout.is_some() {
-                window.borders_enabled = window.floating_rect.is_some();
-            } else {
-                window.borders_enabled = true;
-            }
         }
     }
 
@@ -209,14 +203,44 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         );
     }
 
-    /// Whether the given window should render borders.
-    pub fn window_borders_enabled(&self, key: WindowKey) -> bool {
-        self.window(key).map(|w| w.borders_enabled).unwrap_or(false)
+    /// Evaluates the dominant [`WindowMode`] for a given window to resolve chrome rules.
+    ///
+    /// ### Precedence Hierarchy
+    /// 1. **`Maximized`**: User explicitly expanded a single window to full screen.
+    /// 2. **`Floating`**: Modals, popups, and floating utility dialogs must maintain
+    ///    their floating chrome rules (e.g., borders/headers) even if the active
+    ///    workspace layout is currently set to Monocle mode.
+    /// 3. **`Monocle`**: Workspace-wide layout mode where the active window takes full
+    ///    content area and omits tiled borders.
+    /// 4. **`Tiled`**: Default fallthrough state for managed windows in a standard layout tree.
+    pub fn window_mode(&self, w: &Window) -> WindowMode {
+        if w.is_maximized() {
+            WindowMode::Maximized
+        } else if w.is_floating() {
+            WindowMode::Floating
+        } else if self.is_monocle() {
+            WindowMode::Monocle
+        } else {
+            WindowMode::Tiled
+        }
     }
 
-    /// Whether the given window should render its header.
+    /// Single read boundary for border rendering.
+    pub fn window_borders_enabled(&self, key: WindowKey) -> bool {
+        self.window(key)
+            .map(|w| {
+                w.chrome_config()
+                    .rules_for(self.window_mode(w))
+                    .show_borders
+            })
+            .unwrap_or(false)
+    }
+
+    /// Single read boundary for header rendering.
     pub fn window_header_enabled(&self, key: WindowKey) -> bool {
-        self.window(key).map(|w| w.header_enabled).unwrap_or(false)
+        self.window(key)
+            .map(|w| w.chrome_config().rules_for(self.window_mode(w)).show_header)
+            .unwrap_or(false)
     }
 
     /// Handle mouse-click focus switching.
@@ -382,8 +406,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 height: self.managed_area.height,
             });
             for (_id, window) in self.windows.iter_mut() {
-                if window.floating_rect == Some(prev_full) {
-                    window.floating_rect = Some(new_full);
+                if window.floating_rect() == Some(prev_full) {
+                    window.set_floating_rect(Some(new_full));
                 }
             }
         }
@@ -436,8 +460,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .iter()
             .filter_map(|(key, window)| {
                 if window.is_floating()
-                    && window.state != WindowState::Iconic
-                    && window.state != WindowState::Unmapped
+                    && window.state() != WindowState::Iconic
+                    && window.state() != WindowState::Unmapped
                 {
                     Some(key)
                 } else {
@@ -488,11 +512,11 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     pub fn build_display_order(&self) -> Vec<WindowKey> {
         let mut ordered: Vec<(WindowKey, &super::Window)> = self.windows.iter().collect();
-        ordered.sort_by_key(|(_, window)| window.creation_order);
+        ordered.sort_by_key(|(_, window)| window.creation_order());
 
         let mut out: Vec<WindowKey> = Vec::new();
         for (key, window) in ordered {
-            if self.managed_draw_order.contains(&key) || window.state == WindowState::Iconic {
+            if self.managed_draw_order.contains(&key) || window.state() == WindowState::Iconic {
                 out.push(key);
             }
         }
@@ -508,14 +532,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         let title = title.into();
         let prev = self
             .window(key)
-            .and_then(|w| w.title.as_deref().map(|t| t.to_string()));
+            .and_then(|w| w.title().map(|t| t.to_string()));
         if prev.as_deref() != Some(&title)
             && let Some(window) = self.windows.get_mut(key)
         {
             let seq = self.next_title_seq;
             self.next_title_seq += 1;
-            window.title = Some(title);
-            window.title_set_order = Some(seq);
+            window.set_title(Some(title));
+            window.set_title_set_order(Some(seq));
         }
     }
 
@@ -644,7 +668,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         let floating_keys: Vec<WindowKey> = self
             .windows
             .iter()
-            .filter_map(|(key, window)| window.floating_rect.as_ref().map(|_| key))
+            .filter_map(|(key, window)| window.floating_rect().map(|_| key))
             .collect();
         for key in floating_keys {
             let Some(FloatRectSpec::Absolute(fr)) = self.floating_rect(key) else {
@@ -779,12 +803,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Idempotent — safe to call even if already detached.
     pub(super) fn detach_from_tiling_layout(&mut self, key: WindowKey) {
         // Capture void_id before the mutable layout borrow
-        let void_id = self.window(key).and_then(|w| w.void_id);
+        let void_id = self.window(key).and_then(|w| w.void_id());
         if let Some(ref mut layout) = self.managed_layout {
             if let Some(vid) = void_id {
                 layout.remove_void_by_id(vid);
                 if let Some(w) = self.windows.get_mut(key) {
-                    w.void_id = None;
+                    w.clear_void_id();
                 }
             } else {
                 let _ = layout.root_mut().remove_leaf(key);
@@ -816,7 +840,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         let current_focus = *self.focus.current();
         let floating_info = self
             .window(key)
-            .and_then(|w| w.floating_rect)
+            .and_then(|w| w.floating_rect())
             .map(|spec| spec.resolve(self.managed_area));
 
         let Some(layout) = self.managed_layout.as_mut() else {
@@ -1047,5 +1071,68 @@ mod tests {
         };
         let result = wm.localize_event_content(key, &Event::Mouse(mouse));
         assert!(result.is_some());
+    }
+}
+
+#[cfg(test)]
+mod window_mode_tests {
+    use super::*;
+    use crate::window::window_manager::Window;
+    use crate::window::{ComponentKey, FloatRectSpec};
+
+    // Helper to spin up a stub Window
+    fn create_test_window(key_idx: usize) -> Window {
+        Window::new(key_idx, ComponentKey::default())
+    }
+
+    // Helper to create a dummy FloatRectSpec for testing floating state
+    fn dummy_float_spec() -> FloatRectSpec {
+        FloatRectSpec::Absolute(Default::default())
+    }
+
+    #[test]
+    fn test_window_mode_priority_hierarchy() {
+        let mut window = create_test_window(1);
+
+        // 1. Base state: Tiled (not floating, not maximized, not monocle)
+        let is_monocle = false;
+        let mode = evaluate_mode(&window, is_monocle);
+        assert_eq!(mode, WindowMode::Tiled);
+
+        // 2. Monocle active -> Monocle mode
+        let is_monocle = true;
+        let mode = evaluate_mode(&window, is_monocle);
+        assert_eq!(mode, WindowMode::Monocle);
+
+        // 3. Floating window inside Monocle workspace -> Floating overrides Monocle
+        window.set_floating_rect(Some(dummy_float_spec()));
+        let mode = evaluate_mode(&window, is_monocle);
+        assert_eq!(
+            mode,
+            WindowMode::Floating,
+            "Floating windows must preserve floating chrome rules even under Monocle layout"
+        );
+
+        // 4. Maximized window -> Maximized overrides Floating & Monocle
+        window.set_maximized(true);
+        let mode = evaluate_mode(&window, is_monocle);
+        assert_eq!(
+            mode,
+            WindowMode::Maximized,
+            "Maximized state must take precedence over all other modes"
+        );
+    }
+
+    /// Isolated helper mirroring `WindowManager::window_mode` priority order for pure testing
+    fn evaluate_mode(w: &Window, is_monocle: bool) -> WindowMode {
+        if w.is_maximized() {
+            WindowMode::Maximized
+        } else if w.is_floating() {
+            WindowMode::Floating
+        } else if is_monocle {
+            WindowMode::Monocle
+        } else {
+            WindowMode::Tiled
+        }
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -5824,7 +5824,8 @@ mod tests {
         assert_eq!(wm.window_state(target), Some(WindowState::Unmapped));
         assert!(!wm.z_order.contains(&target), "removed from z_order");
         assert!(
-            wm.window(target).is_some_and(|w| w.floating_rect().is_some()),
+            wm.window(target)
+                .is_some_and(|w| w.floating_rect().is_some()),
             "floating rect preserved across Unmap"
         );
         // Focus ring auto-fallbacks via set_order removing current → first()

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -414,7 +414,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Set the close policy for a window (Destroy or Unmap).
     pub fn set_close_policy(&mut self, key: WindowKey, policy: entry::ClosePolicy) {
         if let Some(w) = self.windows.get_mut(key) {
-            w.close_policy = policy;
+            w.set_close_policy(policy);
         }
     }
 
@@ -434,7 +434,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     pub fn window_state(&self, key: WindowKey) -> Option<WindowState> {
-        self.window(key).map(|w| w.state)
+        self.window(key).map(|w| w.state())
     }
 
     /// Validate that a state transition is legal.
@@ -457,7 +457,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     pub fn transition_window(&mut self, key: WindowKey, new_state: WindowState) {
         // Step 1: Read old state (immutable borrow, immediately dropped)
         let old_state = match self.window(key) {
-            Some(w) => w.state,
+            Some(w) => w.state(),
             None => {
                 tracing::warn!("transition_window: unknown key {:?}", key);
                 return;
@@ -474,7 +474,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         );
 
         // Step 2: Mutate state (brief mutable borrow, immediately dropped)
-        self.window_mut(key).state = new_state;
+        self.window_mut(key).set_state(new_state);
 
         // Step 3: Side-effects — full &mut self available
         match (old_state, new_state) {
@@ -528,7 +528,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 let has_other_floating = self
                     .windows
                     .values()
-                    .any(|w| w.state == WindowState::Mapped && w.is_floating());
+                    .any(|w| w.state() == WindowState::Mapped && w.is_floating());
                 let floating_mode = self.managed_layout.is_none();
 
                 if !self.is_window_floating(key) && (has_other_floating || floating_mode) {
@@ -559,7 +559,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     fn floating_rect(&self, key: WindowKey) -> Option<crate::window::FloatRectSpec> {
-        self.window(key).and_then(|window| window.floating_rect)
+        self.window(key).and_then(|window| window.floating_rect())
     }
 
     pub fn set_floating_rect(
@@ -568,14 +568,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         rect: Option<crate::window::FloatRectSpec>,
     ) {
         if let Some(w) = self.windows.get_mut(key) {
-            w.floating_rect = rect;
+            w.set_floating_rect(rect);
         }
     }
 
     fn clear_floating_rect(&mut self, key: WindowKey) {
         if let Some(w) = self.windows.get_mut(key) {
-            w.floating_rect = None;
-            w.is_maximized = false;
+            w.set_floating_rect(None);
+            w.set_maximized(false);
         }
     }
 
@@ -585,12 +585,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         rect: Option<crate::window::FloatRectSpec>,
     ) {
         if let Some(w) = self.windows.get_mut(key) {
-            w.prev_floating_rect = rect;
+            w.set_prev_floating_rect(rect);
         }
     }
 
     fn take_prev_floating_rect(&mut self, key: WindowKey) -> Option<crate::window::FloatRectSpec> {
-        self.windows.get_mut(key)?.prev_floating_rect.take()
+        self.windows.get_mut(key)?.take_prev_floating_rect()
     }
 
     pub fn is_window_floating(&self, key: WindowKey) -> bool {
@@ -624,16 +624,16 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     pub fn direct_mode(&self, key: WindowKey) -> bool {
-        self.window(key).is_some_and(|window| window.direct_mode)
+        self.window(key).is_some_and(|window| window.direct_mode())
     }
 
     pub fn set_direct_mode(&mut self, key: WindowKey, value: bool) {
         let title = self.window_title(key);
         if let Some(w) = self.windows.get_mut(key)
-            && w.direct_mode != value
+            && w.direct_mode() != value
         {
-            w.direct_mode = value;
-            if value && let Some(c) = self.components.get_mut(w.component_key) {
+            w.set_direct_mode(value);
+            if value && let Some(c) = self.components.get_mut(w.component_key()) {
                 c.clear_selection();
             }
             self.mark_layout_dirty();
@@ -688,7 +688,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 .window(oid)
                 .map(|w| w.title_or_default(oid))
                 .unwrap_or_else(|| format!("{:?}", oid));
-            let set_order = self.window(oid).and_then(|w| w.title_set_order);
+            let set_order = self.window(oid).and_then(|w| w.title_set_order());
             groups.entry(base).or_default().push((oid, set_order));
         }
         for group in groups.values_mut() {
@@ -714,8 +714,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     fn clear_all_floating(&mut self) {
         for (_key, window) in self.windows.iter_mut() {
-            window.floating_rect = None;
-            window.prev_floating_rect = None;
+            window.set_floating_rect(None);
+            window.set_prev_floating_rect(None);
         }
     }
 
@@ -1018,7 +1018,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .with_screen_area(self.region(key));
         // Inject the window's active keyboard focus into the context.
         if let Some(window) = self.windows.get(key)
-            && let Some(focus_id) = window.active_keyboard_focus
+            && let Some(focus_id) = window.active_keyboard_focus()
         {
             ctx = ctx.with_keyboard_focus_id(focus_id);
         }
@@ -1187,7 +1187,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     pub fn floating_panes(&self) -> Vec<(WindowKey, crate::window::FloatRectSpec)> {
         self.windows
             .iter()
-            .filter_map(|(key, window)| window.floating_rect.map(|rect| (key, rect)))
+            .filter_map(|(key, window)| window.floating_rect().map(|rect| (key, rect)))
             .collect()
     }
 
@@ -1224,7 +1224,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         &self,
         key: WindowKey,
     ) -> Option<crate::hitbox_registry::HitboxId> {
-        self.windows.get(key).map(|w| w.content_hitbox_id)
+        self.windows.get(key).map(|w| w.content_hitbox_id())
     }
 
     /// Dispatch a mouse event through the hitbox registry.
@@ -1288,7 +1288,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                             let dx = col.abs_diff(*anchor_x);
                             let dy = row.abs_diff(*anchor_y);
                             let is_maximized =
-                                self.windows.get(*key).is_some_and(|w| w.is_maximized);
+                                self.windows.get(*key).is_some_and(|w| w.is_maximized());
 
                             if dx + dy <= 2 {
                                 // Deadzone guard: ignore micro-nudges
@@ -1654,8 +1654,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                         // Unset maximized so further resize/move isn't restricted,
                         // but keep the current rect so the cursor stays on the handle.
                         if let Some(w) = self.windows.get_mut(*h_key) {
-                            w.is_maximized = false;
-                            w.borders_enabled = true;
+                            w.set_maximized(false);
                         }
                         let rect = self.full_region_for_key(*h_key);
                         let (start_x, start_y, start_width, start_height) =
@@ -2153,14 +2152,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Returns &C — no vtable cast. Callers in generic context get static dispatch.
     pub fn component_for_key(&self, key: WindowKey) -> Option<&C> {
         let w = self.windows.get(key)?;
-        self.components.get(w.component_key)
+        self.components.get(w.component_key())
     }
 
     /// Event/update-phase access: borrow component mutably.
     /// Returns &mut C — no vtable cast. Callers in generic context get static dispatch.
     pub fn component_for_key_mut(&mut self, key: WindowKey) -> Option<&mut C> {
         let w = self.windows.get_mut(key)?;
-        self.components.get_mut(w.component_key)
+        self.components.get_mut(w.component_key())
     }
 
     /// Return all window keys currently in the SlotMap.
@@ -2177,7 +2176,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     pub fn mapped_windows(&self) -> Vec<WindowKey> {
         self.windows
             .iter()
-            .filter(|(_, w)| w.state == WindowState::Mapped)
+            .filter(|(_, w)| w.state() == WindowState::Mapped)
             .map(|(key, _)| key)
             .collect()
     }
@@ -2448,7 +2447,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         hitbox_id: crate::hitbox_registry::HitboxId,
     ) {
         if let Some(window) = self.windows.get_mut(key) {
-            window.active_keyboard_focus = Some(hitbox_id);
+            window.set_active_keyboard_focus(Some(hitbox_id));
         }
     }
 
@@ -2461,7 +2460,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         if !self.windows.contains_key(focused) {
             return Vec::new();
         }
-        let is_maxed = self.window(focused).is_some_and(|w| w.is_maximized);
+        let is_maxed = self.window(focused).is_some_and(|w| w.is_maximized());
         let mut btns = vec![WmButton {
             action: TermWmAction::CloseWindow(focused),
             label: "Close Window",
@@ -3079,7 +3078,7 @@ mod tests {
         // Maximize the tiled window
         wm.toggle_maximize(keys[0]);
         assert!(
-            wm.windows.get(keys[0]).unwrap().is_maximized,
+            wm.windows.get(keys[0]).unwrap().is_maximized(),
             "is_maximized set"
         );
 
@@ -3089,7 +3088,7 @@ mod tests {
 
         // Original window should be unmaximized and back in the tiling layout
         let w0 = wm.windows.get(keys[0]).unwrap();
-        assert!(!w0.is_maximized, "should no longer be maximized");
+        assert!(!w0.is_maximized(), "should no longer be maximized");
         assert!(!w0.is_floating(), "should be tiled (not floating)");
         assert!(
             wm.managed_layout
@@ -3137,7 +3136,7 @@ mod tests {
         // Maximize the floating window
         wm.toggle_maximize(keys[0]);
         assert!(
-            wm.windows.get(keys[0]).unwrap().is_maximized,
+            wm.windows.get(keys[0]).unwrap().is_maximized(),
             "is_maximized set"
         );
 
@@ -3148,7 +3147,7 @@ mod tests {
         // Original window should be unmaximized and still floating at its
         // pre-maximize position
         let w0 = wm.windows.get(keys[0]).unwrap();
-        assert!(!w0.is_maximized, "should no longer be maximized");
+        assert!(!w0.is_maximized(), "should no longer be maximized");
         assert!(w0.is_floating(), "should remain floating (not tiled)");
         // Its floating rect should be the original pre-maximize rect
         let restored = wm.floating_rect(keys[0]);
@@ -3191,14 +3190,14 @@ mod tests {
 
         // Maximize
         wm.toggle_maximize(keys[0]);
-        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
-        assert!(wm.windows.get(keys[0]).unwrap().void_id.is_some());
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized());
+        assert!(wm.windows.get(keys[0]).unwrap().void_id().is_some());
 
         // Toggle back (unmaximize directly)
         wm.toggle_maximize(keys[0]);
         let w0 = wm.windows.get(keys[0]).unwrap();
-        assert!(!w0.is_maximized, "unmaximized");
-        assert!(w0.void_id.is_none(), "void_id cleared");
+        assert!(!w0.is_maximized(), "unmaximized");
+        assert!(w0.void_id().is_none(), "void_id cleared");
         assert!(!w0.is_floating(), "not floating");
         // Should be back in tree at original position
         assert!(
@@ -3235,7 +3234,7 @@ mod tests {
         wm.toggle_maximize(keys[0]);
         let w0 = wm.windows.get(keys[0]).unwrap();
         assert!(
-            w0.void_id.is_some(),
+            w0.void_id().is_some(),
             "void_id set after maximizing tiled window"
         );
         // Tree should contain a Void, not a Leaf(keys[0])
@@ -3279,13 +3278,13 @@ mod tests {
         // Maximize floating window
         wm.toggle_maximize(keys[0]);
         let w0 = wm.windows.get(keys[0]).unwrap();
-        assert!(w0.is_maximized);
+        assert!(w0.is_maximized());
         // Window still has floating_rect (now = full), so is_floating is true
 
         // Toggle back
         wm.toggle_maximize(keys[0]);
         let w0 = wm.windows.get(keys[0]).unwrap();
-        assert!(!w0.is_maximized, "unmaximized");
+        assert!(!w0.is_maximized(), "unmaximized");
         assert!(w0.is_floating(), "still floating");
         let restored = wm.floating_rect(keys[0]);
         assert_eq!(restored, Some(float_rect), "original rect restored");
@@ -3328,7 +3327,7 @@ mod tests {
 
         assert_eq!(wm.focused_window(), keys[1], "focus moved to keys[1]");
         assert!(
-            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            !wm.windows.get(keys[0]).unwrap().is_maximized(),
             "keys[0] unmaximized by focus shift"
         );
     }
@@ -3373,7 +3372,7 @@ mod tests {
             "focus moved to clicked window"
         );
         assert!(
-            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            !wm.windows.get(keys[0]).unwrap().is_maximized(),
             "keys[0] unmaximized by mouse click"
         );
     }
@@ -3402,7 +3401,7 @@ mod tests {
         wm.focus_window_key(keys[0]);
 
         wm.toggle_maximize(keys[0]);
-        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized());
         // Tree should be Void (single leaf replaced)
         assert!(matches!(
             wm.managed_layout.as_ref().unwrap().root(),
@@ -3411,7 +3410,7 @@ mod tests {
 
         wm.toggle_maximize(keys[0]);
         let w0 = wm.windows.get(keys[0]).unwrap();
-        assert!(!w0.is_maximized, "unmaximized");
+        assert!(!w0.is_maximized(), "unmaximized");
         // Back to a leaf at root
         assert_eq!(
             wm.managed_layout.as_ref().unwrap().root().unwrap_leaf(),
@@ -3454,7 +3453,7 @@ mod tests {
 
         // Maximize middle window
         wm.toggle_maximize(keys[1]);
-        assert!(wm.windows.get(keys[1]).unwrap().is_maximized);
+        assert!(wm.windows.get(keys[1]).unwrap().is_maximized());
         // Other windows still in tree
         let leaves: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
         assert_eq!(
@@ -3509,7 +3508,7 @@ mod tests {
 
         // Still maximized after restore
         assert!(
-            wm.windows.get(keys[0]).unwrap().is_maximized,
+            wm.windows.get(keys[0]).unwrap().is_maximized(),
             "still maximized"
         );
     }
@@ -3541,7 +3540,7 @@ mod tests {
         wm.toggle_maximize(keys[0]); // unmaximize
         wm.toggle_maximize(keys[0]); // maximize again
         assert!(
-            wm.windows.get(keys[0]).unwrap().is_maximized,
+            wm.windows.get(keys[0]).unwrap().is_maximized(),
             "can re-maximize"
         );
     }
@@ -3572,7 +3571,7 @@ mod tests {
         // should NOT unmaximize it
         wm.focus_window_key(keys[0]);
         assert!(
-            wm.windows.get(keys[0]).unwrap().is_maximized,
+            wm.windows.get(keys[0]).unwrap().is_maximized(),
             "focus same window should not unmaximize"
         );
     }
@@ -3687,7 +3686,7 @@ mod tests {
         let leaves: Vec<_> = wm.managed_layout.as_ref().unwrap().root().collect_leaves();
         assert_eq!(leaves, vec![keys[1]], "only remaining window in tree");
         assert!(
-            wm.windows.get(keys[0]).unwrap().void_id.is_none(),
+            wm.windows.get(keys[0]).unwrap().void_id().is_none(),
             "void_id cleared"
         );
     }
@@ -3876,7 +3875,7 @@ mod tests {
 
         // Maximize keys[0] (was tiled)
         wm.toggle_maximize(keys[0]);
-        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized());
 
         // Simulate what open_window does manuallly to see where it breaks
         let b = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
@@ -3903,7 +3902,7 @@ mod tests {
         wm.tile_window_key(b);
         assert_eq!(wm.focused_window(), b, "focus moved to new window");
         assert!(
-            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            !wm.windows.get(keys[0]).unwrap().is_maximized(),
             "keys[0] unmaximized by focus shift"
         );
         assert!(
@@ -3946,7 +3945,7 @@ mod tests {
 
         // Maximize keys[0] (was floating)
         wm.toggle_maximize(keys[0]);
-        assert!(wm.windows.get(keys[0]).unwrap().is_maximized);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized());
         assert_eq!(
             wm.focused_window(),
             keys[0],
@@ -3976,7 +3975,7 @@ mod tests {
 
         wm.tile_window_key(b);
         assert!(
-            !wm.windows.get(keys[0]).unwrap().is_maximized,
+            !wm.windows.get(keys[0]).unwrap().is_maximized(),
             "keys[0] unmaximized by focus shift"
         );
         // B gets tiled (managed_layout exists with keys[1])
@@ -4109,8 +4108,8 @@ mod tests {
             .localize_event_to_app(keys[1], &event)
             .expect("content-local event");
         if let Event::Mouse(local) = content_local {
-            assert_eq!(local.column, 4);
-            assert_eq!(local.row, 2);
+            assert_eq!(local.column, 5);
+            assert_eq!(local.row, 3);
         } else {
             panic!("expected mouse event");
         }
@@ -5825,7 +5824,7 @@ mod tests {
         assert_eq!(wm.window_state(target), Some(WindowState::Unmapped));
         assert!(!wm.z_order.contains(&target), "removed from z_order");
         assert!(
-            wm.window(target).is_some_and(|w| w.floating_rect.is_some()),
+            wm.window(target).is_some_and(|w| w.floating_rect().is_some()),
             "floating rect preserved across Unmap"
         );
         // Focus ring auto-fallbacks via set_order removing current → first()
@@ -6523,7 +6522,7 @@ mod tests {
         let wm_click = crate::events::core_event_to_wm(&click).unwrap();
         assert!(wm.dispatch_mouse(&wm_click).is_consumed());
         assert!(wm.is_window_floating(win_key));
-        assert!(wm.windows.get(win_key).unwrap().is_maximized);
+        assert!(wm.windows.get(win_key).unwrap().is_maximized());
     }
 
     #[test]


### PR DESCRIPTION
Make all Window struct fields private and provide accessor/mutator
methods, completing the TODO at entry.rs:89. The private field
pattern (is_maximized/chrome_config) is now used for every field.

Changes:
- entry.rs: Make 12 fields private; add getters & setters for each.
  Idiomatic signatures: title() returns Option<&str>, floating_rect()
  and prev_floating_rect() return Option<FloatRectSpec> by value
  (Copy type). Add take_floating_rect(), take_prev_floating_rect(),
  clear_void_id() convenience helpers.
- mod.rs: Update 25+ direct field reads/writes to use accessors.
- layout.rs: Update 12 field accesses (creation_order, state,
  floating_rect, title, title_set_order, void_id).
- chrome.rs: Update 6 field accesses (void_id, close_policy,
  component_key).
- focus.rs: Update 1 field access (window_mode uses accessors).
- window/mod.rs: Export Window so layout/test modules can reach it.
- draw_plan_renderer.rs, help.md, wm_help_overlay.rs: style/doc tweaks.

Also, prioritize hiding borders when maximized.