### PR TITLE
fix: Detect PTY child exit even when no subscriber is attached

### DIFF
--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -281,6 +281,7 @@ pub async fn run_server(
                     // output or exit state that needs processing.
                     guard.notify.notify_one();
 
+                    let is_dead = guard.session.is_none();
                     drop(guard);
 
                     if let Some(data) = snapshot
@@ -290,6 +291,9 @@ pub async fn run_server(
                     }
                     if let Some(data) = early {
                         respond.respond(data, false);
+                    }
+                    if is_dead {
+                        respond.respond(Vec::new(), true);
                     }
                 });
             }
@@ -333,9 +337,14 @@ pub async fn run_server(
             let mut guard = st.lock().await;
 
             if guard.subscribers.is_empty() {
+                let mut exited = false;
                 if let Some(session) = guard.session.as_mut() {
-                    // No subscribers — drain dirty flag to keep reader budget flowing
                     session.sync_screen();
+                    exited = session.check_exited();
+                }
+                if exited {
+                    tracing::info!("Session exited, tearing down");
+                    guard.session = None;
                 }
                 continue;
             }

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -191,12 +191,38 @@ impl Pty {
 
     /// Set a status callback invoked by the reader thread on data and exit.
     /// Uses `Arc<Mutex<>>` so the reader thread (which holds a clone) sees updates.
+    ///
+    /// If the child has already exited (reader thread detected EOF before the
+    /// callback was registered, or ConPTY swallowed the EOF), fires the callback
+    /// immediately so the async polling loop can process the exit state.
     pub fn set_status_callback(&mut self, cb: Option<Box<dyn Fn(PtyStatus) + Send + Sync>>) {
+        let mut fire_cb = None;
+
         if let Ok(mut guard) = self.status_cb.lock() {
-            *guard = cb;
+            if self.exited {
+                self.exited_emitted.store(true, Ordering::Release);
+                fire_cb = cb;
+                *guard = None;
+            } else if let Some(child) = self.child.as_mut()
+                && let Ok(Some(status)) = child.try_wait()
+            {
+                self.exited = true;
+                self.exit_status = Some(status);
+                self.child = None;
+                self.exited_emitted.store(true, Ordering::Release);
+                fire_cb = cb;
+                *guard = None;
+            } else {
+                *guard = cb;
+            }
         }
+
         if let Some(reader) = &self.reader {
             reader.thread().unpark();
+        }
+
+        if let Some(cb_fn) = fire_cb {
+            cb_fn(PtyStatus::Exited);
         }
     }
 
@@ -1120,6 +1146,85 @@ mod tests {
         assert_eq!(
             count_after_first, count_after_second,
             "has_exited() must not re-fire the Exited callback after returning true"
+        );
+    }
+
+    // ── set_status_callback with pre-exited child ────────────────────
+
+    #[test]
+    fn set_status_callback_fires_when_child_already_exited() {
+        let cmd = CommandBuilder::new(get_test_executable());
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        // Kill and reap the child process, consuming the latch via has_exited().
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+        for _ in 0..250 {
+            if pty.has_exited() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let exited_fired = Arc::new(AtomicBool::new(false));
+        let exited_cb = Arc::clone(&exited_fired);
+
+        // Register a new callback — must fire immediately (self.exited branch
+        // with latch reset).
+        pty.set_status_callback(Some(Box::new(move |status| {
+            if status == PtyStatus::Exited {
+                exited_cb.store(true, Ordering::Relaxed);
+            }
+        })));
+
+        assert!(
+            exited_fired.load(Ordering::Relaxed),
+            "set_status_callback must fire PtyStatus::Exited when child already exited"
+        );
+    }
+
+    #[test]
+    fn set_status_callback_fires_via_try_wait_after_direct_kill() {
+        let cmd = CommandBuilder::new(get_test_executable());
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        // Kill the child but do NOT call has_exited() — let the try_wait()
+        // path in set_status_callback detect the exit.
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+        for _ in 0..250 {
+            if let Some(Ok(Some(_))) = pty.child.as_mut().map(|c| c.try_wait()) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let exited_fired = Arc::new(AtomicBool::new(false));
+        let exited_cb = Arc::clone(&exited_fired);
+
+        pty.set_status_callback(Some(Box::new(move |status| {
+            if status == PtyStatus::Exited {
+                exited_cb.store(true, Ordering::Relaxed);
+            }
+        })));
+
+        assert!(
+            exited_fired.load(Ordering::Relaxed),
+            "set_status_callback must fire PtyStatus::Exited via try_wait() when child killed"
         );
     }
 

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -263,6 +263,40 @@ async fn session_child_exit() {
     assert!(got_end, "Stream should end when child exits");
 }
 
+// Note: [serial] was added due to some Windows flakiness
+#[tokio::test]
+#[serial]
+async fn session_child_exit_before_subscribe() {
+    let mock = get_mock_bin();
+    let (client, _dir) =
+        spawn_session(vec![mock, "exit".into(), "0".into()], TEST_COLS, TEST_ROWS).await;
+
+    // Give the server time to detect child exit and tear down the session
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    let mut got_end = false;
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(3) {
+        match tokio::time::timeout(Duration::from_millis(500), reader.recv()).await {
+            Ok(None) => {
+                got_end = true;
+                break;
+            }
+            Ok(Some(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(
+        got_end,
+        "Should get end-of-stream when subscribing after child exit"
+    );
+}
+
 #[tokio::test]
 async fn session_reconnect() {
     let mock = get_mock_bin();


### PR DESCRIPTION
The session server's polling loop only called session.check_exited() when
subscribers existed, so a child exiting before any subscriber attached left
the polling loop blocked on notify.notified() forever.
- set_status_callback() now checks child.try_wait() at registration time and immediately fires PtyStatus::Exited if the child already exited
- Polling loop now calls check_exited() in the no-subscriber path and tears down the session (guard.session = None) when detected
- SubscribeOutput handler sends an immediate end-of-stream marker when a subscriber attaches to a session that was already torn down
- Added unit tests for both set_status_callback code paths
- Added integration test for subscribing after child exit