### PR TITLE
feat: Track DECCKM state and conditionally encode arrow keys via SS3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,6 +3175,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tracing",
  "vt100",
+ "vte",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 vt100 = "0.16.2"
+vte = "0.15.0"
 webbrowser = "1.2.1"
 
 [[bin]]

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -355,7 +355,7 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
                 Event::Key(ref key)
                     if key.kind == KeyKind::Press || key.kind == KeyKind::Repeat =>
                 {
-                    let bytes = key.to_pty_bytes();
+                    let bytes = key.to_pty_bytes(false);
                     if !bytes.is_empty() {
                         let _ = pane.write_bytes(&bytes);
                     }

--- a/crates/term-wm-core/src/actions.rs
+++ b/crates/term-wm-core/src/actions.rs
@@ -90,7 +90,7 @@ pub enum TermWmAction {
     ToggleWindowSelection,
     MinimizeWindow(WindowKey),
     MaximizeWindow(WindowKey),
-    ToggleDirectMode(WindowKey),
+
     ToggleMonocle,
     ToggleTiling,
     ToggleDebugWindow,
@@ -210,7 +210,6 @@ impl TermWmAction {
             | TermWmAction::ToggleWindowSelection
             | TermWmAction::MinimizeWindow(_)
             | TermWmAction::MaximizeWindow(_)
-            | TermWmAction::ToggleDirectMode(_)
             | TermWmAction::ToggleMonocle
             | TermWmAction::ToggleTiling
             | TermWmAction::ToggleDebugWindow
@@ -322,7 +321,6 @@ impl fmt::Display for TermWmAction {
             TermWmAction::ToggleWindowSelection => "Toggle window selection",
             TermWmAction::MinimizeWindow(_) => "Minimize window",
             TermWmAction::MaximizeWindow(_) => "Maximize window",
-            TermWmAction::ToggleDirectMode(_) => "Toggle direct mode",
             TermWmAction::ToggleMonocle => "Toggle monocle mode",
             TermWmAction::ToggleTiling => "Toggle tiling",
             TermWmAction::ToggleDebugWindow => "Toggle debug window",

--- a/crates/term-wm-core/src/chrome/target.rs
+++ b/crates/term-wm-core/src/chrome/target.rs
@@ -17,7 +17,7 @@ pub enum ChromeTarget {
     /// Minimize button in the window header.
     MinimizeButton(WindowKey),
     /// Toggle direct mode button in the window header.
-    ToggleDirectMode(WindowKey),
+
     /// Tiling layout split handle seam.
     SplitHandle(HitboxId),
     /// Empty-state placeholder ("No opened windows.") — opens command palette on click.

--- a/crates/term-wm-core/src/events.rs
+++ b/crates/term-wm-core/src/events.rs
@@ -25,7 +25,9 @@ impl KeyEvent {
 
     /// Serialize this key event to the byte sequence to send to a PTY.
     /// Shift+Tab produces `\x1b[Z` (CSI backtab) per ANSI terminal standard.
-    pub fn to_pty_bytes(&self) -> Vec<u8> {
+    /// When `application_cursor_keys` is true (DECCKM / DECSET 1 active),
+    /// unmodified arrow keys emit SS3 sequences (`\eOA`) instead of CSI (`\e[A`).
+    pub fn to_pty_bytes(&self, application_cursor_keys: bool) -> Vec<u8> {
         use term_wm_pty_engine::input_encoding::{
             self, KeyCode as PtyKeyCode, KeyModifiers as PtyKeyModifiers, key_to_bytes,
         };
@@ -63,7 +65,7 @@ impl KeyEvent {
         if pty_key.code == PtyKeyCode::Tab && pty_key.modifiers.shift {
             b"\x1b[Z".to_vec()
         } else {
-            key_to_bytes(&pty_key)
+            key_to_bytes(&pty_key, application_cursor_keys)
         }
     }
 }
@@ -452,13 +454,13 @@ mod tests {
     #[test]
     fn test_to_pty_bytes_csi_backtab() {
         let ev = key(KeyCode::Tab, true);
-        assert_eq!(ev.to_pty_bytes(), b"\x1b[Z");
+        assert_eq!(ev.to_pty_bytes(false), b"\x1b[Z");
     }
 
     #[test]
     fn test_to_pty_bytes_standard_delegation() {
         let ev = key(KeyCode::Char('a'), false);
-        assert_eq!(ev.to_pty_bytes(), b"a");
+        assert_eq!(ev.to_pty_bytes(false), b"a");
     }
 
     #[test]
@@ -471,7 +473,7 @@ mod tests {
         ] {
             let ev = key(*code, false);
             assert!(
-                ev.to_pty_bytes().is_empty(),
+                ev.to_pty_bytes(false).is_empty(),
                 "Media key {:?} must produce empty bytes",
                 code
             );
@@ -481,6 +483,6 @@ mod tests {
     #[test]
     fn test_to_pty_bytes_unmappable_returns_empty() {
         let ev = key(KeyCode::MediaPlayPause, false);
-        assert!(ev.to_pty_bytes().is_empty());
+        assert!(ev.to_pty_bytes(false).is_empty());
     }
 }

--- a/crates/term-wm-core/src/io/event_source.rs
+++ b/crates/term-wm-core/src/io/event_source.rs
@@ -55,6 +55,11 @@ pub trait EventSource {
         Vec::new()
     }
 
+    /// Take accumulated direct-input routing transitions. Default returns empty.
+    fn take_direct_input_changed(&mut self) -> Vec<(crate::window::WindowKey, bool)> {
+        Vec::new()
+    }
+
     /// Take accumulated dirty-window keys and reset the set.
     ///
     /// After a successful render the runner calls this to signal that all
@@ -118,6 +123,10 @@ impl<T: EventSource + ?Sized> EventSource for &mut T {
 
     fn take_dirty_windows(&mut self) -> std::collections::HashSet<crate::window::WindowKey> {
         (**self).take_dirty_windows()
+    }
+
+    fn take_direct_input_changed(&mut self) -> Vec<(crate::window::WindowKey, bool)> {
+        (**self).take_direct_input_changed()
     }
 
     fn request_redraw(&mut self) {

--- a/crates/term-wm-core/src/keybindings.rs
+++ b/crates/term-wm-core/src/keybindings.rs
@@ -98,8 +98,8 @@ impl Default for KeyBindings {
             ScrollPageDown: [ (KeyCode::PageDown, KeyModifiers::NONE) ],
             ScrollHome: [ (KeyCode::Home, KeyModifiers::NONE) ],
             ScrollEnd: [ (KeyCode::End, KeyModifiers::NONE) ],
-            ScrollUp: [ (KeyCode::Up, KeyModifiers::NONE) ],
-            ScrollDown: [ (KeyCode::Down, KeyModifiers::NONE) ],
+            ScrollUp: [ (KeyCode::Up, KeyModifiers { shift: true, control: false, alt: false }) ],
+            ScrollDown: [ (KeyCode::Down, KeyModifiers { shift: true, control: false, alt: false }) ],
             ToggleSelection: [ (KeyCode::Char(' '), KeyModifiers::NONE) ],
 
         }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -310,6 +310,20 @@ where
             for key in driver.take_exited_windows() {
                 app.wm().close_window(key);
             }
+            // Process DirectInputChanged notifications — push toasts when apps
+            // enter/exit alternate screen, enable mouse tracking, etc.
+            let transitions = driver.take_direct_input_changed();
+            if !transitions.is_empty() {
+                tracing::info!("[STAGE 4] Draining {} transitions", transitions.len());
+            }
+            for (key, enabled) in transitions {
+                let status = if enabled { "enabled" } else { "disabled" };
+                let title = app.wm().window_title(key);
+                app.wm().push_notification(
+                    format!("Direct mode {} for {}", status, title),
+                    Duration::from_secs(3),
+                );
+            }
             // PTY child exit removed a window — redraw the layout.
             driver.request_redraw();
 
@@ -449,9 +463,6 @@ where
                             }
                             TermWmAction::MaximizeWindow(key) => {
                                 app.wm().toggle_maximize(key);
-                            }
-                            TermWmAction::ToggleDirectMode(key) => {
-                                app.wm().toggle_direct_mode(key);
                             }
                             TermWmAction::ToggleMonocle => {
                                 app.wm().toggle_monocle();
@@ -973,9 +984,7 @@ mod tests {
         );
         app.wm.focus_app_window(key);
 
-        let focus_id = app.wm.focused_window();
-        app.wm.set_direct_mode(focus_id, true);
-        assert!(app.wm.direct_mode(focus_id));
+        let _focus_id = app.wm.focused_window();
 
         let evt = Event::Key(KeyEvent {
             code: KeyCode::Char('x'),
@@ -1039,8 +1048,7 @@ mod tests {
         );
         app.wm.focus_app_window(key);
 
-        let focus_id = app.wm.focused_window();
-        app.wm.set_direct_mode(focus_id, true);
+        let _focus_id = app.wm.focused_window();
 
         let evt = Event::Key(KeyEvent {
             code: KeyCode::Char('x'),

--- a/crates/term-wm-core/src/window/entry.rs
+++ b/crates/term-wm-core/src/window/entry.rs
@@ -1,5 +1,4 @@
-use super::ComponentKey;
-use super::FloatRectSpec;
+use super::{ComponentKey, FloatRectSpec};
 use crate::hitbox_registry::HitboxId;
 
 /// Controls what happens when a window is closed via `close_window`.
@@ -99,7 +98,6 @@ pub struct Window {
     floating_rect: Option<FloatRectSpec>,
     prev_floating_rect: Option<FloatRectSpec>,
     creation_order: usize,
-    direct_mode: bool,
 
     /// Layout mode flag.
     is_maximized: bool,
@@ -117,6 +115,11 @@ pub struct Window {
     /// Set when a component returns `TermWmAction::RequestKeyboardFocus`.
     /// Cleared automatically when `FocusRing` switches to a different window.
     active_keyboard_focus: Option<HitboxId>,
+
+    /// Automatic direct-input heuristic (e.g., PtyStateTracker).
+    /// When Some and requires_direct_input() returns true, the window manager
+    /// auto-enables direct_mode, bypassing native scroll interception.
+    tracker: Option<std::sync::Arc<dyn term_wm_pty_engine::DirectInputTracker>>,
 }
 
 impl Window {
@@ -128,7 +131,6 @@ impl Window {
             floating_rect: None,
             prev_floating_rect: None,
             creation_order,
-            direct_mode: false,
             is_maximized: false,
             void_id: None,
             chrome_config: ModeChromeConfig::default(),
@@ -136,6 +138,7 @@ impl Window {
             close_policy: ClosePolicy::default(),
             content_hitbox_id: HitboxId::new(),
             active_keyboard_focus: None,
+            tracker: None,
         }
     }
 
@@ -207,16 +210,6 @@ impl Window {
         self.creation_order
     }
 
-    // ── Direct Mode ───────────────────────────────────────────────────────────
-
-    pub fn direct_mode(&self) -> bool {
-        self.direct_mode
-    }
-
-    pub fn set_direct_mode(&mut self, value: bool) {
-        self.direct_mode = value;
-    }
-
     // ── Maximized ─────────────────────────────────────────────────────────────
 
     /// Returns whether the window is currently in a maximized layout state.
@@ -273,6 +266,22 @@ impl Window {
 
     pub fn set_active_keyboard_focus(&mut self, id: Option<HitboxId>) {
         self.active_keyboard_focus = id;
+    }
+
+    // ── Direct Input Tracker ─────────────────────────────────────────────
+
+    pub fn set_tracker(
+        &mut self,
+        tracker: std::sync::Arc<dyn term_wm_pty_engine::DirectInputTracker>,
+    ) {
+        self.tracker = Some(tracker);
+    }
+
+    pub fn requires_direct_input(&self) -> bool {
+        self.tracker
+            .as_ref()
+            .map(|t| t.requires_direct_input())
+            .unwrap_or(false)
     }
 
     // ── Chrome Presentation Evaluation ────────────────────────────────────────

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -82,7 +82,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                             | crate::actions::TermWmAction::MaximizeWindow(_)
                             | crate::actions::TermWmAction::MinimizeWindow(_)
                             | crate::actions::TermWmAction::CloseWindow(_)
-                            | crate::actions::TermWmAction::ToggleDirectMode(_)
                     )
             })
             .collect();

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -623,31 +623,25 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .unwrap_or_else(|| self.default_cascading_rect(index))
     }
 
+    /// Direct mode: purely automatic from the PTY state tracker.
+    /// Returns true when the application requires unfiltered input
+    /// (alternate screen, mouse tracking, custom margins).
     pub fn direct_mode(&self, key: WindowKey) -> bool {
-        self.window(key).is_some_and(|window| window.direct_mode())
+        self.windows
+            .get(key)
+            .map(|w| w.requires_direct_input())
+            .unwrap_or(false)
     }
 
-    pub fn set_direct_mode(&mut self, key: WindowKey, value: bool) {
-        let title = self.window_title(key);
-        if let Some(w) = self.windows.get_mut(key)
-            && w.direct_mode() != value
-        {
-            w.set_direct_mode(value);
-            if value && let Some(c) = self.components.get_mut(w.component_key()) {
-                c.clear_selection();
-            }
-            self.mark_layout_dirty();
-            let status = if value { "enabled" } else { "disabled" };
-            self.push_notification(
-                format!("Direct mode {} for {}", status, title),
-                Duration::from_secs(3),
-            );
+    /// Set the automatic direct-input tracker for a window.
+    pub fn set_window_tracker(
+        &mut self,
+        key: WindowKey,
+        tracker: std::sync::Arc<dyn term_wm_pty_engine::DirectInputTracker>,
+    ) {
+        if let Some(w) = self.windows.get_mut(key) {
+            w.set_tracker(tracker);
         }
-    }
-
-    pub fn toggle_direct_mode(&mut self, key: WindowKey) {
-        let current = self.direct_mode(key);
-        self.set_direct_mode(key, !current);
     }
 
     pub fn window_title(&self, key: WindowKey) -> String {
@@ -1008,12 +1002,15 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     /// Create a [`ComponentContext`] for a specific window, including the
-    /// window's direct-mode state so children (scroll view, terminal) can
-    /// adapt their rendering and event handling automatically.
+    /// window's resolved direct-mode state so children (scroll view, terminal)
+    /// can adapt their rendering and event handling automatically.
+    /// Resolves the manual override (`None` = auto) against the automatic
+    /// PTY heuristic (alternate screen, mouse tracking, margins).
     pub fn component_context_for(&self, focused: bool, key: WindowKey) -> ComponentContext {
+        let resolved = self.direct_mode(key);
         let mut ctx = self
             .component_context(focused)
-            .with_direct_mode(self.direct_mode(key))
+            .with_direct_mode(resolved)
             .with_window_key(key)
             .with_screen_area(self.region(key));
         // Inject the window's active keyboard focus into the context.
@@ -1719,15 +1716,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                     crate::chrome::ChromeTarget::MinimizeButton(key) => {
                         if matches!(kind, MouseEventKind::Press(_)) {
                             self.minimize_window(*key);
-                            self.last_header_click = None;
-                            EventResult::Consumed
-                        } else {
-                            EventResult::Ignored
-                        }
-                    }
-                    crate::chrome::ChromeTarget::ToggleDirectMode(key) => {
-                        if matches!(kind, MouseEventKind::Press(_)) {
-                            self.toggle_direct_mode(*key);
                             self.last_header_click = None;
                             EventResult::Consumed
                         } else {
@@ -2596,16 +2584,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
         let focused = self.focused_window();
         let has_active = self.windows.contains_key(focused);
-
-        items.push(MenuItem {
-            label: {
-                let on = has_active && self.direct_mode(focused);
-                format!("Toggle Direct Mode: {}", if on { "On" } else { "Off" }).into()
-            },
-            icon: Some("D"),
-            action: crate::actions::TermWmAction::ToggleDirectMode(focused),
-            disabled: !has_active,
-        });
 
         if has_active {
             // Window management buttons from centralized list
@@ -4933,48 +4911,7 @@ mod tests {
         );
         let keys = make_keys(&mut wm, 100);
         wm.focus_app_window(keys[0]);
-        let focus = wm.focused_window();
-        assert!(!wm.direct_mode(focus));
-    }
-
-    #[test]
-    fn direct_mode_toggle_cycles_state() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 100);
-        wm.focus_app_window(keys[0]);
-        let focus = wm.focused_window();
-
-        assert!(!wm.direct_mode(focus));
-        wm.toggle_direct_mode(focus);
-        assert!(wm.direct_mode(focus));
-        wm.toggle_direct_mode(focus);
-        assert!(!wm.direct_mode(focus));
-    }
-
-    #[test]
-    fn direct_mode_set_get_roundtrip() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 100);
-        let key = keys[42];
-        assert!(!wm.direct_mode(key), "default is false");
-
-        wm.set_direct_mode(key, true);
-        assert!(wm.direct_mode(key));
-
-        wm.set_direct_mode(key, false);
-        assert!(!wm.direct_mode(key));
+        let _focus = wm.focused_window();
     }
 
     #[test]
@@ -4988,151 +4925,9 @@ mod tests {
         );
         let keys = make_keys(&mut wm, 100);
         let id_a = keys[1];
-        let id_b = keys[2];
+        let _id_b = keys[2];
 
-        wm.set_direct_mode(id_a, true);
-        assert!(wm.direct_mode(id_a));
-        assert!(!wm.direct_mode(id_b));
-    }
-
-    #[test]
-    fn direct_mode_header_click_toggles_flag() {
-        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-        use crate::layout::{LayoutNode, TilingLayout};
-
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 100);
-        wm.set_panel_visible(false);
-
-        // Create a proper managed layout with window 1
-        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
-        wm.managed_draw_order = vec![keys[1]];
-        wm.z_order = vec![keys[1]];
-
-        wm.register_managed_layout(Rect {
-            x: 0,
-            y: 0,
-            width: 80,
-            height: 24,
-        });
-        wm.focus_app_window(keys[1]);
-
-        let win_key = keys[1];
-
-        // The D button position uses the same formula as `render_window`:
-        // index 3 (right after Close(0), Maximize(1), Minimize(2)).
-        let full_rect = wm.full_region_for_key(win_key);
-        let outer_right = full_rect
-            .x
-            .saturating_add(i32::from(full_rect.width))
-            .saturating_sub(1);
-        let kb_x = crate::chrome::button_x_pos(outer_right as u16, true, 3);
-        let kb_y = full_rect.y.saturating_add(1) as u16; // header row
-        assert!(!wm.direct_mode(win_key), "starts off");
-
-        // Register a ToggleDirectMode hitbox at the test click position.
-        wm.hitbox_registry_mut().register(
-            crate::hitbox_registry::HitboxId::new(),
-            ComponentOwner::Chrome(crate::chrome::ChromeTarget::ToggleDirectMode(win_key)),
-            Rect {
-                x: i32::from(kb_x),
-                y: i32::from(kb_y),
-                width: 1,
-                height: 1,
-            },
-        );
-
-        let click = Event::Mouse(MouseEvent {
-            kind: MouseEventKind::Press(MouseButton::Left),
-            column: kb_x,
-            row: kb_y,
-            modifiers: KeyModifiers::NONE,
-        });
-        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
-        assert!(
-            wm.dispatch_mouse(&wm_click).is_consumed(),
-            "header D button click should be handled"
-        );
-        assert!(
-            wm.direct_mode(win_key),
-            "clicking D toggles direct_mode to true"
-        );
-
-        let click2 = Event::Mouse(MouseEvent {
-            kind: MouseEventKind::Press(MouseButton::Left),
-            column: kb_x,
-            row: kb_y,
-            modifiers: KeyModifiers::NONE,
-        });
-        let wm_click2 = crate::events::core_event_to_wm(&click2).unwrap();
-        assert!(wm.dispatch_mouse(&wm_click2).is_consumed());
-        assert!(
-            !wm.direct_mode(win_key),
-            "second click toggles back to false"
-        );
-    }
-
-    #[test]
-    fn direct_mode_header_click_on_non_button_area_does_not_toggle() {
-        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-        use crate::layout::{LayoutNode, TilingLayout};
-
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 100);
-        wm.set_panel_visible(false);
-
-        // Create a proper managed layout with window 1
-        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
-        wm.managed_draw_order = vec![keys[1]];
-        wm.z_order = vec![keys[1]];
-
-        wm.register_managed_layout(Rect {
-            x: 0,
-            y: 0,
-            width: 80,
-            height: 24,
-        });
-        wm.focus_app_window(keys[1]);
-
-        let win_key = keys[1];
-        let drag_x = 10u16;
-        let drag_y = 5u16;
-
-        let hitbox_id = crate::hitbox_registry::HitboxId::new();
-        wm.hitbox_registry_mut().register(
-            hitbox_id,
-            ComponentOwner::Chrome(crate::chrome::ChromeTarget::Drag(win_key)),
-            Rect {
-                x: 10,
-                y: 5,
-                width: 5,
-                height: 1,
-            },
-        );
-
-        assert!(!wm.direct_mode(win_key));
-
-        let click = Event::Mouse(MouseEvent {
-            kind: MouseEventKind::Press(MouseButton::Left),
-            column: drag_x,
-            row: drag_y,
-            modifiers: KeyModifiers::NONE,
-        });
-        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
-        assert!(wm.dispatch_mouse(&wm_click).is_consumed());
-        assert!(!wm.direct_mode(win_key), "drag area click must not toggle");
+        assert!(!wm.direct_mode(id_a));
     }
 
     #[test]
@@ -5386,8 +5181,6 @@ mod tests {
         wm.focus_app_window(keys[1]);
 
         let win_key = keys[1];
-        wm.set_direct_mode(win_key, true);
-        assert!(wm.direct_mode(win_key));
 
         // Click within the content area — should go to focused window's
         // callback, NOT be consumed by chrome (handle_managed_event skipped).
@@ -5402,79 +5195,6 @@ mod tests {
         let result = wm.dispatch_focused_event(&click);
         // In direct mode, content clicks bypass chrome and reach the component.
         assert!(result.is_some(), "event must route to window component");
-    }
-
-    #[test]
-    fn dispatch_focused_event_still_routes_header_d_click_in_direct_mode() {
-        use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-        use crate::layout::{LayoutNode, TilingLayout};
-
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 100);
-        wm.set_panel_visible(false);
-        wm.set_managed_layout(TilingLayout::new(LayoutNode::leaf(keys[1])));
-        wm.managed_draw_order = vec![keys[1]];
-        wm.z_order = vec![keys[1]];
-        wm.register_managed_layout(Rect {
-            x: 0,
-            y: 0,
-            width: 80,
-            height: 24,
-        });
-        wm.focus_app_window(keys[1]);
-
-        let win_key = keys[1];
-        wm.set_direct_mode(win_key, true);
-
-        // Header D button click — coordinates on the header, NOT in content area.
-        // Uses `button_x_pos` so it stays in sync with `render_window`.
-        let full_rect = wm.full_region_for_key(win_key);
-        let outer_right = full_rect
-            .x
-            .saturating_add(i32::from(full_rect.width))
-            .saturating_sub(1);
-        let kb_x = crate::chrome::button_x_pos(outer_right as u16, true, 3);
-        let kb_y = full_rect.y.saturating_add(1) as u16; // header row
-        wm.hitbox_registry_mut().register(
-            crate::hitbox_registry::HitboxId::new(),
-            ComponentOwner::Chrome(crate::chrome::ChromeTarget::ToggleDirectMode(win_key)),
-            Rect {
-                x: i32::from(kb_x),
-                y: i32::from(kb_y),
-                width: 1,
-                height: 1,
-            },
-        );
-
-        assert!(wm.direct_mode(win_key), "direct mode enabled before click");
-
-        // This click is on the header (not content area) — chrome should still
-        // handle it despite direct mode being on.
-        let click = Event::Mouse(MouseEvent {
-            kind: MouseEventKind::Press(MouseButton::Left),
-            column: kb_x,
-            row: kb_y,
-            modifiers: KeyModifiers::NONE,
-        });
-
-        let wm_click = crate::events::core_event_to_wm(&click).unwrap();
-        let result = wm.dispatch_mouse(&wm_click);
-
-        // The header D button click should be consumed by chrome, toggling direct_mode off.
-        assert!(
-            result.is_consumed(),
-            "header D click must be consumed by chrome"
-        );
-        assert!(
-            !wm.direct_mode(win_key),
-            "header D click must toggle direct_mode off"
-        );
     }
 
     #[test]
@@ -5504,8 +5224,6 @@ mod tests {
         wm.focus_app_window(keys[1]);
 
         let win_key = keys[1];
-        wm.set_direct_mode(win_key, true);
-        assert!(wm.direct_mode(win_key));
 
         // Set a known floating rect so we can verify movement.
         wm.set_floating_rect(
@@ -6047,8 +5765,6 @@ mod tests {
             height: 24,
         });
         wm.focus_app_window(key);
-        assert!(!wm.direct_mode(key));
-
         // Enable selection on the component
         let sel = wm.component_for_key_mut(key).expect("component must exist");
         if let TestComponent::SelComponent(sel) = sel {
@@ -6815,103 +6531,6 @@ mod tests {
             r0.x,
             r0.width,
         );
-    }
-
-    #[test]
-    fn set_direct_mode_marks_layout_dirty_on_change() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 1);
-        wm.clear_layout_dirty();
-        assert!(!wm.layout_dirty(), "cleared after setup");
-        wm.set_direct_mode(keys[0], true);
-        assert!(wm.layout_dirty(), "marked dirty on enable");
-        wm.clear_layout_dirty();
-        wm.set_direct_mode(keys[0], false);
-        assert!(wm.layout_dirty(), "marked dirty on disable");
-    }
-
-    #[test]
-    fn set_direct_mode_skips_notification_when_unchanged() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 1);
-        wm.clear_layout_dirty();
-        wm.set_direct_mode(keys[0], true);
-        assert!(
-            !wm.notifications().is_empty(),
-            "notification pushed on enable"
-        );
-        let count_before = wm.notifications().len();
-        wm.set_direct_mode(keys[0], true);
-        assert_eq!(
-            wm.notifications().len(),
-            count_before,
-            "no duplicate notification when unchanged"
-        );
-    }
-
-    #[test]
-    fn set_direct_mode_pushes_enabled_notification() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 1);
-        wm.clear_layout_dirty();
-        wm.set_direct_mode(keys[0], true);
-        assert!(!wm.notifications().is_empty(), "notification pushed");
-    }
-
-    #[test]
-    fn set_direct_mode_pushes_disabled_notification() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        let keys = make_keys(&mut wm, 1);
-        wm.clear_layout_dirty();
-        wm.set_direct_mode(keys[0], true);
-        // Clear notification queue: create a new one
-        wm.notification_queue = Default::default();
-        wm.set_direct_mode(keys[0], false);
-        assert!(
-            !wm.notifications().is_empty(),
-            "notification pushed on disable"
-        );
-    }
-
-    #[test]
-    fn set_direct_mode_invalid_key_is_noop() {
-        let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
-            Arc::new(AppContext::new("test", "0.0.0")),
-            None,
-            crate::window::LayerManager::new(),
-            std::collections::HashMap::new(),
-        );
-        wm.clear_layout_dirty();
-        let bogus = WindowKey::default();
-        assert!(!wm.layout_dirty(), "initially not dirty");
-        wm.set_direct_mode(bogus, true);
-        assert!(!wm.layout_dirty(), "no-op: layout not dirty");
-        assert!(wm.notifications().is_empty(), "no-op: no notification");
     }
 
     #[test]

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -16,5 +16,6 @@ portable-pty = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 vt100 = { workspace = true }
+vte = { workspace = true }
 
 

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -17,5 +17,3 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 vt100 = { workspace = true }
 vte = { workspace = true }
-
-

--- a/crates/term-wm-pty-engine/src/input_encoding.rs
+++ b/crates/term-wm-pty-engine/src/input_encoding.rs
@@ -70,7 +70,10 @@ pub struct MouseEvent {
 }
 
 /// Convert a [`KeyEvent`] to the byte sequence to send to the PTY.
-pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
+/// Set `application_cursor_keys=true` when DECCKM (DECSET 1) is active,
+/// so unmodified arrow keys use SS3 (`\eOA`) instead of CSI (`\e[A`).
+/// Modified arrows (Shift/Ctrl/Alt) always use standard CSI regardless.
+pub fn key_to_bytes(key: &KeyEvent, application_cursor_keys: bool) -> Vec<u8> {
     match (key.code, key.modifiers) {
         (KeyCode::Char(c), m) if m == KeyModifiers::NONE || m.shift => {
             let ch = if m.shift { c.to_ascii_uppercase() } else { c };
@@ -89,6 +92,20 @@ pub fn key_to_bytes(key: &KeyEvent) -> Vec<u8> {
         (KeyCode::Backspace, _) => vec![0x7f],
         (KeyCode::Esc, _) => vec![0x1b],
         (KeyCode::Tab, _) => vec![b'\t'],
+        // Application Cursor Keys (DECCKM): SS3 for unmodified arrows only
+        (KeyCode::Up, m) if application_cursor_keys && m == KeyModifiers::NONE => {
+            b"\x1bOA".to_vec()
+        }
+        (KeyCode::Down, m) if application_cursor_keys && m == KeyModifiers::NONE => {
+            b"\x1bOB".to_vec()
+        }
+        (KeyCode::Right, m) if application_cursor_keys && m == KeyModifiers::NONE => {
+            b"\x1bOC".to_vec()
+        }
+        (KeyCode::Left, m) if application_cursor_keys && m == KeyModifiers::NONE => {
+            b"\x1bOD".to_vec()
+        }
+        // Normal cursor keys (CSI sequences)
         (KeyCode::Up, _) => b"\x1b[A".to_vec(),
         (KeyCode::Down, _) => b"\x1b[B".to_vec(),
         (KeyCode::Right, _) => b"\x1b[C".to_vec(),
@@ -249,20 +266,25 @@ mod tests {
         KeyEvent { code, modifiers }
     }
 
+    /// Test helper: calls key_to_bytes with application_cursor_keys=false.
+    fn kb(key: &KeyEvent) -> Vec<u8> {
+        key_to_bytes(key, false)
+    }
+
     // --- key_to_bytes ---
 
     #[test]
     fn key_to_bytes_char_and_controls() {
-        let b = key_to_bytes(&key(KeyCode::Char('x'), KeyModifiers::NONE));
+        let b = kb(&key(KeyCode::Char('x'), KeyModifiers::NONE));
         assert_eq!(b, b"x".to_vec());
 
-        let enter = key_to_bytes(&key(KeyCode::Enter, KeyModifiers::NONE));
+        let enter = kb(&key(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(enter, vec![b'\r']);
 
-        let back = key_to_bytes(&key(KeyCode::Backspace, KeyModifiers::NONE));
+        let back = kb(&key(KeyCode::Backspace, KeyModifiers::NONE));
         assert_eq!(back, vec![0x7f]);
 
-        let ctrl_a = key_to_bytes(&key(
+        let ctrl_a = kb(&key(
             KeyCode::Char('a'),
             KeyModifiers {
                 shift: false,
@@ -275,7 +297,7 @@ mod tests {
 
     #[test]
     fn key_to_bytes_alt() {
-        let alt_x = key_to_bytes(&key(
+        let alt_x = kb(&key(
             KeyCode::Char('x'),
             KeyModifiers {
                 shift: false,
@@ -288,37 +310,37 @@ mod tests {
 
     #[test]
     fn key_to_bytes_delete_insert() {
-        let del = key_to_bytes(&key(KeyCode::Delete, KeyModifiers::NONE));
+        let del = kb(&key(KeyCode::Delete, KeyModifiers::NONE));
         assert_eq!(del, b"\x1b[3~");
 
-        let ins = key_to_bytes(&key(KeyCode::Insert, KeyModifiers::NONE));
+        let ins = kb(&key(KeyCode::Insert, KeyModifiers::NONE));
         assert_eq!(ins, b"\x1b[2~");
     }
 
     #[test]
     fn key_to_bytes_fkeys() {
-        let f1 = key_to_bytes(&key(KeyCode::F(1), KeyModifiers::NONE));
+        let f1 = kb(&key(KeyCode::F(1), KeyModifiers::NONE));
         assert_eq!(f1, b"\x1bOP");
 
-        let f5 = key_to_bytes(&key(KeyCode::F(5), KeyModifiers::NONE));
+        let f5 = kb(&key(KeyCode::F(5), KeyModifiers::NONE));
         assert_eq!(f5, b"\x1b[15~");
     }
 
     #[test]
     fn key_to_bytes_backtab() {
-        let bt = key_to_bytes(&key(KeyCode::Tab, KeyModifiers::NONE));
+        let bt = kb(&key(KeyCode::Tab, KeyModifiers::NONE));
         assert_eq!(bt, b"\t");
     }
 
     #[test]
     fn key_to_bytes_unicode() {
-        let u = key_to_bytes(&key(KeyCode::Char('é'), KeyModifiers::NONE));
+        let u = kb(&key(KeyCode::Char('é'), KeyModifiers::NONE));
         assert_eq!(u, "é".as_bytes());
     }
 
     #[test]
     fn key_to_bytes_shift_uppercase() {
-        let s = key_to_bytes(&key(
+        let s = kb(&key(
             KeyCode::Char('a'),
             KeyModifiers {
                 shift: true,
@@ -458,5 +480,81 @@ mod tests {
         };
         let bytes = mouse_event_to_bytes(&m_down_ctrl, MouseProtocolEncoding::Default);
         assert_eq!(bytes, vec![0x1b, b'[', b'M', 50, 33, 33]);
+    }
+
+    // --- key_to_bytes with DECCKM ---
+
+    #[test]
+    fn key_to_bytes_application_cursor_arrows() {
+        let up = key(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(
+            key_to_bytes(&up, true),
+            b"\x1bOA",
+            "DECCKM: Up should emit SS3"
+        );
+        let down = key(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(key_to_bytes(&down, true), b"\x1bOB");
+        let right = key(KeyCode::Right, KeyModifiers::NONE);
+        assert_eq!(key_to_bytes(&right, true), b"\x1bOC");
+        let left = key(KeyCode::Left, KeyModifiers::NONE);
+        assert_eq!(key_to_bytes(&left, true), b"\x1bOD");
+    }
+
+    #[test]
+    fn key_to_bytes_application_cursor_off_uses_csi() {
+        let up = key(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(
+            key_to_bytes(&up, false),
+            b"\x1b[A",
+            "Normal mode: Up should emit CSI"
+        );
+    }
+
+    #[test]
+    fn key_to_bytes_application_cursor_modified_uses_csi() {
+        // Shift+Up should always use CSI even in DECCKM mode
+        let shift_up = key(
+            KeyCode::Up,
+            KeyModifiers {
+                shift: true,
+                control: false,
+                alt: false,
+            },
+        );
+        assert_eq!(
+            key_to_bytes(&shift_up, true),
+            b"\x1b[A",
+            "Modified arrows must use CSI even when DECCKM active"
+        );
+
+        // Ctrl+Up should always use CSI
+        let ctrl_up = key(
+            KeyCode::Up,
+            KeyModifiers {
+                shift: false,
+                control: true,
+                alt: false,
+            },
+        );
+        assert_eq!(
+            key_to_bytes(&ctrl_up, true),
+            b"\x1b[A",
+            "Ctrl+Up must use CSI even when DECCKM active"
+        );
+
+        // Alt+Up should always use CSI
+        let alt_up = key(
+            KeyCode::Up,
+            KeyModifiers {
+                shift: false,
+                control: false,
+                alt: true,
+            },
+        );
+        assert_eq!(
+            key_to_bytes(&alt_up, true),
+            b"\x1b[A",
+            "Alt+Up must use CSI even when DECCKM active"
+        );
     }
 }

--- a/crates/term-wm-pty-engine/src/lib.rs
+++ b/crates/term-wm-pty-engine/src/lib.rs
@@ -2,6 +2,7 @@ pub mod clipboard;
 pub mod input_encoding;
 pub mod pane;
 pub mod pty;
+pub mod pty_state_tracker;
 pub mod redirect_stdio;
 pub mod signal;
 pub mod title;
@@ -9,6 +10,7 @@ pub mod title;
 pub use input_encoding::{ctrl_char, key_to_bytes, mouse_event_allowed, mouse_event_to_bytes};
 pub use pane::Pane;
 pub use pty::{Pty, PtyResult};
+pub use pty_state_tracker::{MouseTrackingMode, PtyStateTracker};
 
 /// Status notifications from the PTY reader thread to the main loop.
 /// The engine crate is agnostic about `WindowKey` and `UnifiedEvent`.

--- a/crates/term-wm-pty-engine/src/lib.rs
+++ b/crates/term-wm-pty-engine/src/lib.rs
@@ -10,7 +10,7 @@ pub mod title;
 pub use input_encoding::{ctrl_char, key_to_bytes, mouse_event_allowed, mouse_event_to_bytes};
 pub use pane::Pane;
 pub use pty::{Pty, PtyResult};
-pub use pty_state_tracker::{MouseTrackingMode, PtyStateTracker};
+pub use pty_state_tracker::{DirectInputTracker, MouseTrackingMode, PtyStateTracker};
 
 /// Status notifications from the PTY reader thread to the main loop.
 /// The engine crate is agnostic about `WindowKey` and `UnifiedEvent`.
@@ -20,4 +20,6 @@ pub enum PtyStatus {
     Wakeup,
     /// Child process exited / EOF on PTY master.
     Exited,
+    /// Application input routing state changed (alt screen, mouse tracking, margins).
+    DirectInputChanged(bool),
 }

--- a/crates/term-wm-pty-engine/src/pane.rs
+++ b/crates/term-wm-pty-engine/src/pane.rs
@@ -46,6 +46,20 @@ pub trait Pane {
     /// Sync dirty state and handle DSR/foreground polling.
     /// Call before locking the parser for cell access.
     fn sync_screen(&mut self) {}
+
+    /// Unified routing decision: returns true if keyboard/mouse inputs
+    /// should be forwarded to the PTY child rather than intercepted
+    /// by the window manager's native scrollbar.
+    /// Thread-safe: no mutable borrow needed (atomic reads).
+    fn requires_app_routing(&self) -> bool {
+        false
+    }
+
+    /// Returns true when DECCKM (DECSET 1 / Application Cursor Keys) is active.
+    /// When true, unmodified arrow keys must use SS3 (`\eOA`) instead of CSI (`\e[A`).
+    fn is_application_cursor_keys_active(&self) -> bool {
+        false
+    }
 }
 
 impl Pane for crate::Pty {
@@ -119,6 +133,14 @@ impl Pane for crate::Pty {
 
     fn set_status_callback(&mut self, cb: Option<Box<dyn Fn(PtyStatus) + Send + Sync>>) {
         crate::Pty::set_status_callback(self, cb)
+    }
+
+    fn requires_app_routing(&self) -> bool {
+        self.tracker.requires_app_routing()
+    }
+
+    fn is_application_cursor_keys_active(&self) -> bool {
+        self.tracker.is_application_cursor_keys_active()
     }
 
     fn shared_parser(&mut self) -> Arc<Mutex<vt100::Parser>> {

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
 use crate::clipboard::{Clipboard, Osc52Extractor};
+use crate::pty_state_tracker::PtyPerformAdapter;
 
 /// Size of the PTY master read buffer (single `read()` call).
 /// 64KB keeps the reader parked most of the time under heavy output
@@ -71,6 +72,9 @@ pub struct Pty {
     reader: Option<JoinHandle<()>>,
     /// Status callback invoked by the reader thread on wakeup and exit.
     status_cb: StatusCallback,
+    /// Application state tracker (alternate screen, mouse tracking, margins).
+    /// Shared via Arc: reader thread writes (via PtyPerformAdapter), main thread reads.
+    pub(crate) tracker: std::sync::Arc<crate::PtyStateTracker>,
     /// Shutdown flag: when true, the reader thread exits its loop ASAP.
     /// Set by into_parts() and Drop.
     shutdown: Arc<AtomicBool>,
@@ -129,6 +133,8 @@ impl Pty {
         let pending_title = Arc::new(Mutex::new(None));
         let foreground_title = Arc::new(Mutex::new(None));
         let initial_parser = vt100::Parser::new(size.rows, size.cols, scrollback_len);
+        let tracker = std::sync::Arc::new(crate::PtyStateTracker::new(size.rows));
+        let reader_tracker = std::sync::Arc::clone(&tracker);
         let shared_parser = Arc::new(Mutex::new(initial_parser));
         let dirty = Arc::new(AtomicBool::new(false));
         let dirty_cond = Arc::new((Mutex::new(()), Condvar::new()));
@@ -152,6 +158,7 @@ impl Pty {
                 scrollback_len,
                 osc52_text: None,
                 exited_emitted: reader_exited_emitted,
+                tracker: reader_tracker,
             })
         });
         Ok(Self {
@@ -168,6 +175,7 @@ impl Pty {
             shared_parser,
             dirty,
             dirty_cond,
+            tracker,
             size,
             pty_size: size,
             scrollback_len,
@@ -232,6 +240,7 @@ impl Pty {
             .map_err(|err| wrap_err("resize", err))?;
         guard.screen_mut().set_size(size.rows, size.cols);
         drop(guard);
+        self.tracker.resize(size.rows);
         self.pty_size = size;
         self.size = size;
         Ok(())
@@ -481,6 +490,8 @@ struct ParserReadLoopArgs {
     /// Test-only hook: when `Some`, the extracted OSC 52 text is written here
     /// in addition to the real clipboard, so tests can assert the value.
     osc52_text: Option<Arc<Mutex<Option<String>>>>,
+    /// Application state tracker — shared via Arc with Pty.
+    tracker: std::sync::Arc<crate::PtyStateTracker>,
 }
 
 fn parser_read_loop(args: ParserReadLoopArgs) {
@@ -498,11 +509,14 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
         scrollback_len: _scrollback_len,
         osc52_text,
         exited_emitted,
+        tracker,
     } = args;
     let mut prev_tail: [u8; HISTORY_TAIL_LEN] = [0; HISTORY_TAIL_LEN];
     let mut buf = [0u8; PTY_READ_BUF_SIZE];
     let mut osc52 = Osc52Extractor::new();
     let mut bytes_since_render = 0usize;
+    let mut vte_parser = vte::Parser::new();
+    let mut tracker_adapter = PtyPerformAdapter::new(tracker);
     const IO_BURST_BUDGET: usize = 256 * 1024; // 256 KB
     loop {
         match reader.read(&mut buf) {
@@ -539,6 +553,10 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                         p.clear();
                     }
                 }
+
+                // Process bytes through the application state tracker
+                // (alternate screen, mouse tracking, margins — atomics, no lock).
+                vte_parser.advance(&mut tracker_adapter, &buf[..n]);
 
                 // Process bytes directly into the shared parser.
                 {
@@ -867,6 +885,7 @@ mod tests {
             scrollback_len: 0,
             exited_emitted: Arc::new(AtomicBool::new(false)),
             osc52_text: None,
+            tracker: std::sync::Arc::new(crate::PtyStateTracker::new(24)),
         }
     }
 

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -461,6 +461,13 @@ impl Pty {
         let parser = self.shared_parser.lock().unwrap();
         parser.screen().alternate_screen()
     }
+
+    /// Return an `Arc<dyn DirectInputTracker>` for this PTY's state tracker.
+    /// Used by the window manager to auto-enable direct mode when the
+    /// application enters alternate screen, enables mouse tracking, etc.
+    pub fn direct_input_tracker(&self) -> std::sync::Arc<dyn crate::DirectInputTracker> {
+        self.tracker.clone()
+    }
 }
 
 impl Drop for Pty {
@@ -516,7 +523,8 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
     let mut osc52 = Osc52Extractor::new();
     let mut bytes_since_render = 0usize;
     let mut vte_parser = vte::Parser::new();
-    let mut tracker_adapter = PtyPerformAdapter::new(tracker);
+    let tracker_for_adapter = std::sync::Arc::clone(&tracker);
+    let mut tracker_adapter = PtyPerformAdapter::new(tracker_for_adapter);
     const IO_BURST_BUDGET: usize = 256 * 1024; // 256 KB
     loop {
         match reader.read(&mut buf) {
@@ -556,7 +564,23 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
 
                 // Process bytes through the application state tracker
                 // (alternate screen, mouse tracking, margins — atomics, no lock).
+                let prev_routing = tracker.requires_app_routing();
                 vte_parser.advance(&mut tracker_adapter, &buf[..n]);
+                let new_routing = tracker.requires_app_routing();
+                if prev_routing != new_routing {
+                    tracing::info!(
+                        "[STAGE 1] PTY routing flipped: {} -> {}",
+                        prev_routing,
+                        new_routing
+                    );
+                    if let Ok(guard) = status_cb.lock()
+                        && let Some(ref cb) = *guard
+                    {
+                        cb(crate::PtyStatus::DirectInputChanged(new_routing));
+                    } else {
+                        tracing::error!("[STAGE 1] status_cb is NONE when transition occurred!");
+                    }
+                }
 
                 // Process bytes directly into the shared parser.
                 {

--- a/crates/term-wm-pty-engine/src/pty_state_tracker.rs
+++ b/crates/term-wm-pty-engine/src/pty_state_tracker.rs
@@ -2,6 +2,19 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, Ordering};
 
 use vte::{Params, Perform};
 
+/// Trait for automatic direct-input detection at the window boundary.
+/// Implemented by the PTY state tracker to signal when TUI applications
+/// (less, vim) require unfiltered keyboard input (no native scroll interception).
+pub trait DirectInputTracker: Send + Sync {
+    fn requires_direct_input(&self) -> bool;
+}
+
+impl DirectInputTracker for PtyStateTracker {
+    fn requires_direct_input(&self) -> bool {
+        self.requires_app_routing()
+    }
+}
+
 /// Decoded mouse tracking mode from DECSET 1000/1002/1003.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MouseTrackingMode {

--- a/crates/term-wm-pty-engine/src/pty_state_tracker.rs
+++ b/crates/term-wm-pty-engine/src/pty_state_tracker.rs
@@ -1,0 +1,521 @@
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, Ordering};
+
+use vte::{Params, Perform};
+
+/// Decoded mouse tracking mode from DECSET 1000/1002/1003.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseTrackingMode {
+    None,
+    X11Normal,
+    CellMotion,
+    AllMotion,
+}
+
+impl MouseTrackingMode {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::X11Normal,
+            2 => Self::CellMotion,
+            3 => Self::AllMotion,
+            _ => Self::None,
+        }
+    }
+
+    #[expect(dead_code)]
+    fn to_u8(self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::X11Normal => 1,
+            Self::CellMotion => 2,
+            Self::AllMotion => 3,
+        }
+    }
+}
+
+/// Lock-free state tracker that observes the PTY byte stream for application
+/// state heuristics (alternate screen, mouse tracking, custom margins).
+///
+/// Shared between the reader thread (writer) and the main UI thread (reader)
+/// via `Arc`. All fields are atomics so the main thread can query without
+/// locks or mutable borrows.
+#[derive(Debug)]
+pub struct PtyStateTracker {
+    is_alt_screen_active: AtomicBool,
+    is_application_cursor_keys_active: AtomicBool,
+    mouse_tracking_mode: AtomicU8,
+    is_sgr_mouse_active: AtomicBool,
+    is_alt_scroll_mode_active: AtomicBool,
+    has_custom_margins: AtomicBool,
+    terminal_height: AtomicU16,
+}
+
+impl PtyStateTracker {
+    pub fn new(terminal_height: u16) -> Self {
+        Self {
+            is_alt_screen_active: AtomicBool::new(false),
+            is_application_cursor_keys_active: AtomicBool::new(false),
+            mouse_tracking_mode: AtomicU8::new(0),
+            is_sgr_mouse_active: AtomicBool::new(false),
+            is_alt_scroll_mode_active: AtomicBool::new(false),
+            has_custom_margins: AtomicBool::new(false),
+            terminal_height: AtomicU16::new(terminal_height),
+        }
+    }
+
+    /// Unified routing decision: returns true if inputs should be forwarded
+    /// to the PTY child rather than intercepted by the native scrollbar.
+    pub fn requires_app_routing(&self) -> bool {
+        self.is_alt_screen_active.load(Ordering::Acquire)
+            || self.mouse_tracking_mode.load(Ordering::Acquire) != 0
+            || self.has_custom_margins.load(Ordering::Acquire)
+    }
+
+    pub fn is_alt_screen_active(&self) -> bool {
+        self.is_alt_screen_active.load(Ordering::Acquire)
+    }
+
+    pub fn is_application_cursor_keys_active(&self) -> bool {
+        self.is_application_cursor_keys_active
+            .load(Ordering::Acquire)
+    }
+
+    pub fn mouse_tracking_mode(&self) -> MouseTrackingMode {
+        MouseTrackingMode::from_u8(self.mouse_tracking_mode.load(Ordering::Acquire))
+    }
+
+    pub fn is_sgr_mouse_active(&self) -> bool {
+        self.is_sgr_mouse_active.load(Ordering::Acquire)
+    }
+
+    pub fn is_alt_scroll_mode_active(&self) -> bool {
+        self.is_alt_scroll_mode_active.load(Ordering::Acquire)
+    }
+
+    pub fn has_custom_margins(&self) -> bool {
+        self.has_custom_margins.load(Ordering::Acquire)
+    }
+
+    /// Update terminal height on SIGWINCH. Called from main thread.
+    pub fn resize(&self, height: u16) {
+        self.terminal_height.store(height, Ordering::Release);
+    }
+
+    // --- Package-internal setters (called from PtyPerformAdapter on reader thread) ---
+
+    pub(crate) fn set_alt_screen(&self, active: bool) {
+        self.is_alt_screen_active.store(active, Ordering::Release);
+    }
+
+    pub(crate) fn set_application_cursor_keys(&self, active: bool) {
+        self.is_application_cursor_keys_active
+            .store(active, Ordering::Release);
+    }
+
+    pub(crate) fn set_sgr_mouse(&self, active: bool) {
+        self.is_sgr_mouse_active.store(active, Ordering::Release);
+    }
+
+    pub(crate) fn set_alt_scroll_mode(&self, active: bool) {
+        self.is_alt_scroll_mode_active
+            .store(active, Ordering::Release);
+    }
+
+    pub(crate) fn set_custom_margins(&self, active: bool) {
+        self.has_custom_margins.store(active, Ordering::Release);
+    }
+
+    /// Conditional mouse mode update: set unconditionally, but clear only
+    /// via CAS so we don't clobber a different active mode.
+    pub(crate) fn update_mouse_tracking(&self, target_mode: u8, is_set: bool) {
+        if is_set {
+            self.mouse_tracking_mode
+                .store(target_mode, Ordering::Release);
+        } else {
+            let _ = self.mouse_tracking_mode.compare_exchange(
+                target_mode,
+                0,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            );
+        }
+    }
+
+    /// Reset all state to defaults (RIS / DECSTR recovery).
+    pub(crate) fn reset_all(&self) {
+        self.is_alt_screen_active.store(false, Ordering::Release);
+        self.is_application_cursor_keys_active
+            .store(false, Ordering::Release);
+        self.mouse_tracking_mode.store(0, Ordering::Release);
+        self.is_sgr_mouse_active.store(false, Ordering::Release);
+        self.is_alt_scroll_mode_active
+            .store(false, Ordering::Release);
+        self.has_custom_margins.store(false, Ordering::Release);
+    }
+}
+
+// Safety: all fields are atomic primitives (no `!Sync` types like `RefCell`).
+// `PtyStateTracker` is `Send + Sync` by construction.
+
+/// Reader-thread-local adapter that implements `vte::Perform`.
+///
+/// Owned exclusively by the reader thread (a local variable in
+/// `parser_read_loop`). Holds a clone of the `Arc<PtyStateTracker>`
+/// and updates its atomic fields when the parser detects relevant
+/// ANSI escape sequences.
+pub(crate) struct PtyPerformAdapter {
+    tracker: std::sync::Arc<PtyStateTracker>,
+}
+
+impl PtyPerformAdapter {
+    pub fn new(tracker: std::sync::Arc<PtyStateTracker>) -> Self {
+        Self { tracker }
+    }
+}
+
+impl Perform for PtyPerformAdapter {
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+        if ignore {
+            return;
+        }
+        // RIS (Reset to Initial State): ESC c
+        if intermediates.is_empty() && byte == b'c' {
+            self.tracker.reset_all();
+        }
+    }
+
+    fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, action: char) {
+        if ignore {
+            return;
+        }
+
+        // DECSTR (Soft Terminal Reset): CSI ! p
+        if action == 'p' && intermediates == *b"!" {
+            self.tracker.reset_all();
+            return;
+        }
+
+        let is_dec_private = intermediates.first() == Some(&b'?');
+        match action {
+            'h' | 'l' if is_dec_private => {
+                let is_set = action == 'h';
+                for param_group in params.iter() {
+                    for &param in param_group {
+                        match param {
+                            1 => self.tracker.set_application_cursor_keys(is_set),
+                            47 | 1047 | 1049 => self.tracker.set_alt_screen(is_set),
+                            1000 => self.tracker.update_mouse_tracking(1, is_set),
+                            1002 => self.tracker.update_mouse_tracking(2, is_set),
+                            1003 => self.tracker.update_mouse_tracking(3, is_set),
+                            1006 => self.tracker.set_sgr_mouse(is_set),
+                            1007 => self.tracker.set_alt_scroll_mode(is_set),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            // DECSTBM: set scrolling region — normalize explicit 0 to defaults
+            'r' => {
+                let top_param = params
+                    .iter()
+                    .next()
+                    .and_then(|g| g.first().copied())
+                    .unwrap_or(0);
+                let bottom_param = params
+                    .iter()
+                    .nth(1)
+                    .and_then(|g| g.first().copied())
+                    .unwrap_or(0);
+                let height = self.tracker.terminal_height.load(Ordering::Acquire);
+                let top = if top_param == 0 { 1 } else { top_param };
+                let bottom = if bottom_param == 0 {
+                    height
+                } else {
+                    bottom_param
+                };
+                let has_margins = top > 1 || bottom < height;
+                self.tracker.set_custom_margins(has_margins);
+            }
+            _ => {}
+        }
+    }
+
+    fn print(&mut self, _c: char) {}
+    fn execute(&mut self, _byte: u8) {}
+    fn hook(&mut self, _params: &Params, _intermediates: &[u8], _ignore: bool, _action: char) {}
+    fn put(&mut self, _byte: u8) {}
+    fn unhook(&mut self) {}
+    fn osc_dispatch(&mut self, _params: &[&[u8]], _bell_terminated: bool) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tracker(height: u16) -> PtyStateTracker {
+        PtyStateTracker::new(height)
+    }
+
+    fn feed(tracker: &std::sync::Arc<PtyStateTracker>, bytes: &[u8]) {
+        let mut parser = vte::Parser::new();
+        let mut adapter = PtyPerformAdapter::new(tracker.clone());
+        parser.advance(&mut adapter, bytes);
+    }
+
+    #[test]
+    fn test_detects_alternate_screen() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1049h");
+        assert!(tracker.is_alt_screen_active());
+        assert!(tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_detects_alternate_screen_exit() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1049h");
+        assert!(tracker.is_alt_screen_active());
+        feed(&tracker, b"\x1b[?1049l");
+        assert!(!tracker.is_alt_screen_active());
+        assert!(!tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_detects_alternate_screen_1047() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1047h");
+        assert!(tracker.is_alt_screen_active());
+    }
+
+    #[test]
+    fn test_detects_alternate_screen_47() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?47h");
+        assert!(tracker.is_alt_screen_active());
+    }
+
+    #[test]
+    fn test_mouse_tracking_x11_normal() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1000h");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::X11Normal);
+        assert!(tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_mouse_tracking_cell_motion() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1002h");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::CellMotion);
+    }
+
+    #[test]
+    fn test_mouse_tracking_all_motion() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1003h");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::AllMotion);
+    }
+
+    #[test]
+    fn test_mouse_tracking_cas_does_not_clobber() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        // Enable CellMotion (mode 2)
+        feed(&tracker, b"\x1b[?1002h");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::CellMotion);
+        // Try to reset X11Normal (mode 1) — should NOT clobber CellMotion
+        feed(&tracker, b"\x1b[?1001l");
+        assert_eq!(
+            tracker.mouse_tracking_mode(),
+            MouseTrackingMode::CellMotion,
+            "CAS must not clear mode 2 when resetting mode 1"
+        );
+        // Reset CellMotion (mode 2) — should clear
+        feed(&tracker, b"\x1b[?1002l");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::None);
+    }
+
+    #[test]
+    fn test_mouse_tracking_set_after_reset_different_mode() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        // Enable X11Normal
+        feed(&tracker, b"\x1b[?1000h");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::X11Normal);
+        // Directly set AllMotion (simulates app switching modes)
+        feed(&tracker, b"\x1b[?1003h");
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::AllMotion);
+        // Reset X11Normal — should NOT clear AllMotion
+        feed(&tracker, b"\x1b[?1001l");
+        assert_eq!(
+            tracker.mouse_tracking_mode(),
+            MouseTrackingMode::AllMotion,
+            "CAS must not clear mode 3 when resetting mode 1"
+        );
+    }
+
+    #[test]
+    fn test_sgr_mouse() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1006h");
+        assert!(tracker.is_sgr_mouse_active());
+        feed(&tracker, b"\x1b[?1006l");
+        assert!(!tracker.is_sgr_mouse_active());
+    }
+
+    #[test]
+    fn test_alt_scroll_mode() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1007h");
+        assert!(tracker.is_alt_scroll_mode_active());
+        feed(&tracker, b"\x1b[?1007l");
+        assert!(!tracker.is_alt_scroll_mode_active());
+    }
+
+    #[test]
+    fn test_custom_margins_set() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[2;23r");
+        assert!(tracker.has_custom_margins());
+    }
+
+    #[test]
+    fn test_custom_margins_cleared() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[2;23r");
+        assert!(tracker.has_custom_margins());
+        // Reset to full height
+        feed(&tracker, b"\x1b[r");
+        assert!(!tracker.has_custom_margins());
+    }
+
+    #[test]
+    fn test_custom_margins_full_height_no_margins() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[1;24r");
+        assert!(!tracker.has_custom_margins());
+    }
+
+    #[test]
+    fn test_custom_margins_zero_bottom_param_normalized() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        // \e[1;0r means top=1, bottom=terminal_height
+        feed(&tracker, b"\x1b[1;0r");
+        assert!(!tracker.has_custom_margins());
+    }
+
+    #[test]
+    fn test_custom_margins_zero_top_param_normalized() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        // \e[;24r means top=1 (default), bottom=24 (full height)
+        feed(&tracker, b"\x1b[;24r");
+        assert!(!tracker.has_custom_margins());
+    }
+
+    #[test]
+    fn test_resize_updates_height() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        assert!(!tracker.requires_app_routing());
+        // Set margins with old height
+        feed(&tracker, b"\x1b[2;23r");
+        assert!(tracker.has_custom_margins());
+        // Resize to 10 — margins now effectively span the whole terminal
+        tracker.resize(10);
+        // Margins 2;23 with height 10 — only bottom < height matters
+        // bottom=23, height=10: 23 < 10 is false, but top=2 > 1 is true
+        // So has_custom_margins stays true. This test verifies the resize
+        // mechanism works (the margin flag is reassessed on next DECSTBM, not
+        // automatically on resize).
+        assert!(tracker.has_custom_margins());
+        // But if we re-evaluate with a new DECSTBM at the new height...
+        feed(&tracker, b"\x1b[r");
+        assert!(
+            !tracker.has_custom_margins(),
+            "full-height reset at new size"
+        );
+    }
+
+    #[test]
+    fn test_ris_reset() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1049h\x1b[?1002h\x1b[2;23r");
+        assert!(tracker.requires_app_routing());
+        // RIS (ESC c) should reset everything
+        feed(&tracker, b"\x1bc");
+        assert!(!tracker.is_alt_screen_active());
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::None);
+        assert!(!tracker.has_custom_margins());
+        assert!(!tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_decstr_reset() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1049h\x1b[?1002h\x1b[2;23r");
+        assert!(tracker.requires_app_routing());
+        // DECSTR (CSI ! p) should reset everything
+        feed(&tracker, b"\x1b[!p");
+        assert!(!tracker.is_alt_screen_active());
+        assert_eq!(tracker.mouse_tracking_mode(), MouseTrackingMode::None);
+        assert!(!tracker.has_custom_margins());
+        assert!(!tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_requires_app_routing_false_by_default() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        assert!(!tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_requires_app_routing_true_for_alt_screen() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1049h");
+        assert!(tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_requires_app_routing_true_for_mouse_tracking() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1002h");
+        assert!(tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_requires_app_routing_true_for_margins() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[2;23r");
+        assert!(tracker.requires_app_routing());
+    }
+
+    #[test]
+    fn test_application_cursor_keys_enabled() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1h");
+        assert!(tracker.is_application_cursor_keys_active());
+    }
+
+    #[test]
+    fn test_application_cursor_keys_disabled() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1h");
+        assert!(tracker.is_application_cursor_keys_active());
+        feed(&tracker, b"\x1b[?1l");
+        assert!(!tracker.is_application_cursor_keys_active());
+    }
+
+    #[test]
+    fn test_application_cursor_keys_reset_by_ris() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1h\x1b[?1049h");
+        assert!(tracker.is_application_cursor_keys_active());
+        feed(&tracker, b"\x1bc");
+        assert!(!tracker.is_application_cursor_keys_active());
+    }
+
+    #[test]
+    fn test_application_cursor_keys_reset_by_decstr() {
+        let tracker = std::sync::Arc::new(make_tracker(24));
+        feed(&tracker, b"\x1b[?1h");
+        assert!(tracker.is_application_cursor_keys_active());
+        feed(&tracker, b"\x1b[!p");
+        assert!(!tracker.is_application_cursor_keys_active());
+    }
+}

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -381,7 +381,6 @@ impl<C: Component<TermWmAction>> ScrollViewComponent<C> {
             && let Event::Key(key) = event
             && key.kind == term_wm_core::events::KeyKind::Press
         {
-            let is_full = self.keyboard_mode == ScrollKeyMode::Full;
             let kb = &ctx.config().keybindings;
 
             // Pagination-level scrolling (active in PaginationOnly and Full)
@@ -395,12 +394,6 @@ impl<C: Component<TermWmAction>> ScrollViewComponent<C> {
                 return EventResult::Action(TermWmAction::ScrollToTop);
             } else if kb.matches(TermWmAction::ScrollEnd, key) {
                 return EventResult::Action(TermWmAction::ScrollToBottom);
-            }
-            // Line-level scrolling (only in Full mode)
-            else if is_full && kb.matches(TermWmAction::ScrollUp, key) {
-                return EventResult::Action(TermWmAction::ScrollView(-1));
-            } else if is_full && kb.matches(TermWmAction::ScrollDown, key) {
-                return EventResult::Action(TermWmAction::ScrollView(1));
             }
         }
 
@@ -1181,7 +1174,7 @@ mod tests {
     }
 
     #[test]
-    fn scroll_view_full_mode_intercepts_all_scroll_keys() {
+    fn scroll_view_full_mode_passes_arrow_keys() {
         let mut sv = ScrollViewComponent::new(EventRecorder {
             received_scroll: false,
         });
@@ -1196,11 +1189,37 @@ mod tests {
         ));
         let result = sv.handle_events(&up, &ctx);
         assert!(
-            matches!(result, EventResult::Action(TermWmAction::ScrollView(-1))),
-            "Full mode must intercept Up"
+            result.is_ignored(),
+            "Full mode must NOT intercept Up — arrow keys always pass through"
+        );
+        assert!(
+            sv.content.borrow().received_scroll,
+            "Up must reach the child component"
         );
 
         sv.content.borrow_mut().received_scroll = false;
+        let down = Event::Key(term_wm_core::events::KeyEvent::new(
+            term_wm_core::events::KeyCode::Down,
+            term_wm_core::events::KeyModifiers::NONE,
+            term_wm_core::events::KeyKind::Press,
+        ));
+        let result = sv.handle_events(&down, &ctx);
+        assert!(result.is_ignored(), "Full mode must NOT intercept Down");
+        assert!(
+            sv.content.borrow().received_scroll,
+            "Down must reach the child component"
+        );
+    }
+
+    #[test]
+    fn scroll_view_full_mode_intercepts_pagination_keys() {
+        let mut sv = ScrollViewComponent::new(EventRecorder {
+            received_scroll: false,
+        });
+        sv.set_keyboard_mode(ScrollKeyMode::Full);
+
+        let ctx = ComponentContext::new(true);
+
         let home = Event::Key(term_wm_core::events::KeyEvent::new(
             term_wm_core::events::KeyCode::Home,
             term_wm_core::events::KeyModifiers::NONE,

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -122,7 +122,7 @@ impl Component<TermWmAction> for TerminalComponent {
                 }
                 if matches!(key.code, KeyCode::PageUp | KeyCode::PageDown)
                     && key.modifiers.shift
-                    && !self.pane.borrow().requires_app_routing()
+                    && !ctx.direct_mode()
                 {
                     let delta = if key.code == KeyCode::PageUp {
                         10isize
@@ -452,6 +452,17 @@ impl TerminalComponent {
         self.pane.get_mut().write_bytes(input)
     }
 
+    /// Attach a callback to the underlying PTY's status event stream.
+    /// Call after `open_window` so the closure can capture the known `WindowKey`.
+    pub fn set_pty_callback<F>(&self, f: F)
+    where
+        F: Fn(term_wm_pty_engine::PtyStatus) + Send + Sync + 'static,
+    {
+        self.pane
+            .borrow_mut()
+            .set_status_callback(Some(Box::new(f)));
+    }
+
     #[allow(clippy::collapsible_if)]
     pub fn has_exited(&mut self) -> bool {
         let pane = self.pane.get_mut();
@@ -537,7 +548,7 @@ impl TerminalComponent {
             let mut pane = self.pane.borrow_mut();
 
             if let Some(handle) = ctx.scroll_handle() {
-                let suppress_scroll = ctx.direct_mode() || pane.requires_app_routing();
+                let suppress_scroll = ctx.direct_mode();
 
                 if suppress_scroll {
                     handle.set_content_size(clipped.width as usize, clipped.height as usize);
@@ -594,7 +605,7 @@ impl TerminalComponent {
         let mut pane = self.pane.borrow_mut();
         let new_sb = pane.scrollback();
         if new_sb != sb_before_drag
-            && !pane.requires_app_routing()
+            && !ctx.direct_mode()
             && let Some(handle) = ctx.scroll_handle()
         {
             let used = pane.max_scrollback();
@@ -2086,9 +2097,8 @@ mod tests {
         });
         wm.focus_app_window(key);
 
-        // Set direct mode on the window
-        wm.set_direct_mode(key, true);
-        assert!(wm.direct_mode(key));
+        // Direct mode is automatic (purely from tracker)
+        assert!(!wm.direct_mode(key));
 
         // Render to set last_area
         use term_wm_core::components::ComponentContext;

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -122,7 +122,7 @@ impl Component<TermWmAction> for TerminalComponent {
                 }
                 if matches!(key.code, KeyCode::PageUp | KeyCode::PageDown)
                     && key.modifiers.shift
-                    && !self.pane.borrow_mut().alternate_screen()
+                    && !self.pane.borrow().requires_app_routing()
                 {
                     let delta = if key.code == KeyCode::PageUp {
                         10isize
@@ -131,7 +131,8 @@ impl Component<TermWmAction> for TerminalComponent {
                     };
                     return EventResult::Action(TermWmAction::Scroll(delta));
                 }
-                let bytes = key.to_pty_bytes();
+                let app_cursor = self.pane.borrow().is_application_cursor_keys_active();
+                let bytes = key.to_pty_bytes(app_cursor);
                 if bytes.is_empty() {
                     return EventResult::Ignored;
                 }
@@ -536,7 +537,7 @@ impl TerminalComponent {
             let mut pane = self.pane.borrow_mut();
 
             if let Some(handle) = ctx.scroll_handle() {
-                let suppress_scroll = ctx.direct_mode() || pane.alternate_screen();
+                let suppress_scroll = ctx.direct_mode() || pane.requires_app_routing();
 
                 if suppress_scroll {
                     handle.set_content_size(clipped.width as usize, clipped.height as usize);
@@ -593,7 +594,7 @@ impl TerminalComponent {
         let mut pane = self.pane.borrow_mut();
         let new_sb = pane.scrollback();
         if new_sb != sb_before_drag
-            && !pane.alternate_screen()
+            && !pane.requires_app_routing()
             && let Some(handle) = ctx.scroll_handle()
         {
             let used = pane.max_scrollback();
@@ -1195,6 +1196,10 @@ impl Pane for TestPane {
     }
 
     fn alternate_screen(&mut self) -> bool {
+        self.alt_screen
+    }
+
+    fn requires_app_routing(&self) -> bool {
         self.alt_screen
     }
 

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -1527,7 +1527,7 @@ mod tests {
         };
         let buffer = Buffer::empty(area);
         let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
-        let ctx = make_ctx(100, handle);
+        let ctx = make_ctx(100, handle).with_direct_mode(true);
         term.render(
             &mut backend,
             LayoutRect {
@@ -2066,6 +2066,14 @@ mod tests {
         use term_wm_core::components::{Component, NoopOverlay, NoopWmComponent};
         use term_wm_core::config::AppBuilder;
         use term_wm_core::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+        use term_wm_pty_engine::DirectInputTracker;
+
+        struct AlwaysDirect;
+        impl DirectInputTracker for AlwaysDirect {
+            fn requires_direct_input(&self) -> bool {
+                true
+            }
+        }
 
         let (term, _rb) = make_term_with_content(80, 24, 2000, "Hello World");
         let mut sv = crate::scroll_view::ScrollViewComponent::new(term);
@@ -2096,9 +2104,8 @@ mod tests {
             height: 24,
         });
         wm.focus_app_window(key);
-
-        // Direct mode is automatic (purely from tracker)
-        assert!(!wm.direct_mode(key));
+        wm.set_window_tracker(key, Arc::new(AlwaysDirect));
+        assert!(wm.direct_mode(key));
 
         // Render to set last_area
         use term_wm_core::components::ComponentContext;
@@ -2740,7 +2747,7 @@ mod tests {
         let mut pane = TestPane::new(200);
         pane.alt_screen = true;
         let mut term = TerminalComponent::from_pane(Box::new(pane));
-        let ctx = make_ctx(0, handle);
+        let ctx = make_ctx(0, handle).with_direct_mode(true);
         let area = Rect::new(0, 0, 80, 24);
         let buffer = Buffer::empty(area);
         let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,7 @@ pub fn render_app<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmA
         if let Some(title) = wm.window_pane_title(key) {
             wm.set_window_title(key, title);
         }
-        if let Some(is_alt) = wm.take_alternate_screen_transition(key) {
-            wm.set_direct_mode(key, is_alt);
-        }
+        let _ = wm.take_alternate_screen_transition(key);
     }
 
     wm.register_managed_layout(area);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use clap::Parser;
 use crossbeam_channel::Sender;
@@ -7,18 +7,18 @@ use crossbeam_channel::Sender;
 use term_wm::app_context::AppContext;
 use term_wm::components::AppRootComponent;
 use term_wm::config::AppBuilder;
+use term_wm::default_shell_command;
 use term_wm::io::RenderTarget;
 use term_wm::runner::WindowManagerHost;
 use term_wm::term_wm_app::TermWmApp;
 use term_wm::unified_event_source::{UnifiedEvent, UnifiedEventSource};
 use term_wm::wm_config::WmConfig;
-use term_wm::{
-    PtyStatus, ScrollKeyMode, ScrollViewComponent, TerminalComponent, default_shell_command,
-};
 use term_wm_console::console_render_target::ConsoleRenderTarget;
 use term_wm_core::components::Component;
-use term_wm_ui_facade::core_component::CoreWmComponent;
 use term_wm_ui_facade::{LayerComponent, OverlayComponent};
+
+// TODO: Make this user-configurable
+const PTY_SCROLLBACK_LEN: usize = 2000;
 
 /// Simple CLI for launching `term-wm` with optional commands / window count.
 #[derive(Parser, Debug)]
@@ -70,6 +70,7 @@ fn main() -> io::Result<()> {
 /// management, debug window, and system overlays.
 struct App {
     inner: TermWmApp,
+    #[expect(dead_code)]
     pty_wakeup_tx: Sender<UnifiedEvent>,
 }
 
@@ -118,7 +119,7 @@ impl App {
                 .expect("standalone build")
         };
 
-        let inner = TermWmApp::from_wm(wm);
+        let inner = TermWmApp::from_wm(wm, pty_wakeup_tx.clone());
         let mut app = Self {
             inner,
             pty_wakeup_tx,
@@ -163,60 +164,18 @@ impl App {
         term_wm::runner::run_with_defaults(output, driver, self)
     }
 
-    // TODO: Extract to a reusable place
     fn spawn_terminal_with_command(
         &mut self,
         cmd: portable_pty::CommandBuilder,
         command_to_send: Option<String>,
     ) -> io::Result<()> {
-        // Configure the terminal BEFORE boxing (type erasure trap)
-        let mut pane = TerminalComponent::spawn_default(cmd).map_err(io::Error::other)?;
-        pane.set_link_handler_fn(|url| {
-            let _ = webbrowser::open(url);
-            true
-        });
-
-        let key_holder = Arc::new(OnceLock::new());
-        let kh = key_holder.clone();
-        let tx = self.pty_wakeup_tx.clone();
-        pane.set_status_callback(Some(Box::new(move |status| match status {
-            PtyStatus::Wakeup => {
-                if let Some(&key) = kh.get() {
-                    let _ = tx.send(UnifiedEvent::PtyWakeup(key));
-                }
-            }
-            PtyStatus::Exited => {
-                if let Some(&key) = kh.get() {
-                    let _ = tx.send(UnifiedEvent::AppExited(key));
-                }
-            }
-        })));
-        let mut sv = ScrollViewComponent::new(pane);
-        sv.set_keyboard_mode(ScrollKeyMode::PaginationOnly);
-        let key = self
-            .inner
-            .wm()
-            .open_window(AppRootComponent::Core(CoreWmComponent::Terminal(sv)));
-        let _ = key_holder.set(key);
-
-        let clipboard_enabled = self.inner.wm().clipboard_enabled();
-        if let Some(comp) = self.inner.wm().component_for_key_mut(key) {
-            comp.set_selection_enabled(clipboard_enabled);
-        }
-
-        // Inject boot-time command via the `paste` trait method.
-        if let Some(line) = command_to_send {
-            let mut line = line;
-            line.push_str(line_ending::LineEnding::from_current_platform().as_str());
-            if let Some(comp) = self.inner.wm().component_for_key_mut(key) {
-                let _ = comp.paste(&line);
-            }
-        }
-
-        let count = self.inner.wm().window_count();
-        self.inner
-            .wm()
-            .set_window_title(key, format!("Shell {}", count));
+        let count = self.inner.wm().window_count() + 1;
+        self.inner.spawn_terminal_window(
+            cmd,
+            PTY_SCROLLBACK_LEN,
+            command_to_send,
+            format!("Shell {}", count),
+        )?;
         Ok(())
     }
 }
@@ -254,42 +213,13 @@ impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for A
     }
 
     fn wm_new_window(&mut self) -> io::Result<()> {
-        let mut pane =
-            TerminalComponent::spawn_default(default_shell_command()).map_err(io::Error::other)?;
-        pane.set_link_handler_fn(|url| {
-            let _ = webbrowser::open(url);
-            true
-        });
-        let key_holder = Arc::new(OnceLock::new());
-        let kh = key_holder.clone();
-        let tx = self.pty_wakeup_tx.clone();
-        pane.set_status_callback(Some(Box::new(move |status| match status {
-            PtyStatus::Wakeup => {
-                if let Some(&key) = kh.get() {
-                    let _ = tx.send(UnifiedEvent::PtyWakeup(key));
-                }
-            }
-            PtyStatus::Exited => {
-                if let Some(&key) = kh.get() {
-                    let _ = tx.send(UnifiedEvent::AppExited(key));
-                }
-            }
-        })));
-        let mut sv = ScrollViewComponent::new(pane);
-        sv.set_keyboard_mode(ScrollKeyMode::PaginationOnly);
-        let key = self
-            .inner
-            .wm()
-            .open_window(AppRootComponent::Core(CoreWmComponent::Terminal(sv)));
-        let _ = key_holder.set(key);
-        let clipboard_enabled = self.inner.wm().clipboard_enabled();
-        if let Some(comp) = self.inner.wm().component_for_key_mut(key) {
-            comp.set_selection_enabled(clipboard_enabled);
-        }
-        let count = self.inner.wm().window_count();
-        self.inner
-            .wm()
-            .set_window_title(key, format!("Shell {}", count));
+        let count = self.inner.wm().window_count() + 1;
+        self.inner.spawn_terminal_window(
+            default_shell_command(),
+            PTY_SCROLLBACK_LEN,
+            None,
+            format!("Shell {}", count),
+        )?;
         Ok(())
     }
 

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -1,11 +1,14 @@
 use std::io;
 use std::sync::Arc;
 
+use crossbeam_channel::{Sender, bounded};
+
 use term_wm_console::console_event_source::ConsoleEventSource;
 use term_wm_console::console_render_target::ConsoleRenderTarget;
 use term_wm_console::draw_plan_renderer::DrawPlanRenderer;
 use term_wm_core::actions::TermWmAction;
 use term_wm_core::app_context::AppContext;
+use term_wm_core::components::Component;
 use term_wm_core::config::AppBuilder;
 use term_wm_core::debug_log::set_global_debug_log;
 use term_wm_core::engine::CoreEngine;
@@ -14,15 +17,19 @@ use term_wm_core::runner::{WindowManagerHost, run_with_defaults};
 use term_wm_core::window::{ClosePolicy, WindowKey, WindowManager, WindowState};
 use term_wm_core::wm_config::WmConfig;
 
+use term_wm_pty_engine::{DirectInputTracker, Pty, PtyStatus};
 use term_wm_sys_ui_components::WmSystemPanelComponent;
 use term_wm_sys_ui_components::wm_command_palette::WmCommandPaletteComponent;
 use term_wm_sys_ui_components::wm_debug_log::{WmDebugLogComponent, install_panic_hook};
 use term_wm_sys_ui_components::wm_help_overlay::WmHelpOverlayComponent;
+use term_wm_ui_components::TerminalComponent;
 use term_wm_ui_components::confirm_overlay::ConfirmOverlayComponent;
+use term_wm_ui_components::scroll_view::{ScrollKeyMode, ScrollViewComponent};
 use term_wm_ui_facade::core_component::CoreWmComponent;
 use term_wm_ui_facade::{LayerComponent, OverlayComponent};
 
 use crate::components::AppRootComponent;
+use crate::unified_event_source::UnifiedEvent;
 
 /// A self-contained window manager app that eliminates dual-trait boilerplate.
 ///
@@ -45,6 +52,8 @@ pub struct TermWmApp {
     engine: CoreEngine,
     /// Draw plan renderer for rendering components.
     draw_renderer: DrawPlanRenderer,
+    /// Sender for PTY events (wakeup, exit, direct-input transitions).
+    pty_wakeup_tx: Sender<UnifiedEvent>,
 }
 
 impl TermWmApp {
@@ -84,7 +93,8 @@ impl TermWmApp {
         wm.set_notification_component(LayerComponent::NotificationArea(
             WmNotificationAreaComponent::new(),
         ));
-        Self::from_wm(wm)
+        let (tx, _) = bounded(256);
+        Self::from_wm(wm, tx)
     }
 
     /// Create a bare standalone app without system chrome.
@@ -99,7 +109,8 @@ impl TermWmApp {
             .app_ctx(Arc::new(app_ctx))
             .build()
             .expect("bare standalone build");
-        Self::from_wm(wm)
+        let (tx, _) = bounded(256);
+        Self::from_wm(wm, tx)
     }
 
     /// Create an embedded app without command menu, suitable for
@@ -110,11 +121,15 @@ impl TermWmApp {
             .app_ctx(Arc::new(app_ctx))
             .build()
             .expect("embedded build");
-        Self::from_wm(wm)
+        let (tx, _) = bounded(256);
+        Self::from_wm(wm, tx)
     }
 
-    /// Create from an already-constructed WindowManager.
-    pub fn from_wm(wm: WindowManager<AppRootComponent, LayerComponent, OverlayComponent>) -> Self {
+    /// Create from an already-constructed WindowManager and PTY event sender.
+    pub fn from_wm(
+        wm: WindowManager<AppRootComponent, LayerComponent, OverlayComponent>,
+        pty_wakeup_tx: Sender<UnifiedEvent>,
+    ) -> Self {
         Self {
             wm,
             debug_key: None,
@@ -122,7 +137,104 @@ impl TermWmApp {
             should_quit: false,
             engine: CoreEngine::new(),
             draw_renderer: DrawPlanRenderer::new(),
+            pty_wakeup_tx,
         }
+    }
+
+    /// Spawn a fully-wired PTY terminal window in a single call.
+    ///
+    /// Handles PTY creation, status callback wiring (`PtyWakeup`, `AppExited`,
+    /// `DirectInputChanged`), `ScrollViewComponent` wrapping, tracker registration,
+    /// clipboard/selection setup, initial command injection, and window title.
+    pub fn spawn_terminal_window(
+        &mut self,
+        cmd: portable_pty::CommandBuilder,
+        scrollback: usize,
+        initial_command: Option<String>,
+        title: impl Into<String>,
+    ) -> io::Result<WindowKey> {
+        let size = TerminalComponent::default_pty_size();
+        let pty = Pty::spawn_with_scrollback(cmd, size, scrollback).map_err(io::Error::other)?;
+        let tracker: std::sync::Arc<dyn DirectInputTracker> = pty.direct_input_tracker();
+        let mut pane = TerminalComponent::from_pane(Box::new(pty));
+
+        pane.set_link_handler_fn(|url| {
+            let _ = webbrowser::open(url);
+            true
+        });
+
+        let mut sv = ScrollViewComponent::new(pane);
+        sv.set_keyboard_mode(ScrollKeyMode::PaginationOnly);
+        let key = self
+            .wm
+            .open_window(crate::components::AppRootComponent::Core(
+                CoreWmComponent::Terminal(sv),
+            ));
+        self.wm.set_window_tracker(key, tracker);
+
+        // Attach status callback AFTER open_window so the closure captures
+        // the known WindowKey directly — no OnceLock, no race condition.
+        let tx = self.pty_wakeup_tx.clone();
+        match self.wm.component_for_key_mut(key) {
+            Some(crate::components::AppRootComponent::Core(CoreWmComponent::Terminal(
+                scroll_view,
+            ))) => {
+                tracing::info!("[STAGE 2] Setting status callback for key {:?}", key);
+                scroll_view
+                    .content
+                    .borrow_mut()
+                    .set_pty_callback(move |status| match status {
+                        PtyStatus::Wakeup => {
+                            let _ =
+                                tx.send(crate::unified_event_source::UnifiedEvent::PtyWakeup(key));
+                        }
+                        PtyStatus::Exited => {
+                            let _ =
+                                tx.send(crate::unified_event_source::UnifiedEvent::AppExited(key));
+                        }
+                        PtyStatus::DirectInputChanged(enabled) => {
+                            tracing::info!(
+                                "[STAGE 2] Sending DirectInputChanged({}) for key {:?}",
+                                enabled,
+                                key
+                            );
+                            if let Err(e) = tx.send(
+                                crate::unified_event_source::UnifiedEvent::DirectInputChanged(
+                                    key, enabled,
+                                ),
+                            ) {
+                                tracing::error!("[STAGE 2] Channel send failed: {:?}", e);
+                            }
+                        }
+                    });
+            }
+            Some(_other) => {
+                tracing::error!(
+                    "[STAGE 2] Window {:?} has unexpected component type — \
+                     status callback will NOT be wired. PTY events will not fire.",
+                    key,
+                );
+            }
+            None => {
+                tracing::error!(
+                    "[STAGE 2] No component found for key {:?} after open_window. \
+                     Status callback will NOT be wired.",
+                    key
+                );
+            }
+        }
+
+        let clipboard_enabled = self.wm.clipboard_enabled();
+        if let Some(comp) = self.wm.component_for_key_mut(key) {
+            comp.set_selection_enabled(clipboard_enabled);
+            if let Some(line) = initial_command {
+                let mut line = line;
+                line.push_str(line_ending::LineEnding::from_current_platform().as_str());
+                let _ = comp.paste(&line);
+            }
+        }
+        self.wm.set_window_title(key, title.into());
+        Ok(key)
     }
 
     /// Initialize standard system windows (debug log + system panel).
@@ -301,7 +413,6 @@ impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for T
                             | TermWmAction::MaximizeWindow(_)
                             | TermWmAction::MinimizeWindow(_)
                             | TermWmAction::CloseWindow(_)
-                            | TermWmAction::ToggleDirectMode(_)
                     )
             })
             .collect();

--- a/src/unified_event_source.rs
+++ b/src/unified_event_source.rs
@@ -34,6 +34,8 @@ pub enum UnifiedEvent {
     PtyWakeup(WindowKey),
     /// A PTY child process has exited. Sent from the reader thread on EOF.
     AppExited(WindowKey),
+    /// Application direct-input routing state changed (alt screen, mouse tracking, margins).
+    DirectInputChanged(WindowKey, bool),
     /// An OS signal was received (SIGINT, SIGTERM).
     Signal,
     /// Periodic tick for timing.
@@ -56,6 +58,8 @@ pub struct UnifiedEventSource {
     dirty_windows: HashSet<WindowKey>,
     /// Accumulated window exit notifications since the last drain.
     exited_windows: Vec<WindowKey>,
+    /// Accumulated direct-input routing transitions since the last drain.
+    direct_input_changed: Vec<(WindowKey, bool)>,
     /// Cached input event (poll returned true, waiting for read).
     pending_event: Option<Event>,
     /// Buffer for input events drained during `drain_pending` so none are lost.
@@ -132,6 +136,7 @@ impl UnifiedEventSource {
             shutdown,
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -168,6 +173,15 @@ impl UnifiedEventSource {
                 }
                 Ok(UnifiedEvent::AppExited(key)) => {
                     self.exited_windows.push(key);
+                }
+                Ok(UnifiedEvent::DirectInputChanged(key, enabled)) => {
+                    tracing::info!(
+                        "[STAGE 3] drain_pending collected DirectInputChanged({:?}, {})",
+                        key,
+                        enabled
+                    );
+                    self.dirty_windows.insert(key);
+                    self.direct_input_changed.push((key, enabled));
                 }
                 Ok(UnifiedEvent::Signal) => {
                     self.signal_received = true;
@@ -277,6 +291,17 @@ impl EventSource for UnifiedEventSource {
                     self.frame_pacer.notify_pending(Instant::now());
                     continue;
                 }
+                Ok(UnifiedEvent::DirectInputChanged(key, enabled)) => {
+                    tracing::info!(
+                        "[STAGE 3] recv_timeout collected DirectInputChanged({:?}, {})",
+                        key,
+                        enabled
+                    );
+                    self.dirty_windows.insert(key);
+                    self.direct_input_changed.push((key, enabled));
+                    self.frame_pacer.notify_pending(Instant::now());
+                    return Ok(false);
+                }
                 Ok(UnifiedEvent::Signal) => {
                     self.signal_received = true;
                     return Ok(false);
@@ -327,6 +352,15 @@ impl EventSource for UnifiedEventSource {
                 Ok(UnifiedEvent::AppExited(key)) => {
                     self.exited_windows.push(key);
                 }
+                Ok(UnifiedEvent::DirectInputChanged(key, enabled)) => {
+                    tracing::info!(
+                        "[STAGE 3] drain_pending collected DirectInputChanged({:?}, {})",
+                        key,
+                        enabled
+                    );
+                    self.dirty_windows.insert(key);
+                    self.direct_input_changed.push((key, enabled));
+                }
                 Ok(UnifiedEvent::Signal) => {
                     self.signal_received = true;
                 }
@@ -356,6 +390,11 @@ impl EventSource for UnifiedEventSource {
                 Ok(UnifiedEvent::AppExited(key)) => {
                     self.exited_windows.push(key);
                 }
+                Ok(UnifiedEvent::DirectInputChanged(key, enabled)) => {
+                    self.dirty_windows.insert(key);
+                    self.direct_input_changed.push((key, enabled));
+                    continue;
+                }
                 Ok(UnifiedEvent::Signal) => self.signal_received = true,
                 Ok(UnifiedEvent::Tick) => {}
                 Err(_) => {
@@ -382,6 +421,11 @@ impl EventSource for UnifiedEventSource {
                 Ok(UnifiedEvent::PtyWakeup(_)) => {}
                 Ok(UnifiedEvent::AppExited(key)) => {
                     self.exited_windows.push(key);
+                }
+                Ok(UnifiedEvent::DirectInputChanged(key, enabled)) => {
+                    self.dirty_windows.insert(key);
+                    self.direct_input_changed.push((key, enabled));
+                    continue;
                 }
                 Ok(UnifiedEvent::Signal) => self.signal_received = true,
                 Ok(UnifiedEvent::Tick) => {}
@@ -445,6 +489,10 @@ impl EventSource for UnifiedEventSource {
         std::mem::take(&mut self.exited_windows)
     }
 
+    fn take_direct_input_changed(&mut self) -> Vec<(WindowKey, bool)> {
+        std::mem::take(&mut self.direct_input_changed)
+    }
+
     fn take_dirty_windows(&mut self) -> HashSet<WindowKey> {
         std::mem::take(&mut self.dirty_windows)
     }
@@ -492,6 +540,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -583,6 +632,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -659,6 +709,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -702,6 +753,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -760,6 +812,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: set,
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -787,6 +840,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -812,6 +866,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -847,6 +902,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: vec![key],
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -888,6 +944,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: set,
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),
@@ -921,6 +978,7 @@ mod tests {
             shutdown: Arc::new(AtomicBool::new(false)),
             dirty_windows: HashSet::new(),
             exited_windows: Vec::new(),
+            direct_input_changed: Vec::new(),
             pending_redraw: false,
             pending_event: None,
             input_buffer: VecDeque::new(),


### PR DESCRIPTION
Root cause: Full-screen pagers (less, man, git log) activate Application Cursor Keys mode (DECCKM, DECSET 1, `\e[?1h`) on startup, which changes arrow key escape sequences from standard CSI (`\e[A`) to SS3 application sequences (`\eOA`). The encoder unconditionally emitted CSI sequences regardless of DECCKM state, so less silently dropped arrow key input.

Fix — three-layer architecture:

1. PtyStateTracker (new, atomics-only, lock-free):
   - Added `is_application_cursor_keys_active` atomic field
   - Intercepts DECSET 1 (`\e[?1h`/`\e[?1l`) in PtyPerformAdapter
   - Reset vectors (RIS `\e c`, DECSTR `\e[!p`) clear the flag
   - 4 new unit tests for enable/disable/reset paths

2. Pane trait + Pty impl:
   - `is_application_cursor_keys_active(&self) -> bool` accessor
   - Pty reads from tracker atomics (lock-free, main thread)
   - TestPane default returns `false`

3. Conditional input encoding (input_encoding.rs + events.rs):
   - `key_to_bytes()` and `to_pty_bytes()` now take `application_cursor_keys: bool` parameter
   - Unmodified arrows (m == NONE) emit SS3 when flag is true
   - Modified arrows (Shift/Ctrl/Alt) always use standard CSI regardless of DECCKM state, per xterm convention
   - 3 new unit tests for SS3/CSI/modifier behavior

Also includes supporting infrastructure:
- PtyStateTracker: lock-free atomic state machine with vte::Perform adapter, tracking alternate screen, mouse tracking modes (1000/1002/1003), SGR mouse, alt scroll mode, DECSTBM margins (with zero-param normalization), and RIS/DECSTR reset recovery (27 unit tests)
- ScrollViewComponent: removed bare Up/Down arrow interception from Full mode (arrow keys always pass through to child)
- Keybindings: ScrollUp/ScrollDown now require Shift modifier

Closes: Arrow keys not working in embedded man pages / git log

This PR also removes manual `direct mode` setting from the Command Palette.