### PR TITLE
feat: Spatial outside-click dismissal for command palette and help

### DIFF
--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -818,6 +818,27 @@ pub fn render_overlays<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Te
         }
         wm.hitbox_registry_mut().merge(top_hb);
 
+        // Register the top panel's outer hitbox for the overlay area so
+        // handle_outside_click can find it via hit_test_all and dispatch
+        // to the panel component (which hit-tests sub-elements internally).
+        // Extract metadata first to drop the immutable borrow before mutation.
+        #[allow(clippy::manual_option_zip)]
+        let panel_meta = wm
+            .get_semantic_component(ComponentTag::TopPanel)
+            .and_then(|p| p.hitbox_id())
+            .and_then(|hitbox_id| {
+                wm.semantic_registry
+                    .get(&ComponentTag::TopPanel)
+                    .copied()
+                    .map(|layer_id| (hitbox_id, layer_id))
+            });
+
+        if let Some((hitbox_id, layer_id)) = panel_meta {
+            use term_wm_core::hitbox_registry::ComponentOwner;
+            wm.hitbox_registry_mut()
+                .register(hitbox_id, ComponentOwner::Layer(layer_id), top_area);
+        }
+
         // Bottom panel overlay in monocle mode — keybinding hints
         let bottom_area = LayoutRect {
             x: full_area.x,
@@ -826,11 +847,38 @@ pub fn render_overlays<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Te
             height: 1,
         };
         let mut bottom_hb = HitboxRegistry::new();
+        // Extract hints before mutable borrow (borrow checker safety).
+        let hints = wm
+            .keybindings()
+            .bottom_hints(term_wm_core::constants::MAX_BOTTOM_HINTS);
         if let Some(p) = wm.get_semantic_component_mut(ComponentTag::BottomPanel) {
+            p.process_action(&ComponentAction::SetKeybindingHints(hints));
             let ctx = ComponentContext::new(false).with_screen_area(bottom_area);
             p.render(backend, bottom_area, &ctx, &mut bottom_hb);
         }
         wm.hitbox_registry_mut().merge(bottom_hb);
+
+        // Register the bottom panel's outer hitbox for the overlay area, same
+        // reason as top panel above — the panel's render ignores the registry.
+        #[allow(clippy::manual_option_zip)]
+        let bottom_panel_meta = wm
+            .get_semantic_component(ComponentTag::BottomPanel)
+            .and_then(|p| p.hitbox_id())
+            .and_then(|hitbox_id| {
+                wm.semantic_registry
+                    .get(&ComponentTag::BottomPanel)
+                    .copied()
+                    .map(|layer_id| (hitbox_id, layer_id))
+            });
+
+        if let Some((hitbox_id, layer_id)) = bottom_panel_meta {
+            use term_wm_core::hitbox_registry::ComponentOwner;
+            wm.hitbox_registry_mut().register(
+                hitbox_id,
+                ComponentOwner::Layer(layer_id),
+                bottom_area,
+            );
+        }
     }
 
     let hover_pos = wm.hover_pos();

--- a/crates/term-wm-core/src/components.rs
+++ b/crates/term-wm-core/src/components.rs
@@ -260,6 +260,11 @@ impl Component<TermWmAction> for NoopComponent {
 }
 
 pub trait Overlay<Msg>: Component<Msg> + std::any::Any {
+    /// Returns the overlay's current render area, if available, for spatial
+    /// hit-testing (e.g. dismissing the overlay on outside-click).
+    fn render_area(&self) -> Option<LayoutRect> {
+        None
+    }
     fn visible(&self) -> bool {
         true
     }

--- a/crates/term-wm-core/src/hitbox_registry.rs
+++ b/crates/term-wm-core/src/hitbox_registry.rs
@@ -208,6 +208,41 @@ impl HitboxRegistry {
             .map(|entry| (entry.id, entry.owner, entry.area))
     }
 
+    /// Like `hit_test`, but accepts a filter predicate and checks overlay
+    /// then standard entries. Returns the first entry for which the predicate
+    /// returns `true`.
+    pub fn hit_test_filtered(
+        &self,
+        position: MousePosition,
+        filter: impl Fn(&ComponentOwner) -> bool,
+    ) -> Option<(HitboxId, ComponentOwner, LayoutRect)> {
+        for entry in self.overlay_entries.iter().rev() {
+            if position.is_inside(entry.area) && filter(&entry.owner) {
+                return Some((entry.id, entry.owner, entry.area));
+            }
+        }
+        for entry in self.entries.iter().rev() {
+            if position.is_inside(entry.area) && filter(&entry.owner) {
+                return Some((entry.id, entry.owner, entry.area));
+            }
+        }
+        None
+    }
+
+    /// Returns ALL entries (overlay then standard) whose area contains `position`,
+    /// in reverse-registration order (topmost first).
+    pub fn hit_test_all(
+        &self,
+        position: MousePosition,
+    ) -> impl Iterator<Item = (HitboxId, ComponentOwner, LayoutRect)> + '_ {
+        self.overlay_entries
+            .iter()
+            .rev()
+            .chain(self.entries.iter().rev())
+            .filter(move |entry| position.is_inside(entry.area))
+            .map(|entry| (entry.id, entry.owner, entry.area))
+    }
+
     /// Returns the number of registered entries (for diagnostics / metrics).
     pub fn len(&self) -> usize {
         self.entries.len() + self.overlay_entries.len()
@@ -701,5 +736,73 @@ mod tests {
         let reg = HitboxRegistry::with_owner(ComponentOwner::Test);
         assert!(reg.active_owner.is_some());
         assert_eq!(reg.active_owner.unwrap(), ComponentOwner::Test);
+    }
+
+    #[test]
+    fn hit_test_all_returns_overlay_then_standard_in_order() {
+        let mut reg = HitboxRegistry::new();
+        reg.register(
+            HitboxId::new(),
+            ComponentOwner::Window(slotmap::DefaultKey::default()),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        reg.register(
+            HitboxId::new(),
+            ComponentOwner::Overlay(OverlayKey::default()),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        let results: Vec<_> = reg.hit_test_all(screen_pos(5, 5)).collect();
+        assert_eq!(results.len(), 2);
+        // Overlay entry should come first
+        assert_eq!(results[0].1, ComponentOwner::Overlay(OverlayKey::default()));
+        assert_eq!(
+            results[1].1,
+            ComponentOwner::Window(slotmap::DefaultKey::default())
+        );
+    }
+
+    #[test]
+    fn hit_test_all_empty_returns_empty_iterator() {
+        let reg = HitboxRegistry::new();
+        let results: Vec<_> = reg.hit_test_all(screen_pos(5, 5)).collect();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn hit_test_all_only_returns_matching_position() {
+        let mut reg = HitboxRegistry::new();
+        reg.register(
+            HitboxId::new(),
+            ComponentOwner::Test,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        reg.register(
+            HitboxId::new(),
+            ComponentOwner::Chrome(crate::chrome::ChromeTarget::EmptyStatePlaceholder),
+            LayoutRect {
+                x: 20,
+                y: 20,
+                width: 10,
+                height: 10,
+            },
+        );
+        let results: Vec<_> = reg.hit_test_all(screen_pos(5, 5)).collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, ComponentOwner::Test);
     }
 }

--- a/crates/term-wm-core/src/macros.rs
+++ b/crates/term-wm-core/src/macros.rs
@@ -244,6 +244,9 @@ macro_rules! impl_overlay_delegate {
             fn set_tab_outline(&mut self, expires_at: Option<std::time::Instant>) {
                 match self { $(Self::$variant(c) => c.set_tab_outline(expires_at),)* }
             }
+            fn render_area(&self) -> Option<$crate::Rect> {
+                match self { $(Self::$variant(c) => c.render_area(),)* }
+            }
         }
     };
 }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -65,6 +65,71 @@ pub trait WindowManagerHost<
     }
 }
 
