### PR TITLE
feat: Make menu icons searchable in Command Palette

### DIFF
--- a/crates/term-wm-core/src/command_menu/matcher.rs
+++ b/crates/term-wm-core/src/command_menu/matcher.rs
@@ -25,9 +25,11 @@ impl FuzzyMatch {
         }
     }
 
-    /// Score a list of (name, description, disabled) triples against a query string.
+    /// Score a list of (name, description, searchable_text, disabled) tuples
+    /// against a query string.  `searchable_text` is a precomputed string that
+    /// includes both the display name and icon text so both are fuzzy-matchable.
     /// Returns indices into the input slice, sorted by score descending.
-    pub fn score(&mut self, query: &str, items: &[(String, String, bool)]) -> Vec<usize> {
+    pub fn score(&mut self, query: &str, items: &[(String, String, String, bool)]) -> Vec<usize> {
         if query.is_empty() {
             return (0..items.len()).collect();
         }
@@ -47,13 +49,13 @@ impl FuzzyMatch {
         let mut scored: Vec<(u32, usize)> = items
             .iter()
             .enumerate()
-            .filter_map(|(i, (name, _desc, _disabled))| {
+            .filter_map(|(i, (_name, _desc, searchable_text, _disabled))| {
                 // Clear the buffer before use. Utf32Str::new appends to the
                 // buffer for non-ASCII strings. Without this, the buffer grows
                 // indefinitely until it breaches nucleo's max haystack length
                 // and returns None.
                 self.char_buf.clear();
-                let haystack = Utf32Str::new(name, &mut self.char_buf);
+                let haystack = Utf32Str::new(searchable_text, &mut self.char_buf);
                 let score = pattern.score(haystack, &mut self.matcher);
                 score.map(|s| (s, i))
             })
@@ -125,8 +127,18 @@ mod tests {
     fn fuzzy_empty_query_returns_all() {
         let mut fmatch = FuzzyMatch::new();
         let items = vec![
-            ("New Window".to_string(), String::new(), false),
-            ("Close Window".to_string(), String::new(), false),
+            (
+                "New Window".to_string(),
+                String::new(),
+                "New Window".to_string(),
+                false,
+            ),
+            (
+                "Close Window".to_string(),
+                String::new(),
+                "Close Window".to_string(),
+                false,
+            ),
         ];
         let results = fmatch.score("", &items);
         assert_eq!(results, vec![0, 1]);
@@ -136,8 +148,18 @@ mod tests {
     fn fuzzy_matching_prefix() {
         let mut fmatch = FuzzyMatch::new();
         let items = vec![
-            ("New Window".to_string(), String::new(), false),
-            ("Close Window".to_string(), String::new(), false),
+            (
+                "New Window".to_string(),
+                String::new(),
+                "New Window".to_string(),
+                false,
+            ),
+            (
+                "Close Window".to_string(),
+                String::new(),
+                "Close Window".to_string(),
+                false,
+            ),
         ];
         let results = fmatch.score("new", &items);
         assert_eq!(results.len(), 1);
@@ -148,8 +170,18 @@ mod tests {
     fn fuzzy_no_match_returns_empty() {
         let mut fmatch = FuzzyMatch::new();
         let items = vec![
-            ("New Window".to_string(), String::new(), false),
-            ("Close Window".to_string(), String::new(), false),
+            (
+                "New Window".to_string(),
+                String::new(),
+                "New Window".to_string(),
+                false,
+            ),
+            (
+                "Close Window".to_string(),
+                String::new(),
+                "Close Window".to_string(),
+                false,
+            ),
         ];
         let results = fmatch.score("zzzzz", &items);
         assert!(results.is_empty());
@@ -162,8 +194,18 @@ mod tests {
     fn fuzzy_multiple_successive_scores() {
         let mut fmatch = FuzzyMatch::new();
         let items = vec![
-            ("New Window".to_string(), String::new(), false),
-            ("Close Window".to_string(), String::new(), false),
+            (
+                "New Window".to_string(),
+                String::new(),
+                "New Window".to_string(),
+                false,
+            ),
+            (
+                "Close Window".to_string(),
+                String::new(),
+                "Close Window".to_string(),
+                false,
+            ),
         ];
 
         // Empty query → all items
@@ -196,8 +238,18 @@ mod tests {
     fn fuzzy_case_and_multi_char() {
         let mut fmatch = FuzzyMatch::new();
         let items = vec![
-            ("Resume".to_string(), String::new(), false),
-            ("Exit UI".to_string(), String::new(), false),
+            (
+                "Resume".to_string(),
+                String::new(),
+                "Resume".to_string(),
+                false,
+            ),
+            (
+                "Exit UI".to_string(),
+                String::new(),
+                "Exit UI".to_string(),
+                false,
+            ),
         ];
 
         // All queries are case-insensitive with CaseMatching::Ignore
@@ -224,6 +276,62 @@ mod tests {
         let r5 = fmatch.score("Res", &items);
         assert_eq!(r5.len(), 1, "'Res' should match 'Resume'");
         assert_eq!(r5[0], 0);
+    }
+
+    #[test]
+    fn test_icon_searchability() {
+        let mut matcher = FuzzyMatch::new();
+
+        let items = vec![
+            (
+                "Toggle System Panel".into(),
+                "Show or hide the system panel".into(),
+                "* Toggle System Panel".into(),
+                false,
+            ),
+            (
+                "New Tab".into(),
+                "Open a new terminal tab".into(),
+                "+ New Tab".into(),
+                false,
+            ),
+            (
+                "Close Tab".into(),
+                "Close the current tab".into(),
+                "x Close Tab".into(),
+                false,
+            ),
+            (
+                "No Icon Command".into(),
+                "A command without an icon".into(),
+                "No Icon Command".into(),
+                false,
+            ),
+        ];
+
+        let results = matcher.score("*", &items);
+        assert_eq!(results.len(), 1, "'*' should match exactly one item");
+        assert_eq!(results[0], 0, "'*' should match 'Toggle System Panel'");
+
+        let results = matcher.score("+", &items);
+        assert_eq!(results.len(), 1, "'+' should match exactly one item");
+        assert_eq!(results[0], 1, "'+' should match 'New Tab'");
+
+        let results = matcher.score("* sys", &items);
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0], 0,
+            "combined '* sys' should match 'Toggle System Panel'"
+        );
+
+        let results = matcher.score("Tab", &items);
+        assert_eq!(
+            results.len(),
+            2,
+            "'Tab' should match both commands containing 'Tab'"
+        );
+        assert!(results.contains(&1));
+        assert!(results.contains(&2));
     }
 
     #[test]

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2628,7 +2628,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             },
             MenuItem {
                 label: "Toggle System Panel".into(),
-                icon: Some("⚙"),
+                icon: Some("*"),
                 action: crate::actions::TermWmAction::ToggleSystemPanel,
                 disabled: false,
             },

--- a/crates/term-wm-ui-components/src/command_palette.rs
+++ b/crates/term-wm-ui-components/src/command_palette.rs
@@ -41,7 +41,7 @@ pub struct CommandPaletteComponent {
     pub query_dirty: bool,
     pub current_context_mask: ContextMask,
     active_ids: Vec<CommandNodeId>,
-    display_items: Vec<(String, String, bool)>,
+    display_items: Vec<(String, String, String, bool)>,
     nav_keys: KeyBindings,
     list_scroll: ScrollViewComponent<MenuComponent>,
     last_list_area: LayoutRect,
@@ -108,7 +108,13 @@ impl CommandPaletteComponent {
                 let node = registry.get(*id)?;
                 let display_name = node.name.format(self.current_context_mask);
                 let desc = node.description.clone().unwrap_or_default();
-                Some((display_name, desc, node.disabled))
+                let icon_text = node.icon.unwrap_or("");
+                let searchable_text = if icon_text.is_empty() {
+                    display_name.clone()
+                } else {
+                    format!("{} {}", icon_text, display_name)
+                };
+                Some((display_name, desc, searchable_text, node.disabled))
             })
             .collect();
         self.data_dirty = false;
@@ -121,7 +127,7 @@ impl CommandPaletteComponent {
             .iter()
             .filter_map(|&i| {
                 let id = self.active_ids.get(i)?;
-                let (display_name, description, is_disabled) = self.display_items.get(i)?;
+                let (display_name, description, _, is_disabled) = self.display_items.get(i)?;
                 let node_ref = self.registry_getter_placeholder(*id, display_name, description);
                 Some(PaletteItem {
                     stable_id: node_ref.0,
@@ -205,7 +211,7 @@ impl CommandPaletteComponent {
             .iter()
             .filter_map(|&i| {
                 let id = *self.active_ids.get(i)?;
-                let (ref display_name, ref desc, _disabled) = self.display_items[i];
+                let (ref display_name, ref desc, _, _disabled) = self.display_items[i];
                 let data = Self::extract_palette_data(id, display_name, desc, registry)?;
                 Some(PaletteItem {
                     stable_id: data.0,
@@ -778,5 +784,28 @@ mod tests {
         assert!(!palette.filtered_items[0].disabled);
         assert!(palette.filtered_items[1].disabled);
         assert!(!palette.filtered_items[2].disabled);
+    }
+
+    #[test]
+    fn test_searchable_text_generation() {
+        let display_name = "System Panel";
+        let icon_text = "*";
+
+        let searchable_text = if icon_text.is_empty() {
+            display_name.to_string()
+        } else {
+            format!("{} {}", icon_text, display_name)
+        };
+
+        assert_eq!(searchable_text, "* System Panel");
+
+        let no_icon = "";
+        let searchable_text_empty = if no_icon.is_empty() {
+            display_name.to_string()
+        } else {
+            format!("{} {}", no_icon, display_name)
+        };
+
+        assert_eq!(searchable_text_empty, "System Panel");
     }
 }


### PR DESCRIPTION
Extend `FuzzyMatch::score` to accept a 4-tuple `(name, desc,
searchable_text, disabled)` where `searchable_text` is a precomputed
string of `"{icon} {name}"`.  The hot matching loop reads this field
directly — zero allocations per keystroke.

`rebuild_data_cache` precomputes `searchable_text` once per item,
concatenating the node's icon (if present) with the display name.

Add `test_icon_searchability` covering icon-only queries (`*`, `+`),
combined icon+text (`* sys`), and normal text fallback (`Tab`).
Add `test_searchable_text_generation` covering the formatting logic
with and without an icon.