### PR TITLE
feat: Make AppRootComponent extensible via generic parameter

### DIFF
--- a/crates/term-wm-core/src/macros.rs
+++ b/crates/term-wm-core/src/macros.rs
@@ -7,6 +7,93 @@
 /// ```
 #[macro_export]
 macro_rules! impl_component_delegate {
+    ($enum_name:ident, param: $param:ident, bound: $bound:path, variants: { $($variant:ident),* $(,)? }) => {
+        impl<$param: $bound> $crate::components::Component<$crate::actions::TermWmAction>
+            for $enum_name<$param>
+        {
+            fn init(&mut self) {
+                match self { $(Self::$variant(c) => c.init(),)* }
+            }
+            fn on_mount(&mut self, key: $crate::window::WindowKey, app: &$crate::app_context::AppContext) {
+                match self { $(Self::$variant(c) => c.on_mount(key, app),)* }
+            }
+            fn hitbox_id(&self) -> Option<$crate::hitbox_registry::HitboxId> {
+                match self { $(Self::$variant(c) => c.hitbox_id(),)* }
+            }
+            fn handle_events(&mut self, event: &$crate::events::Event, ctx: &$crate::component_context::ComponentContext) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.handle_events(event, ctx),)* }
+            }
+            fn on_mouse_press(
+                &mut self, col: u16, row: u16, button: $crate::events::MouseButton,
+                modifiers: $crate::events::KeyModifiers, ctx: &$crate::component_context::ComponentContext,
+            ) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.on_mouse_press(col, row, button, modifiers, ctx),)* }
+            }
+            fn on_mouse_release(
+                &mut self, col: u16, row: u16, button: $crate::events::MouseButton,
+                modifiers: $crate::events::KeyModifiers, ctx: &$crate::component_context::ComponentContext,
+            ) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.on_mouse_release(col, row, button, modifiers, ctx),)* }
+            }
+            fn on_mouse_drag(
+                &mut self, col: u16, row: u16, button: $crate::events::MouseButton,
+                modifiers: $crate::events::KeyModifiers, ctx: &$crate::component_context::ComponentContext,
+            ) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.on_mouse_drag(col, row, button, modifiers, ctx),)* }
+            }
+            fn on_mouse_scroll(
+                &mut self, col: u16, row: u16, kind: $crate::events::MouseEventKind,
+                modifiers: $crate::events::KeyModifiers, ctx: &$crate::component_context::ComponentContext,
+            ) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.on_mouse_scroll(col, row, kind, modifiers, ctx),)* }
+            }
+            fn on_mouse_move(
+                &mut self, col: u16, row: u16, modifiers: $crate::events::KeyModifiers,
+                ctx: &$crate::component_context::ComponentContext,
+            ) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.on_mouse_move(col, row, modifiers, ctx),)* }
+            }
+            fn on_key(&mut self, event: &$crate::events::Event, ctx: &$crate::component_context::ComponentContext) -> $crate::actions::EventResult<$crate::actions::TermWmAction> {
+                match self { $(Self::$variant(c) => c.on_key(event, ctx),)* }
+            }
+            fn update(&mut self, action: $crate::actions::TermWmAction, ctx: &$crate::component_context::ComponentContext, actions: &mut std::collections::VecDeque<($crate::window::WindowKey, $crate::actions::TermWmAction)>) {
+                match self { $(Self::$variant(c) => c.update(action, ctx, actions),)* }
+            }
+            fn render(&mut self, backend: &mut dyn term_wm_render::RenderBackend, area: $crate::Rect, ctx: &$crate::component_context::ComponentContext, registry: &mut $crate::hitbox_registry::HitboxRegistry) {
+                match self { $(Self::$variant(c) => $crate::components::Component::<$crate::actions::TermWmAction>::render(c, backend, area, ctx, registry),)* }
+            }
+            fn destroy(&mut self) {
+                match self { $(Self::$variant(c) => c.destroy(),)* }
+            }
+            fn clear_selection(&mut self) {
+                match self { $(Self::$variant(c) => c.clear_selection(),)* }
+            }
+            fn selection_status(&self) -> $crate::components::SelectionStatus {
+                match self { $(Self::$variant(c) => c.selection_status(),)* }
+            }
+            fn selection_text(&self) -> Option<String> {
+                match self { $(Self::$variant(c) => c.selection_text(),)* }
+            }
+            fn desired_height(&self, width: u16) -> u16 {
+                match self { $(Self::$variant(c) => c.desired_height(width),)* }
+            }
+            fn take_pending_title(&mut self) -> Option<String> {
+                match self { $(Self::$variant(c) => c.take_pending_title(),)* }
+            }
+            fn take_alternate_screen_transition(&mut self) -> Option<bool> {
+                match self { $(Self::$variant(c) => c.take_alternate_screen_transition(),)* }
+            }
+            fn take_teardown_parts(&mut self) -> Option<(Box<dyn std::any::Any + Send + Sync>, std::thread::JoinHandle<()>)> {
+                match self { $(Self::$variant(c) => c.take_teardown_parts(),)* }
+            }
+            fn set_selection_enabled(&mut self, enabled: bool) {
+                match self { $(Self::$variant(c) => c.set_selection_enabled(enabled),)* }
+            }
+            fn paste(&mut self, text: &str) -> bool {
+                match self { $(Self::$variant(c) => c.paste(text),)* }
+            }
+        }
+    };
     ($enum_name:ident { $($variant:ident),* $(,)? }) => {
         impl $crate::components::Component<$crate::actions::TermWmAction> for $enum_name {
             fn init(&mut self) {

--- a/crates/term-wm-sys-ui-components/assets/help.md
+++ b/crates/term-wm-sys-ui-components/assets/help.md
@@ -3,7 +3,7 @@
 **Package:** `%PACKAGE%` ([https://crates.io/crates/%PACKAGE%](https://crates.io/crates/%PACKAGE%))  
 **Version:** `%VERSION%` (%PLATFORM%)
 
-Submit bug reports: %REPOSITORY%/issues/new
+Submit bug reports to %REPOSITORY%/issues/new
 
 Welcome to `%PACKAGE%`! This page is a quick reference for navigating the UI.
 
@@ -11,35 +11,30 @@ Welcome to `%PACKAGE%`! This page is a quick reference for navigating the UI.
 
 _See also: [No-Keybinding-Conflict Philosophy](#no-keybinding-conflict-philosophy)_
 
-* **%SUPER%**: Exit the active window context and open the menu (the "WM layer").
+The following keybindings are active in the WM layer. The Command Palette binding works in any mode, including direct mode:
 
-While the menu is open:
+* **%SUPER%**: Open (or close) the `Command Palette`.
+
+While the Command Palette is open:
 
 * **%FOCUS_NEXT% / %FOCUS_PREV%**: Cycle focus between windows.
-* **%MENU_NAV%** or **%MENU_ALT%**: Move up/down in lists and menus.
+* **%MENU_NAV%**: Move up/down in lists and menus.
 * **%MENU_SELECT%**: Activate the selected menu item.
-* **%HELP_MENU%**: Open the full help overlay (Panel menu: Top-left -> Help).
+* **%HELP_MENU%**: Open this help overlay. (Alternatively: press **%SUPER%** to open the Command Palette and search for 'Help').
 
 ## No-Keybinding-Conflict Philosophy
 
-A core goal of `%PACKAGE%` is conflict-free keybindings so you can run terminal
-apps (e.g., `screen`, `tmux`, editors, etc.) without the window manager (WM) stealing their keys.
+A core goal of `%PACKAGE%` is conflict-free keybindings so you can run terminal apps (e.g., `screen`, `tmux`, editors, etc.) without the window manager (WM) stealing their keys.
 
 By default, the WM only watches **%SUPER%**. When you press it, you enter the
 WM layer and can use WM commands (like **%FOCUS_NEXT%** / **%FOCUS_PREV%**).
 
-To send **%SUPER%** to the currently focused application, press **%SUPER%**
-twice quickly. (The second press is forwarded to the active window.)
-
-Per-window **direct mode** (toggled via the `[D]` header button) disables all WM
-key interception, including **%SUPER%**, so keyboard-driven apps receive every
-keystroke unfiltered. In direct mode, a single **%SUPER%** is deferred (a countdown
-appears in the panel); a second **%SUPER%** within the timeout opens the WM overlay.
+Per-window `direct mode` (toggled via the `[D]` header button) disables all WM key interception, except for **%SUPER%**, so keyboard-driven apps receive every keystroke unfiltered.
 
 ## Mouse Capture
 
 Mouse capture is enabled by default when supported. To disable it, open the
-menu and toggle `Mouse Capture`.
+Command Palette and toggle `Mouse Capture`.
 
 Mouse capture lets `%PACKAGE%` receive mouse input for WM actions like:
 
@@ -53,7 +48,32 @@ Most of these actions are also purely keyboard driven, by initially pressing the
 Notes:
 
 * Mouse interactions work only while `Mouse Capture` is enabled.
-* Use the panel menu (top-left) for common WM actions.
+* Open the Command Palette (%SUPER%) for common WM actions.
+
+## Selection & Clipboard
+
+`%PACKAGE%` provides text selection and clipboard integration for terminal windows.
+
+**Selecting text:** Left-click drag within a terminal window to select text.
+On release, the selection is automatically copied to the system clipboard
+and a brief notification is shown.
+
+**Pasting:** Right-click to paste the system clipboard contents at the cursor position.
+Paste also works via your terminal emulator's standard shortcut (e.g., Ctrl+Shift+V),
+which sends the text as a bracketed-paste event.
+
+**OSC 52 copy:** Terminal applications (e.g., `vim`, `tmux`) can write to the system
+clipboard using the OSC 52 escape sequence. `%PACKAGE%` intercepts these sequences
+automatically.
+
+Notes:
+
+* Selection and right-click paste are available only while **not** in direct mode.
+  In direct mode, all mouse events pass through to the running application unfiltered.
+* To disable clipboard integration, open the Command Palette (`%SUPER%`) and toggle
+  "Clipboard Mode".
+* To enable or disable window text selection via the Command Palette, toggle
+  "Window Selection: On/Off".
 
 ----
 

--- a/crates/term-wm-sys-ui-components/assets/help.md
+++ b/crates/term-wm-sys-ui-components/assets/help.md
@@ -3,7 +3,7 @@
 **Package:** `%PACKAGE%` ([https://crates.io/crates/%PACKAGE%](https://crates.io/crates/%PACKAGE%))  
 **Version:** `%VERSION%` (%PLATFORM%)
 
-Submit bug reports to %REPOSITORY%/issues/new
+Submit bug reports: %REPOSITORY%/issues/new
 
 Welcome to `%PACKAGE%`! This page is a quick reference for navigating the UI.
 
@@ -11,30 +11,35 @@ Welcome to `%PACKAGE%`! This page is a quick reference for navigating the UI.
 
 _See also: [No-Keybinding-Conflict Philosophy](#no-keybinding-conflict-philosophy)_
 
-The following keybindings are active in the WM layer. The Command Palette binding works in any mode, including direct mode:
+* **%SUPER%**: Exit the active window context and open the menu (the "WM layer").
 
-* **%SUPER%**: Open (or close) the `Command Palette`.
-
-While the Command Palette is open:
+While the menu is open:
 
 * **%FOCUS_NEXT% / %FOCUS_PREV%**: Cycle focus between windows.
-* **%MENU_NAV%**: Move up/down in lists and menus.
+* **%MENU_NAV%** or **%MENU_ALT%**: Move up/down in lists and menus.
 * **%MENU_SELECT%**: Activate the selected menu item.
-* **%HELP_MENU%**: Open this help overlay. (Alternatively: press **%SUPER%** to open the Command Palette and search for 'Help').
+* **%HELP_MENU%**: Open the full help overlay (Panel menu: Top-left -> Help).
 
 ## No-Keybinding-Conflict Philosophy
 
-A core goal of `%PACKAGE%` is conflict-free keybindings so you can run terminal apps (e.g., `screen`, `tmux`, editors, etc.) without the window manager (WM) stealing their keys.
+A core goal of `%PACKAGE%` is conflict-free keybindings so you can run terminal
+apps (e.g., `screen`, `tmux`, editors, etc.) without the window manager (WM) stealing their keys.
 
 By default, the WM only watches **%SUPER%**. When you press it, you enter the
 WM layer and can use WM commands (like **%FOCUS_NEXT%** / **%FOCUS_PREV%**).
 
-Per-window `direct mode` (toggled via the `[D]` header button) disables all WM key interception, except for **%SUPER%**, so keyboard-driven apps receive every keystroke unfiltered.
+To send **%SUPER%** to the currently focused application, press **%SUPER%**
+twice quickly. (The second press is forwarded to the active window.)
+
+Per-window **direct mode** (toggled via the `[D]` header button) disables all WM
+key interception, including **%SUPER%**, so keyboard-driven apps receive every
+keystroke unfiltered. In direct mode, a single **%SUPER%** is deferred (a countdown
+appears in the panel); a second **%SUPER%** within the timeout opens the WM overlay.
 
 ## Mouse Capture
 
 Mouse capture is enabled by default when supported. To disable it, open the
-Command Palette and toggle `Mouse Capture`.
+menu and toggle `Mouse Capture`.
 
 Mouse capture lets `%PACKAGE%` receive mouse input for WM actions like:
 
@@ -48,32 +53,7 @@ Most of these actions are also purely keyboard driven, by initially pressing the
 Notes:
 
 * Mouse interactions work only while `Mouse Capture` is enabled.
-* Open the Command Palette (%SUPER%) for common WM actions.
-
-## Selection & Clipboard
-
-`%PACKAGE%` provides text selection and clipboard integration for terminal windows.
-
-**Selecting text:** Left-click drag within a terminal window to select text.
-On release, the selection is automatically copied to the system clipboard
-and a brief notification is shown.
-
-**Pasting:** Right-click to paste the system clipboard contents at the cursor position.
-Paste also works via your terminal emulator's standard shortcut (e.g., Ctrl+Shift+V),
-which sends the text as a bracketed-paste event.
-
-**OSC 52 copy:** Terminal applications (e.g., `vim`, `tmux`) can write to the system
-clipboard using the OSC 52 escape sequence. `%PACKAGE%` intercepts these sequences
-automatically.
-
-Notes:
-
-* Selection and right-click paste are available only while **not** in direct mode.
-  In direct mode, all mouse events pass through to the running application unfiltered.
-* To disable clipboard integration, open the Command Palette (`%SUPER%`) and toggle
-  "Clipboard Mode".
-* To enable or disable window text selection via the Command Palette, toggle
-  "Window Selection: On/Off".
+* Use the panel menu (top-left) for common WM actions.
 
 ----
 

--- a/examples/dual_image.rs
+++ b/examples/dual_image.rs
@@ -14,20 +14,21 @@ fn main() -> io::Result<()> {
         paths.push(paths[0].clone());
     }
 
-    let mut app = TermWmApp::new(AppContext::new("example", "0.0.0"));
+    let mut app: TermWmApp<SvgImageComponent> =
+        TermWmApp::new_custom(AppContext::new("example", "0.0.0"));
 
     let mut left = SvgImageComponent::new();
     left.set_keep_aspect(true);
     left.set_colorize(true);
     left.load_from_path(&paths[0])?;
-    let left_key = app.open_window(AppRootComponent::SvgImage(left));
+    let left_key = app.open_window(AppRootComponent::Custom(left));
     app.set_window_title(left_key, "Left Image");
 
     let mut right = SvgImageComponent::new();
     right.set_keep_aspect(true);
     right.set_colorize(true);
     right.load_from_path(&paths[1])?;
-    let right_key = app.open_window(AppRootComponent::SvgImage(right));
+    let right_key = app.open_window(AppRootComponent::Custom(right));
     app.set_window_title(right_key, "Right Image");
 
     app.run()

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,12 +1,14 @@
 pub use term_wm_core::components::NoopComponent;
 
+use term_wm_core::actions::TermWmAction;
+use term_wm_core::components::Component;
 use term_wm_core::impl_component_delegate;
-use term_wm_ui_components::svg_image::SvgImageComponent;
 use term_wm_ui_facade::core_component::CoreWmComponent;
 
-pub enum AppRootComponent {
+#[allow(clippy::large_enum_variant)]
+pub enum AppRootComponent<C = NoopComponent> {
     Core(CoreWmComponent),
-    SvgImage(SvgImageComponent),
+    Custom(C),
 }
 
-impl_component_delegate!(AppRootComponent { Core, SvgImage });
+impl_component_delegate!(AppRootComponent, param: C, bound: Component<TermWmAction>, variants: { Core, Custom });

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -28,23 +28,56 @@ use term_wm_ui_components::scroll_view::{ScrollKeyMode, ScrollViewComponent};
 use term_wm_ui_facade::core_component::CoreWmComponent;
 use term_wm_ui_facade::{LayerComponent, OverlayComponent};
 
-use crate::components::AppRootComponent;
+use crate::components::{AppRootComponent, NoopComponent};
 use crate::unified_event_source::UnifiedEvent;
 
 /// A self-contained window manager app that eliminates dual-trait boilerplate.
 ///
-/// # Example
+/// Generic parameter `C` allows injecting custom root-level components
+/// (beyond the built-in `CoreWmComponent` variants like `Terminal`,
+/// `DebugLog`, `SystemPanel`) without modifying term-wm source.
+///
+/// # Choosing a constructor
+///
+/// | You want…                                          | Use                              |
+/// |----------------------------------------------------|----------------------------------|
+/// | Only built-in components, no annotation needed     | `TermWmApp::new(ctx)`            |
+/// | Built-in + your own component type (e.g., `MyComp`)| `TermWmApp::<MyComp>::new_custom(ctx)` |
+///
+/// The `new()` / `bare()` / `embedded()` convenience methods exist only
+/// on `TermWmApp<NoopComponent>` so Rust can infer `C` without turbofish.
+/// When `C` is your own type you must call `new_custom()` / `bare_custom()`
+/// / `embedded_custom()` instead — they are defined on the generic block
+/// and work for any `C: Component<TermWmAction>`.
+///
+/// # Example (built-in only)
 /// ```ignore
 /// use term_wm::prelude::*;
 ///
 /// fn main() -> io::Result<()> {
 ///     let mut app = TermWmApp::new(AppContext::new("myapp", "1.0"));
-///     let key = app.open_window(MyComponent::new());
+///     let key = app.open_window(AppRootComponent::Core(core_component));
 ///     app.run()
 /// }
 /// ```
-pub struct TermWmApp {
-    wm: WindowManager<AppRootComponent, LayerComponent, OverlayComponent>,
+///
+/// # Example (with a custom component)
+/// ```ignore
+/// use term_wm::prelude::*;
+/// use term_wm::SvgImageComponent;
+/// use term_wm::components::AppRootComponent;
+///
+/// fn main() -> io::Result<()> {
+///     let mut app = TermWmApp::<SvgImageComponent>::new_custom(AppContext::new("myapp", "1.0"));
+///     app.open_window(AppRootComponent::Custom(my_svg));
+///     app.run()
+/// }
+/// ```
+pub struct TermWmApp<C = NoopComponent>
+where
+    C: Component<TermWmAction>,
+{
+    wm: WindowManager<AppRootComponent<C>, LayerComponent, OverlayComponent>,
     debug_key: Option<WindowKey>,
     system_panel_key: Option<WindowKey>,
     should_quit: bool,
@@ -56,10 +89,14 @@ pub struct TermWmApp {
     pty_wakeup_tx: Sender<UnifiedEvent>,
 }
 
-impl TermWmApp {
+impl<C: Component<TermWmAction>> TermWmApp<C> {
     /// Create a new standalone app with all system chrome (panels, menu).
+    ///
+    /// This is the generic constructor — works for any `C: Component<TermWmAction>`.
+    /// When `C = NoopComponent` you can use `TermWmApp::new(ctx)` instead
+    /// (it forwards here) to avoid a type annotation.
     #[cfg(feature = "sys-ui")]
-    pub fn new(app_ctx: AppContext) -> Self {
+    pub fn new_custom(app_ctx: AppContext) -> Self {
         let app_name = app_ctx.app_name.clone();
         let app_version = app_ctx.app_version.clone();
         let hostname = app_ctx.hostname.clone();
@@ -98,13 +135,10 @@ impl TermWmApp {
     }
 
     /// Create a bare standalone app without system chrome.
-    #[cfg(not(feature = "sys-ui"))]
-    pub fn new(app_ctx: AppContext) -> Self {
-        Self::bare(app_ctx)
-    }
-
-    /// Create a bare standalone app without system chrome.
-    pub fn bare(app_ctx: AppContext) -> Self {
+    ///
+    /// Generic constructor — use `TermWmApp::bare(ctx)` instead when
+    /// `C = NoopComponent` to avoid a type annotation.
+    pub fn bare_custom(app_ctx: AppContext) -> Self {
         let wm = AppBuilder::<LayerComponent>::bare()
             .app_ctx(Arc::new(app_ctx))
             .build()
@@ -115,7 +149,10 @@ impl TermWmApp {
 
     /// Create an embedded app without command menu, suitable for
     /// embedding in an existing Ratatui application.
-    pub fn embedded(app_ctx: AppContext) -> Self {
+    ///
+    /// Generic constructor — use `TermWmApp::embedded(ctx)` instead when
+    /// `C = NoopComponent` to avoid a type annotation.
+    pub fn embedded_custom(app_ctx: AppContext) -> Self {
         let wm = AppBuilder::<LayerComponent>::bare()
             .config(WmConfig::minimal())
             .app_ctx(Arc::new(app_ctx))
@@ -127,7 +164,7 @@ impl TermWmApp {
 
     /// Create from an already-constructed WindowManager and PTY event sender.
     pub fn from_wm(
-        wm: WindowManager<AppRootComponent, LayerComponent, OverlayComponent>,
+        wm: WindowManager<AppRootComponent<C>, LayerComponent, OverlayComponent>,
         pty_wakeup_tx: Sender<UnifiedEvent>,
     ) -> Self {
         Self {
@@ -167,18 +204,14 @@ impl TermWmApp {
         sv.set_keyboard_mode(ScrollKeyMode::PaginationOnly);
         let key = self
             .wm
-            .open_window(crate::components::AppRootComponent::Core(
-                CoreWmComponent::Terminal(sv),
-            ));
+            .open_window(AppRootComponent::Core(CoreWmComponent::Terminal(sv)));
         self.wm.set_window_tracker(key, tracker);
 
         // Attach status callback AFTER open_window so the closure captures
         // the known WindowKey directly — no OnceLock, no race condition.
         let tx = self.pty_wakeup_tx.clone();
         match self.wm.component_for_key_mut(key) {
-            Some(crate::components::AppRootComponent::Core(CoreWmComponent::Terminal(
-                scroll_view,
-            ))) => {
+            Some(AppRootComponent::Core(CoreWmComponent::Terminal(scroll_view))) => {
                 tracing::info!("[STAGE 2] Setting status callback for key {:?}", key);
                 scroll_view
                     .content
@@ -288,12 +321,14 @@ impl TermWmApp {
 
     /// Open a component as a visible window. Returns the `WindowKey` for
     /// later access.
-    pub fn open_window(&mut self, component: AppRootComponent) -> WindowKey {
+    pub fn open_window(&mut self, component: AppRootComponent<C>) -> WindowKey {
         self.wm.open_window(component)
     }
 
     /// Borrow the WindowManager for configuration or direct access.
-    pub fn wm(&mut self) -> &mut WindowManager<AppRootComponent, LayerComponent, OverlayComponent> {
+    pub fn wm(
+        &mut self,
+    ) -> &mut WindowManager<AppRootComponent<C>, LayerComponent, OverlayComponent> {
         &mut self.wm
     }
 
@@ -351,8 +386,37 @@ impl TermWmApp {
     }
 }
 
-impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for TermWmApp {
-    fn wm(&mut self) -> &mut WindowManager<AppRootComponent, LayerComponent, OverlayComponent> {
+/// Facade constructors for `C = NoopComponent` — enables type inference
+/// for `TermWmApp::new(ctx)` without annotations.
+impl TermWmApp<NoopComponent> {
+    /// Create a new standalone app with all system chrome (panels, menu).
+    #[cfg(feature = "sys-ui")]
+    pub fn new(app_ctx: AppContext) -> Self {
+        Self::new_custom(app_ctx)
+    }
+
+    /// Create a bare standalone app without system chrome.
+    #[cfg(not(feature = "sys-ui"))]
+    pub fn new(app_ctx: AppContext) -> Self {
+        Self::bare(app_ctx)
+    }
+
+    /// Create a bare standalone app without system chrome.
+    pub fn bare(app_ctx: AppContext) -> Self {
+        Self::bare_custom(app_ctx)
+    }
+
+    /// Create an embedded app without command menu, suitable for
+    /// embedding in an existing Ratatui application.
+    pub fn embedded(app_ctx: AppContext) -> Self {
+        Self::embedded_custom(app_ctx)
+    }
+}
+
+impl<C: Component<TermWmAction>>
+    WindowManagerHost<AppRootComponent<C>, LayerComponent, OverlayComponent> for TermWmApp<C>
+{
+    fn wm(&mut self) -> &mut WindowManager<AppRootComponent<C>, LayerComponent, OverlayComponent> {
         &mut self.wm
     }
 


### PR DESCRIPTION
Replace the closed enum `AppRootComponent` with `AppRootComponent<C = NoopComponent>`
with a `Custom(C)` variant. Users can now inject any `Component<TermWmAction>`
type without modifying library source.

- Add generic arm to `impl_component_delegate!` macro (param/bound/variants syntax)
- `AppRootComponent<C>` with `Core(CoreWmComponent)` + `Custom(C)` variants
- `TermWmApp<C>` with `new_custom`/`bare_custom`/`embedded_custom` on the generic block
- `TermWmApp<NoopComponent>` facade preserves type inference for `TermWmApp::new(ctx)`
- Update `dual_image` example to use `AppRootComponent::Custom` + `new_custom` If you want to split the unrelated help.md change into a separate commit: docs(help): update keyboard shortcut reference in help overlay