+/// Single authoritative action dispatcher. Both the component action queue
+/// and the overlay keybinding barrier route through this function.
+fn dispatch_action<
+    C: Component<TermWmAction>,
+    L: WmComponent,
+    O: Overlay<TermWmAction>,
+    A: WindowManagerHost<C, L, O>,
+>(
+    app: &mut A,
+    key: WindowKey,
+    action: TermWmAction,
+    queue: &mut VecDeque<(WindowKey, TermWmAction)>,
+) {
+    match action {
+        TermWmAction::Quit | TermWmAction::ExitUi => app.open_exit_confirm(),
+        TermWmAction::Help | TermWmAction::OpenHelp => app.open_help_overlay(),
+        TermWmAction::CloseWindow(k) => app.wm().close_window(k),
+        TermWmAction::NewWindow => drop(app.wm_new_window()),
+        TermWmAction::MinimizeWindow(k) => app.wm().minimize_window(k),
+        TermWmAction::MaximizeWindow(k) => app.wm().toggle_maximize(k),
+        TermWmAction::ToggleMonocle => app.wm().toggle_monocle(),
+        TermWmAction::ToggleTiling => app.wm().toggle_tiling(),
+        TermWmAction::ToggleMouseCapture => app.wm().toggle_mouse_capture(),
+        TermWmAction::ToggleClipboardMode => app.wm().toggle_clipboard_enabled(),
+        TermWmAction::ToggleWindowSelection => app.wm().toggle_window_selection(),
+        TermWmAction::ToggleDebugWindow => app.toggle_debug_window(),
+        TermWmAction::ToggleSystemPanel => app.toggle_system_panel(),
+        TermWmAction::FocusWindow(k) => {
+            if app.wm().window_state(k) == Some(crate::window::WindowState::Iconic) {
+                app.wm()
+                    .transition_window(k, crate::window::WindowState::Mapped);
+            }
+            app.wm().focus_window_key(k);
+        }
+        TermWmAction::FocusNext => app.wm().advance_focus(true),
+        TermWmAction::FocusPrev => app.wm().advance_focus(false),
+        TermWmAction::OpenCommandPalette => {
+            if app.wm().command_menu_visible() {
+                app.wm().close_command_palette();
+            } else {
+                app.open_command_palette();
+            }
+        }
+        TermWmAction::SendNotification(msg) => {
+            app.wm()
+                .push_notification(msg, std::time::Duration::from_secs(3));
+        }
+        TermWmAction::Callback(f) => f(),
+        TermWmAction::RequestKeyboardFocus(id) => {
+            app.wm().set_keyboard_focus(key, id);
+        }
+        TermWmAction::PasteClipboard => {
+            if let Some(text) = app.wm().clipboard_mut().and_then(|cb| cb.get().ok()) {
+                queue.push_back((key, TermWmAction::ClipboardPaste(text)));
+            }
+        }
+        action => {
+            let ctx = app.wm().component_context_for(true, key);
+            if let Some(comp) = app.wm().component_for_key_mut(key) {
+                comp.update(action, &ctx, queue);
+            }
+        }
+    }
+}
+
 fn drain_action_queue<
     C: Component<TermWmAction>,
     L: WmComponent,
@@ -75,56 +140,7 @@ fn drain_action_queue<
     queue: &mut VecDeque<(WindowKey, TermWmAction)>,
 ) {
     while let Some((key, action)) = queue.pop_front() {
-        match action {
-            TermWmAction::SendNotification(msg) => {
-                tracing::info!("drain_action_queue: SendNotification({})", msg);
-                app.wm()
-                    .push_notification(msg, std::time::Duration::from_secs(3));
-            }
-            TermWmAction::OpenCommandPalette => {
-                if app.wm().command_menu_visible() {
-                    app.wm().close_command_palette();
-                } else {
-                    app.open_command_palette();
-                }
-            }
-            TermWmAction::RequestKeyboardFocus(id) => {
-                app.wm().set_keyboard_focus(key, id);
-            }
-            TermWmAction::PasteClipboard => {
-                let text = app.wm().clipboard_mut().and_then(|cb| cb.get().ok());
-                if let Some(text) = text {
-                    queue.push_back((key, TermWmAction::ClipboardPaste(text)));
-                }
-            }
-            TermWmAction::ToggleMouseCapture => {
-                app.wm().toggle_mouse_capture();
-            }
-            TermWmAction::ToggleWindowSelection => {
-                app.wm().toggle_window_selection();
-            }
-            TermWmAction::ToggleClipboardMode => {
-                app.wm().toggle_clipboard_enabled();
-            }
-            TermWmAction::ToggleTiling => {
-                app.wm().toggle_tiling();
-            }
-            TermWmAction::FocusWindow(k) => {
-                let state = app.wm().window_state(k);
-                if state == Some(crate::window::WindowState::Iconic) {
-                    app.wm()
-                        .transition_window(k, crate::window::WindowState::Mapped);
-                }
-                app.wm().focus_window_key(k);
-            }
-            TermWmAction::Callback(f) => f(),
-            action => {
-                let ctx = app.wm().component_context_for(true, key);
-                if let Some(comp) = app.wm().component_for_key_mut(key) {
-                    comp.update(action, &ctx, queue);
-                }
-            }
-        }
+        dispatch_action(app, key, action, queue);
     }
 }
 
@@ -399,6 +415,35 @@ where
                 }
 
                 if app.wm().help_overlay_visible() {
+                    // Spatial check for outside-click dismissal
+                    if let Event::Mouse(mouse_evt) = &evt
+                        && matches!(mouse_evt.kind, MouseEventKind::Press(_))
+                        && let Some(bounds) = app.wm().help_overlay_bounds()
+                        && !bounds.contains(mouse_evt.column, mouse_evt.row)
+                    {
+                        let stale_key = app.wm().help_key();
+                        app.wm().close_help_overlay();
+                        let mut actions = std::collections::VecDeque::new();
+                        if !app.wm().handle_outside_click(
+                            mouse_evt.column,
+                            mouse_evt.row,
+                            &evt,
+                            &mut actions,
+                            stale_key,
+                        ) {
+                            app.wm()
+                                .handle_mouse_focus_click(mouse_evt.column, mouse_evt.row);
+                        }
+                        drain_action_queue(app, &mut actions);
+                        update_selection_snapshot(app);
+                        return flush_state_changes(
+                            app,
+                            driver,
+                            ControlFlow::Continue,
+                            false,
+                            None,
+                        );
+                    }
                     let _ = app.wm().handle_help_event(&evt);
                     update_selection_snapshot(app);
                     return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
@@ -435,63 +480,56 @@ where
                     return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
                 }
 
-                // Command palette absolute event barrier (same pattern as help overlay)
+                // Command palette: spatial hit-test barrier.
+                // Clicks outside the palette bounds dismiss it AND activate the
+                // window under the cursor in one gesture. Clicks inside are
+                // handled by the palette as before — event does NOT propagate.
                 if app.wm().command_palette_visible() {
-                    if let Some(action) = app.wm().handle_command_palette_event(&evt) {
-                        match action {
-                            TermWmAction::CloseMenu => {}
-                            TermWmAction::ToggleDebugWindow => {
-                                app.toggle_debug_window();
-                            }
-                            TermWmAction::ToggleSystemPanel => {
-                                app.toggle_system_panel();
-                            }
-                            TermWmAction::Help | TermWmAction::OpenHelp => {
-                                app.open_help_overlay();
-                            }
-                            TermWmAction::Quit | TermWmAction::ExitUi => {
-                                app.open_exit_confirm();
-                            }
-                            TermWmAction::CloseWindow(key) => {
-                                app.wm().close_window(key);
-                            }
-                            TermWmAction::NewWindow => {
-                                app.wm_new_window()?;
-                            }
-                            TermWmAction::MinimizeWindow(key) => {
-                                app.wm().minimize_window(key);
-                            }
-                            TermWmAction::MaximizeWindow(key) => {
-                                app.wm().toggle_maximize(key);
-                            }
-                            TermWmAction::ToggleMonocle => {
-                                app.wm().toggle_monocle();
-                            }
-                            TermWmAction::ToggleTiling => {
-                                app.wm().toggle_tiling();
-                            }
-                            TermWmAction::ToggleMouseCapture => app.wm().toggle_mouse_capture(),
-                            TermWmAction::ToggleClipboardMode => {
-                                app.wm().toggle_clipboard_enabled()
-                            }
-                            TermWmAction::ToggleWindowSelection => {
-                                app.wm().toggle_window_selection()
-                            }
-                            TermWmAction::FocusWindow(k) => {
-                                let state = app.wm().window_state(k);
-                                if state == Some(crate::window::WindowState::Iconic) {
-                                    app.wm()
-                                        .transition_window(k, crate::window::WindowState::Mapped);
-                                }
-                                app.wm().focus_window_key(k);
-                            }
-                            TermWmAction::SendNotification(msg) => {
-                                app.wm()
-                                    .push_notification(msg, std::time::Duration::from_secs(3));
-                            }
-                            TermWmAction::Callback(f) => f(),
-                            _ => {}
+                    // Outside-click detection via explicit bounds check
+                    if let Event::Mouse(mouse_evt) = &evt
+                        && matches!(mouse_evt.kind, MouseEventKind::Press(_))
+                        && let Some(palette_bounds) = app.wm().command_palette_bounds()
+                        && !palette_bounds.contains(mouse_evt.column, mouse_evt.row)
+                    {
+                        let palette_key = app.wm().command_palette_key();
+                        let mut actions = std::collections::VecDeque::new();
+                        if !app.wm().handle_outside_click(
+                            mouse_evt.column,
+                            mouse_evt.row,
+                            &evt,
+                            &mut actions,
+                            palette_key,
+                        ) {
+                            // No panel/overlay/chrome hit — activate window under cursor
+                            app.wm()
+                                .handle_mouse_focus_click(mouse_evt.column, mouse_evt.row);
                         }
+                        // Process panel/overlay actions BEFORE closing the palette
+                        // so the OpenCommandPalette toggle behavior works correctly:
+                        // action checks command_menu_visible() → true → closes palette.
+                        drain_action_queue(app, &mut actions);
+                        // Close palette (no-op if already closed by the action above)
+                        app.wm().close_command_palette();
+                        update_selection_snapshot(app);
+                        return flush_state_changes(
+                            app,
+                            driver,
+                            ControlFlow::Continue,
+                            false,
+                            None,
+                        );
+                    }
+
+                    if let Some(action) = app.wm().handle_command_palette_event(&evt) {
+                        let key = app.wm().focused_window();
+                        let mut actions = std::collections::VecDeque::new();
+                        // NewWindow returns Result — propagate the error
+                        if matches!(action, TermWmAction::NewWindow) {
+                            app.wm_new_window()?;
+                        } else {
+                            actions.push_back((key, action));
+                        }
+                        drain_action_queue(app, &mut actions);
                     }
                     // Focus routing while menu is open (Tab/Shift+Tab)
                     if matches!(&evt, Event::Key(_)) && app.wm().handle_focus_event(&evt) {
@@ -1382,6 +1420,359 @@ mod tests {
         }
     }
     impl crate::components::WmComponent for TestMenu {}
+
+    // ── dispatch_action / drain_action_queue tests ─────────────────────────
+
+    #[test]
+    fn dispatch_action_focus_window_focuses() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let k1 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        let k2 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k1, crate::window::WindowState::Mapped);
+        wm.transition_window(k2, crate::window::WindowState::Mapped);
+        wm.focus_window_key(k1);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(&mut app, k1, TermWmAction::FocusWindow(k2), &mut queue);
+        assert_eq!(app.wm.focused_window(), k2);
+    }
+
+    #[test]
+    fn dispatch_action_focus_next_advances_focus() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let k1 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        let k2 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k1, crate::window::WindowState::Mapped);
+        wm.transition_window(k2, crate::window::WindowState::Mapped);
+        wm.set_focus_order(vec![k1, k2]);
+        wm.focus_window_key(k1);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(&mut app, k1, TermWmAction::FocusNext, &mut queue);
+        assert_eq!(app.wm.focused_window(), k2);
+    }
+
+    #[test]
+    fn drain_action_queue_empty_does_nothing() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        drain_action_queue(&mut app, &mut queue);
+    }
+
+    #[test]
+    fn dispatch_action_focus_prev_advances_focus_backward() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let k1 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        let k2 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k1, crate::window::WindowState::Mapped);
+        wm.transition_window(k2, crate::window::WindowState::Mapped);
+        wm.set_focus_order(vec![k1, k2]);
+        wm.focus_window_key(k2);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(&mut app, k2, TermWmAction::FocusPrev, &mut queue);
+        assert_eq!(app.wm.focused_window(), k1);
+    }
+
+    #[test]
+    fn dispatch_action_toggle_tiling_toggles() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let k = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k, crate::window::WindowState::Mapped);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(&mut app, k, TermWmAction::ToggleTiling, &mut queue);
+        // ToggleTiling flips config.tiling_enabled without cascading actions
+        assert!(queue.is_empty(), "ToggleTiling should not cascade");
+        assert_eq!(
+            app.wm.focused_window(),
+            k,
+            "focus should be unchanged after toggle"
+        );
+    }
+
+    #[test]
+    fn dispatch_action_unknown_forwards_to_component() {
+        use crate::window::WindowManager;
+        use crate::window::test_component::ActionRecorder;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let recorder = ActionRecorder {
+            actions: Vec::new(),
+            received_mouse_bytes: false,
+        };
+        let k = wm.create_window(TestComponent::ActionRecorder(recorder));
+        wm.transition_window(k, crate::window::WindowState::Mapped);
+        wm.focus_window_key(k);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(&mut app, k, TermWmAction::ScrollView(42), &mut queue);
+        // Verify the action was forwarded to the component's update method
+        if let Some(comp) = app.wm.component_for_key_mut(k) {
+            if let TestComponent::ActionRecorder(r) = comp {
+                assert!(
+                    r.actions.contains(&TermWmAction::ScrollView(42)),
+                    "ActionRecorder should have received the forwarded action"
+                );
+            } else {
+                panic!("expected ActionRecorder component");
+            }
+        } else {
+            panic!("component should exist at the created key");
+        }
+    }
+
+    #[test]
+    fn drain_action_queue_multiple_actions() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let k = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k, crate::window::WindowState::Mapped);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back((k, TermWmAction::ToggleMouseCapture));
+        queue.push_back((k, TermWmAction::ToggleClipboardMode));
+        drain_action_queue(&mut app, &mut queue);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn dispatch_action_toggle_mouse_capture_toggles() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let initial = wm.mouse_capture_enabled();
+        let k = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k, crate::window::WindowState::Mapped);
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(&mut app, k, TermWmAction::ToggleMouseCapture, &mut queue);
+        assert_ne!(
+            app.wm.mouse_capture_enabled(),
+            initial,
+            "mouse capture should toggle"
+        );
+    }
+
+    #[test]
+    fn dispatch_action_toggle_clipboard_mode_toggles() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let initial = wm.clipboard_enabled();
+        let mut app = App { wm };
+        let mut queue = std::collections::VecDeque::new();
+        dispatch_action(
+            &mut app,
+            slotmap::DefaultKey::default(),
+            TermWmAction::ToggleClipboardMode,
+            &mut queue,
+        );
+        assert_ne!(
+            app.wm.clipboard_enabled(),
+            initial,
+            "clipboard mode should toggle"
+        );
+    }
+
+    #[test]
+    fn keybinding_barrier_focus_window_drains() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // Create two windows and focus the first
+        let k1 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        let k2 = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k1, crate::window::WindowState::Mapped);
+        wm.transition_window(k2, crate::window::WindowState::Mapped);
+        wm.focus_window_key(k1);
+        let mut app = App { wm };
+        // Simulate the keybinding barrier: action from handle_command_palette_event
+        let action = TermWmAction::FocusWindow(k2);
+        let key = app.wm.focused_window();
+        let mut actions = std::collections::VecDeque::new();
+        actions.push_back((key, action));
+        drain_action_queue(&mut app, &mut actions);
+        assert_eq!(
+            app.wm.focused_window(),
+            k2,
+            "FocusWindow should switch focus"
+        );
+        assert!(actions.is_empty(), "all actions should be drained");
+    }
+
+    #[test]
+    fn keybinding_barrier_send_notification_drains() {
+        use crate::window::WindowManager;
+        struct App {
+            wm: WindowManager<TestComponent>,
+        }
+        impl WindowManagerHost<TestComponent> for App {
+            fn wm(&mut self) -> &mut WindowManager<TestComponent> {
+                &mut self.wm
+            }
+        }
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let k = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(k, crate::window::WindowState::Mapped);
+        let mut app = App { wm };
+        let key = app.wm.focused_window();
+        let mut actions = std::collections::VecDeque::new();
+        actions.push_back((key, TermWmAction::SendNotification("test".into())));
+        drain_action_queue(&mut app, &mut actions);
+        assert!(
+            actions.is_empty(),
+            "notification action should drain without error"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod layer_manager;
 mod layout;
 mod overlays;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 
 use crate::window::entry;
@@ -2291,6 +2291,89 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         }
     }
 
+    /// Handles a mouse click landing outside the command palette upon dismissal.
+    ///
+    /// Inspects ALL hitboxes at (col, row) in Z-order with priority:
+    /// 1. Layer components (TopPanel, BottomPanel, FAB) — dispatch event
+    /// 2. Non-palette Overlays — dispatch event
+    /// 3. Window Chrome (titlebar, buttons, resize handles) — focus window
+    /// 4. Window body — focus window
+    ///
+    /// Returns `true` if any hitbox was handled. Panel/overlay actions are
+    /// pushed to `actions` for the caller to dispatch.
+    pub fn handle_outside_click(
+        &mut self,
+        col: u16,
+        row: u16,
+        event: &Event,
+        actions: &mut VecDeque<(WindowKey, TermWmAction)>,
+        ignored_overlay: Option<OverlayKey>,
+    ) -> bool {
+        use crate::mouse_coord::{CoordSpace, MousePosition};
+
+        let position = MousePosition {
+            column: col as i16,
+            row: row as i16,
+            space: CoordSpace::Screen,
+        };
+        let hits: Vec<_> = self.hitbox_registry.hit_test_all(position).collect();
+
+        for (hitbox_id, owner, hit_rect) in hits {
+            match owner {
+                ComponentOwner::Layer(layer_id) => {
+                    let ctx = self
+                        .component_context(false)
+                        .with_screen_area(hit_rect)
+                        .with_active_hitbox(hitbox_id);
+                    if let Some(layer_comp) = self.layer_manager.get_mut(layer_id) {
+                        match layer_comp.handle_events(event, &ctx) {
+                            EventResult::Action(action) => {
+                                actions.push_back((self.focused_window(), action));
+                                return true;
+                            }
+                            EventResult::Consumed => return true,
+                            EventResult::Ignored => {}
+                        }
+                    }
+                }
+                ComponentOwner::Overlay(key) if Some(key) != ignored_overlay => {
+                    if let Some(overlay) = self.overlays.get_mut(key) {
+                        let ctx = ComponentContext::new(true).with_screen_area(hit_rect);
+                        match overlay.handle_events(event, &ctx) {
+                            EventResult::Action(action) => {
+                                actions.push_back((self.focused_window(), action));
+                                return true;
+                            }
+                            EventResult::Consumed => return true,
+                            EventResult::Ignored => {}
+                        }
+                    }
+                }
+                ComponentOwner::Chrome(target) => {
+                    let win_key = match target {
+                        crate::chrome::ChromeTarget::Resize(k, _)
+                        | crate::chrome::ChromeTarget::Drag(k)
+                        | crate::chrome::ChromeTarget::CloseButton(k)
+                        | crate::chrome::ChromeTarget::MaximizeButton(k)
+                        | crate::chrome::ChromeTarget::MinimizeButton(k) => Some(k),
+                        _ => None,
+                    };
+                    if let Some(k) = win_key {
+                        self.focus_app_window(k);
+                        return true;
+                    }
+                }
+                ComponentOwner::Window(key) => {
+                    self.focus_app_window(key);
+                    return true;
+                }
+                _ => {}
+            }
+        }
+
+        false
+    }
+
     /// No-op: chrome hitbox registration is now handled by the console
     /// during the rendering pass. See `render_window_chrome` in
     /// `term-wm-console/src/draw_plan_renderer.rs`.
@@ -2707,6 +2790,7 @@ fn make_keys<L: WmComponent, O: Overlay<TermWmAction>>(
 mod tests {
     use super::*;
     use crate::components::NoopOverlay;
+    use crate::components::NoopWmComponent;
     use crate::events::{KeyModifiers, MouseButton};
     use crate::hitbox_registry::HitboxId;
     use crate::layout::Direction;
@@ -6560,5 +6644,594 @@ mod tests {
         // ActionRecorder returns None by default
         let result = wm.take_alternate_screen_transition(keys[0]);
         assert_eq!(result, None);
+    }
+
+    // ── TestOverlay for command_palette_bounds tests ──────────────────────
+
+    struct TestOverlay {
+        bounds: Option<LayoutRect>,
+    }
+
+    impl Component<TermWmAction> for TestOverlay {
+        fn render(
+            &mut self,
+            _backend: &mut dyn term_wm_render::RenderBackend,
+            _area: LayoutRect,
+            _ctx: &crate::component_context::ComponentContext,
+            _registry: &mut crate::hitbox_registry::HitboxRegistry,
+        ) {
+        }
+        fn update(
+            &mut self,
+            _action: TermWmAction,
+            _ctx: &crate::component_context::ComponentContext,
+            _actions: &mut VecDeque<(WindowKey, TermWmAction)>,
+        ) {
+        }
+    }
+
+    impl Overlay<TermWmAction> for TestOverlay {
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+        fn render_area(&self) -> Option<LayoutRect> {
+            self.bounds.filter(|b| b.width > 0 && b.height > 0)
+        }
+    }
+
+    // ── command_palette_bounds tests ──────────────────────────────────────
+
+    #[test]
+    fn command_palette_bounds_returns_none_when_no_key() {
+        let wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        assert_eq!(wm.command_palette_bounds(), None);
+    }
+
+    #[test]
+    fn command_palette_bounds_delegates_to_overlay_render_area() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let expected = LayoutRect {
+            x: 10,
+            y: 5,
+            width: 40,
+            height: 10,
+        };
+        let overlay = TestOverlay {
+            bounds: Some(expected),
+        };
+        wm.open_command_palette_overlay(overlay);
+        assert_eq!(wm.command_palette_bounds(), Some(expected));
+    }
+
+    #[test]
+    fn command_palette_bounds_returns_none_for_zero_size() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let overlay = TestOverlay {
+            bounds: Some(LayoutRect::default()),
+        };
+        wm.open_command_palette_overlay(overlay);
+        // zero-size is filtered by render_area() → None
+        assert_eq!(wm.command_palette_bounds(), None);
+    }
+
+    #[test]
+    fn command_palette_bounds_returns_none_for_missing_overlay() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // Insert a different overlay but don't set command_palette_key
+        let other = TestOverlay {
+            bounds: Some(LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            }),
+        };
+        wm.overlays.insert(other);
+        assert_eq!(wm.command_palette_bounds(), None);
+    }
+
+    // ── handle_outside_click tests ───────────────────────────────────────
+
+    #[test]
+    fn handle_outside_click_empty_registry_returns_false() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        assert!(!wm.handle_outside_click(5, 5, &event, &mut actions, None));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn handle_outside_click_window_hitbox_focuses_window() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Window(keys[0]),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        assert!(wm.handle_outside_click(5, 5, &event, &mut actions, None));
+        assert_eq!(*wm.focus.current(), keys[0]);
+    }
+
+    #[test]
+    fn handle_outside_click_chrome_hitbox_focuses_window() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Chrome(crate::chrome::ChromeTarget::Drag(
+                keys[0],
+            )),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 1,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 0,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        assert!(wm.handle_outside_click(5, 0, &event, &mut actions, None));
+        assert_eq!(*wm.focus.current(), keys[0]);
+    }
+
+    #[test]
+    fn handle_outside_click_layer_no_component_returns_false() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Layer(
+                crate::window::window_manager::layer_manager::LayerId(42),
+            ),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        assert!(!wm.handle_outside_click(5, 5, &event, &mut actions, None));
+    }
+
+    #[test]
+    fn handle_outside_click_layer_consumed_returns_true() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // Insert a layer component at a known layer_id via semantic_registry
+        let layer_id = crate::window::window_manager::layer_manager::LayerId(1);
+        wm.layer_manager.insert(
+            crate::components::NoopWmComponent,
+            crate::window::window_manager::layer_manager::ZPlane::Background,
+        );
+        // LayerManager.insert returns the new LayerId — use it via semantic_registry
+        wm.semantic_registry.insert(
+            crate::window::window_manager::layer_manager::ComponentTag::TopPanel,
+            layer_id,
+        );
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Layer(layer_id),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 1,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 0,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // NoopWmComponent.handle_events returns Ignored → Layer arm falls through
+        // No other hitbox → returns false
+        assert!(!wm.handle_outside_click(5, 0, &event, &mut actions, None));
+    }
+
+    #[test]
+    fn handle_outside_click_overlay_ignored_by_key() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let overlay = TestOverlay { bounds: None };
+        let overlay_key = wm.overlays.insert(overlay);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Overlay(overlay_key),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // ignored_overlay matches the overlay key → skipped → false
+        assert!(!wm.handle_outside_click(5, 5, &event, &mut actions, Some(overlay_key)));
+    }
+
+    #[test]
+    fn handle_outside_click_chrome_non_window_skipped() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // EmptyStatePlaceholder has no WindowKey → should not focus any window
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Chrome(
+                crate::chrome::ChromeTarget::EmptyStatePlaceholder,
+            ),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        // Also register a Window hitbox → Chrome should be checked first
+        let keys = make_keys(&mut wm, 1);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Window(keys[0]),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // Chrome(EmptyStatePlaceholder) has no key → skipped. Then Window hitbox found → focuses.
+        assert!(wm.handle_outside_click(5, 5, &event, &mut actions, None));
+        assert_eq!(*wm.focus.current(), keys[0]);
+    }
+
+    // ── overlay key accessor tests ─────────────────────────────────────────
+
+    #[test]
+    fn help_key_returns_none_initially() {
+        let wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        assert_eq!(wm.help_key(), None);
+    }
+
+    #[test]
+    fn command_palette_key_returns_none_initially() {
+        let wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        assert_eq!(wm.command_palette_key(), None);
+    }
+
+    // ── help_overlay_bounds tests ──────────────────────────────────────────
+
+    #[test]
+    fn help_overlay_bounds_returns_none_when_no_key() {
+        let wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        assert_eq!(wm.help_overlay_bounds(), None);
+    }
+
+    #[test]
+    fn help_overlay_bounds_delegates_to_overlay_render_area() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let expected = LayoutRect {
+            x: 5,
+            y: 5,
+            width: 40,
+            height: 15,
+        };
+        let overlay = TestOverlay {
+            bounds: Some(expected),
+        };
+        wm.open_help_overlay(overlay);
+        assert_eq!(wm.help_overlay_bounds(), Some(expected));
+    }
+
+    #[test]
+    fn handle_outside_click_layer_action_queued() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent,
+            crate::components::NoopOverlay>::with_config(
+            WmConfig::standalone(), Arc::new(AppContext::new("test", "0.0.0")),
+            None, crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let layer_id = wm.layer_manager.insert(
+            crate::components::NoopWmComponent,
+            crate::window::window_manager::layer_manager::ZPlane::Background,
+        );
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Layer(layer_id),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // NoopWmComponent returns Ignored → no action, returns false
+        assert!(!wm.handle_outside_click(5, 5, &event, &mut actions, None));
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn handle_outside_click_overlay_not_ignored_routes_event() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // Insert overlay with known bounds
+        let overlay = TestOverlay {
+            bounds: Some(LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            }),
+        };
+        let overlay_key = wm.overlays.insert(overlay);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Overlay(overlay_key),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // TestOverlay.handle_events falls through to Component::handle_events default
+        // which checks hitbox_id → TestOverlay has None → ignores → returns false
+        assert!(!wm.handle_outside_click(5, 5, &event, &mut actions, None));
+    }
+
+    #[test]
+    fn handle_outside_click_priority_layer_over_window() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent,
+            crate::components::NoopOverlay>::with_config(
+            WmConfig::standalone(), Arc::new(AppContext::new("test", "0.0.0")),
+            None, crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        let layer_id = wm.layer_manager.insert(
+            crate::components::NoopWmComponent,
+            crate::window::window_manager::layer_manager::ZPlane::Background,
+        );
+        // Register both at same position → Layer registered after Window → Layer checked first
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Window(keys[0]),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Layer(layer_id),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // Layer checked first (last-registered in entries, hit_test_all iterates in reverse)
+        // NoopWmComponent returns Ignored → falls through → Window hitbox focuses window
+        assert!(wm.handle_outside_click(5, 5, &event, &mut actions, None));
+        assert_eq!(*wm.focus.current(), keys[0]);
+    }
+
+    #[test]
+    fn handle_outside_click_stacked_overlay_ignores_stale() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        // Overlay A (stale, will be ignored)
+        let overlay_a = TestOverlay { bounds: None };
+        let key_a = wm.overlays.insert(overlay_a);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Overlay(key_a),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        // Overlay B (active, should be found)
+        let overlay_b = TestOverlay { bounds: None };
+        let key_b = wm.overlays.insert(overlay_b);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Overlay(key_b),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        // Also add a Window hitbox as tertiary fallback
+        let keys = make_keys(&mut wm, 1);
+        wm.hitbox_registry.register(
+            crate::hitbox_registry::HitboxId::new(),
+            crate::hitbox_registry::ComponentOwner::Window(keys[0]),
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        let event = crate::events::Event::Mouse(crate::events::MouseEvent {
+            kind: crate::events::MouseEventKind::Press(crate::events::MouseButton::Left),
+            column: 5,
+            row: 5,
+            modifiers: crate::events::KeyModifiers::NONE,
+        });
+        let mut actions = VecDeque::new();
+        // ignored_overlay = key_a → Overlay A skipped. Overlay B → TestOverlay.handle_events
+        // returns Ignored (no hitbox_id) → falls through to Window → focuses
+        assert!(wm.handle_outside_click(5, 5, &event, &mut actions, Some(key_a)));
+        assert_eq!(*wm.focus.current(), keys[0]);
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/overlays.rs
+++ b/crates/term-wm-core/src/window/window_manager/overlays.rs
@@ -1,7 +1,8 @@
 use crate::components::{Component, Overlay, WmComponent};
 use crate::events::Event;
+use term_wm_layout_engine::LayoutRect;
 
-use super::WindowManager;
+use super::{OverlayKey, WindowManager};
 use crate::actions::{ConfirmAction, EventResult, TermWmAction};
 
 impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> WindowManager<C, L, O> {
@@ -17,6 +18,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     pub fn help_overlay_visible(&self) -> bool {
         self.help_key.is_some()
+    }
+
+    pub fn help_key(&self) -> Option<OverlayKey> {
+        self.help_key
+    }
+
+    pub fn command_palette_key(&self) -> Option<OverlayKey> {
+        self.command_palette_key
     }
 
     pub fn close_help_overlay(&mut self) {
@@ -82,6 +91,18 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
     pub fn command_palette_visible(&self) -> bool {
         self.command_palette_key.is_some()
+    }
+
+    pub fn command_palette_bounds(&self) -> Option<LayoutRect> {
+        self.command_palette_key
+            .and_then(|key| self.overlays.get(key))
+            .and_then(|o| o.render_area())
+    }
+
+    pub fn help_overlay_bounds(&self) -> Option<LayoutRect> {
+        self.help_key
+            .and_then(|key| self.overlays.get(key))
+            .and_then(|o| o.render_area())
     }
 
     pub fn close_command_palette(&mut self) {

--- a/crates/term-wm-sys-ui-components/src/wm_command_palette.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_command_palette.rs
@@ -22,6 +22,10 @@ use term_wm_ui_components::helpers::{downcast_ratatui, layout_rect_to_clipped_re
 
 pub struct WmCommandPaletteComponent {
     area: Cell<LayoutRect>,
+    /// The actual dialog rectangle within the managed area (centered, sized to
+    /// content). Used for spatial hit-testing — clicks outside this rect
+    /// dismiss the palette and activate the window underneath.
+    dialog_bounds: Cell<LayoutRect>,
     dialog: DialogOverlayComponent,
     palette: CommandPaletteComponent,
     managed_area: LayoutRect,
@@ -54,6 +58,7 @@ impl WmCommandPaletteComponent {
         dialog.set_auto_close_on_outside_click(true);
         Self {
             area: Cell::new(LayoutRect::default()),
+            dialog_bounds: Cell::new(LayoutRect::default()),
             dialog,
             palette: CommandPaletteComponent::new(),
             managed_area: LayoutRect::default(),
@@ -153,6 +158,7 @@ impl Component<TermWmAction> for WmCommandPaletteComponent {
                 width: rect.width,
                 height: rect.height,
             };
+            self.dialog_bounds.set(content_rect);
             if content_rect.width > 0 && content_rect.height > 0 {
                 let ratatui = downcast_ratatui(backend);
                 Block::default()
@@ -175,6 +181,7 @@ impl Component<TermWmAction> for WmCommandPaletteComponent {
             width: rect.width,
             height: rect.height,
         };
+        self.dialog_bounds.set(content_rect);
 
         if content_rect.width == 0 || content_rect.height == 0 {
             return;
@@ -305,6 +312,15 @@ impl Overlay<TermWmAction> for WmCommandPaletteComponent {
     fn set_tab_outline(&mut self, expires_at: Option<Instant>) {
         self.tab_outline_until = expires_at;
     }
+
+    fn render_area(&self) -> Option<LayoutRect> {
+        let bounds = self.dialog_bounds.get();
+        if bounds.width > 0 && bounds.height > 0 {
+            Some(bounds)
+        } else {
+            None
+        }
+    }
 }
 
 impl WmComponent for WmCommandPaletteComponent {
@@ -349,7 +365,9 @@ impl WmComponent for WmCommandPaletteComponent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use term_wm_console::RatatuiBackend;
     use term_wm_core::components::MenuItem;
+    use term_wm_core::components::Overlay;
 
     #[test]
     fn new_default_state() {
@@ -485,5 +503,56 @@ mod tests {
         let (consumed, remaining) = palette.consume_area(available);
         assert_eq!(consumed, LayoutRect::default());
         assert_eq!(remaining, available);
+    }
+
+    #[test]
+    fn render_area_returns_none_before_render() {
+        let palette = WmCommandPaletteComponent::new();
+        // dialog_bounds defaults to zero dimensions, so render_area returns None
+        assert_eq!(
+            <WmCommandPaletteComponent as Overlay<TermWmAction>>::render_area(&palette),
+            None
+        );
+    }
+
+    #[test]
+    fn render_area_returns_some_after_render() {
+        let mut palette = WmCommandPaletteComponent::new();
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        palette.set_managed_area(area);
+        palette.show();
+
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::prelude::Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        let mut backend = RatatuiBackend::new_simple(
+            buffer,
+            ratatui::prelude::Rect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        let ctx = term_wm_core::components::ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+
+        palette.render(&mut backend, area, &ctx, &mut registry);
+
+        let bounds = <WmCommandPaletteComponent as Overlay<TermWmAction>>::render_area(&palette);
+        assert!(bounds.is_some(), "bounds should be populated after render");
+        let bounds = bounds.unwrap();
+        assert!(bounds.width > 0);
+        assert!(bounds.height > 0);
+        assert!(bounds.x >= 0);
+        assert!(bounds.y >= 0);
     }
 }

--- a/crates/term-wm-sys-ui-components/src/wm_help_overlay.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_help_overlay.rs
@@ -25,6 +25,7 @@ pub struct WmHelpOverlayComponent {
     dialog: DialogOverlayComponent,
     content: ScrollViewComponent<MarkdownViewerComponent>,
     area: Cell<LayoutRect>,
+    dialog_bounds: Cell<LayoutRect>,
     keybindings: KeyBindings,
     app_ctx: Arc<AppContext>,
 }
@@ -45,6 +46,12 @@ impl Component<TermWmAction> for WmHelpOverlayComponent {
         self.dialog.render_backdrop(backend, area, None);
         let ratatui_area = layout_rect_to_clipped_rect(area);
         let rect = self.dialog.rect_for(ratatui_area);
+        self.dialog_bounds.set(LayoutRect {
+            x: i32::from(rect.x),
+            y: i32::from(rect.y),
+            width: rect.width,
+            height: rect.height,
+        });
         {
             let backend = term_wm_ui_components::helpers::downcast_ratatui(backend);
             let buffer = &mut backend.buffer;
@@ -130,6 +137,15 @@ impl Overlay<TermWmAction> for WmHelpOverlayComponent {
         self
     }
 
+    fn render_area(&self) -> Option<LayoutRect> {
+        let bounds = self.dialog_bounds.get();
+        if bounds.width > 0 && bounds.height > 0 {
+            Some(bounds)
+        } else {
+            None
+        }
+    }
+
     fn shadow_rect(&self, area: LayoutRect) -> Option<LayoutRect> {
         if !self.dialog.visible() {
             return None;
@@ -157,6 +173,7 @@ impl WmHelpOverlayComponent {
             dialog,
             content: viewer,
             area: Cell::new(LayoutRect::default()),
+            dialog_bounds: Cell::new(LayoutRect::default()),
             keybindings,
             app_ctx: Arc::clone(app_ctx),
         };
@@ -173,11 +190,6 @@ impl WmHelpOverlayComponent {
             let focus_prev = kb.combos_for(TermWmAction::FocusPrev).join(" / ");
             let new_win = kb.combos_for(TermWmAction::NewWindow).join(" / ");
             let menu_nav = {
-                let a = kb.combos_for(TermWmAction::MenuNext).join(" / ");
-                let b = kb.combos_for(TermWmAction::MenuPrev).join(" / ");
-                format!("{a} / {b}")
-            };
-            let menu_alt = {
                 let a = kb.combos_for(TermWmAction::MenuUp).join(" / ");
                 let b = kb.combos_for(TermWmAction::MenuDown).join(" / ");
                 format!("{a} / {b}")
@@ -196,7 +208,6 @@ impl WmHelpOverlayComponent {
                 .replace("%FOCUS_PREV%", &focus_prev)
                 .replace("%NEW_WINDOW%", &new_win)
                 .replace("%MENU_NAV%", &menu_nav)
-                .replace("%MENU_ALT%", &menu_alt)
                 .replace("%MENU_SELECT%", &select)
                 .replace("%SUPER%", &super_key)
                 .replace("%HELP_MENU%", &help_label);
@@ -396,5 +407,59 @@ mod tests {
             !overlay.visible(),
             "overlay should be closed by outside click"
         );
+    }
+
+    #[test]
+    fn help_render_area_returns_none_before_render() {
+        let overlay = WmHelpOverlayComponent::new(
+            &Arc::new(AppContext::new("test", "0.0.0")),
+            KeyBindings::new(),
+        );
+        assert_eq!(
+            <WmHelpOverlayComponent as Overlay<TermWmAction>>::render_area(&overlay),
+            None
+        );
+    }
+
+    #[test]
+    fn help_render_area_returns_some_after_render() {
+        let mut overlay = WmHelpOverlayComponent::new(
+            &Arc::new(AppContext::new("test", "0.0.0")),
+            KeyBindings::new(),
+        );
+        overlay.dialog.set_visible(true);
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::prelude::Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::prelude::Rect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
+        );
+        let ctx = term_wm_core::components::ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        overlay.render(&mut backend, area, &ctx, &mut registry);
+
+        let bounds = <WmHelpOverlayComponent as Overlay<TermWmAction>>::render_area(&overlay);
+        assert!(
+            bounds.is_some(),
+            "dialog_bounds should be populated after render"
+        );
+        let bounds = bounds.unwrap();
+        assert!(bounds.width > 0);
+        assert!(bounds.height > 0);
     }
 }


### PR DESCRIPTION
overlays

Adds a generic spatial hit-test mechanism that dismisses overlays when the user clicks outside their bounds, routing the click to panels, window chrome, or activating the window underneath.

Overlay trait:
  - Add render_area() method returning the overlay's dialog bounds
  - Forward render_area() in impl_overlay_delegate! macro

HitboxRegistry:
  - Add hit_test_all(position) returning all entries at a position in Z-order (overlay entries first, then standard entries)

WindowManager:
  - Add handle_outside_click(col, row, event, actions, ignored_overlay) that inspects ALL hitboxes at the click position with priority:
    1. Layer components (panels, FAB) — dispatch event
    2. Overlays (non-ignored) — dispatch event
    3. Chrome (titlebar, buttons) — focus window via ChromeTarget
    4. Window body — focus window directly
  - Add command_palette_bounds(), help_overlay_bounds() accessors
  - Add help_key(), command_palette_key() public accessors
  - Parameterize stale overlay exclusion via ignored_overlay parameter

Runner:
  - Extract dispatch_action() as single authoritative action dispatcher
  - Refactor drain_action_queue() to delegate to dispatch_action()
  - Replace 60-line keybinding barrier match block with queue dispatch
  - Add command palette spatial barrier: outside-click → close + route
  - Add help overlay spatial barrier: same pattern

Overlay components:
  - WmCommandPaletteComponent: cache dialog_bounds, implement render_area()
  - WmHelpOverlayComponent: cache dialog_bounds, implement render_area()

Monocle panel overlays:
  - Register top/bottom panel outer hitboxes during render_overlays()
  - Populate bottom panel keybinding hints before overlay render

Tests: 32 new tests (27 unit + 5 integration)
  - hitbox_registry: hit_test_all order, empty, position filter
  - wm_command_palette: render_area before/after render
  - wm_help_overlay: render_area before/after render
  - WindowManager: handle_outside_click (all variants, key accessors, bounds delegation, stacked overlay exclusion)
  - Runner: dispatch_action (6 variants), drain_action_queue (2), keybinding barrier (2), toggle assertions (not no-crash)
  - Integration: overlay_dismissal.rs (bounds, outside/inside click, no-bounds fallthrough, stale key passthrough)