### PR TITLE
Refactor command palette: separator support, TypeId registry, auto-scroll, group reorder

### DIFF
--- a/crates/term-wm-core/src/components.rs
+++ b/crates/term-wm-core/src/components.rs
@@ -280,7 +280,7 @@ pub trait Overlay<Msg>: Component<Msg> + std::any::Any {
     /// Mark internal state as needing a rebuild (e.g. after a focus change).
     fn mark_dirty(&mut self) {}
     /// Replace the overlay's menu items (e.g. on focus change).
-    fn set_menu_items(&mut self, _items: Vec<MenuItem<Msg>>) {}
+    fn set_menu_items(&mut self, _items: Vec<MenuDisplayItem<Msg>>) {}
     /// Enter/exit tab outline mode (palette becomes dim overlay, panels hide).
     fn set_tab_outline(&mut self, _expires_at: Option<std::time::Instant>) {}
 }
@@ -526,6 +526,12 @@ pub struct MenuItem<R> {
     pub label: Cow<'static, str>,
     pub action: R,
     pub disabled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum MenuDisplayItem<R> {
+    Item(MenuItem<R>),
+    Separator,
 }
 
 /// Actions the engine broadcasts to components.

--- a/crates/term-wm-core/src/macros.rs
+++ b/crates/term-wm-core/src/macros.rs
@@ -238,7 +238,7 @@ macro_rules! impl_overlay_delegate {
             fn mark_dirty(&mut self) {
                 match self { $(Self::$variant(c) => c.mark_dirty(),)* }
             }
-            fn set_menu_items(&mut self, items: Vec<$crate::components::MenuItem<$crate::actions::TermWmAction>>) {
+            fn set_menu_items(&mut self, items: Vec<$crate::components::MenuDisplayItem<$crate::actions::TermWmAction>>) {
                 match self { $(Self::$variant(c) => c.set_menu_items(items),)* }
             }
             fn set_tab_outline(&mut self, expires_at: Option<std::time::Instant>) {

--- a/crates/term-wm-core/src/window/mod.rs
+++ b/crates/term-wm-core/src/window/mod.rs
@@ -1,7 +1,7 @@
 pub mod decorator;
 mod entry;
 pub mod test_component;
-mod window_manager;
+pub mod window_manager;
 
 use crate::Rect;
 use term_wm_layout_engine::{LayoutRect, RectSpec};

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -65,24 +65,30 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         if !self.command_menu_visible() {
             return;
         }
-        let Some(palette_key) = self.command_palette_key else {
+        let Some(palette_key) =
+            self.get_overlay::<crate::window::window_manager::system_tags::CommandPalette>()
+        else {
             return;
         };
 
         // Build fresh items BEFORE accessing the overlay (borrow checker).
+        use crate::components::MenuDisplayItem;
         let items = self.wm_menu_items();
         let supported = &self.supported_menu_actions;
-        let filtered: Vec<_> = items
+        let filtered: Vec<MenuDisplayItem<crate::actions::TermWmAction>> = items
             .into_iter()
-            .filter(|item| {
-                supported.contains(&item.action)
-                    || matches!(
-                        item.action,
-                        crate::actions::TermWmAction::FocusWindow(_)
-                            | crate::actions::TermWmAction::MaximizeWindow(_)
-                            | crate::actions::TermWmAction::MinimizeWindow(_)
-                            | crate::actions::TermWmAction::CloseWindow(_)
-                    )
+            .filter(|entry| match entry {
+                MenuDisplayItem::Item(item) => {
+                    supported.contains(&item.action)
+                        || matches!(
+                            item.action,
+                            crate::actions::TermWmAction::FocusWindow(_)
+                                | crate::actions::TermWmAction::MaximizeWindow(_)
+                                | crate::actions::TermWmAction::MinimizeWindow(_)
+                                | crate::actions::TermWmAction::CloseWindow(_)
+                        )
+                }
+                MenuDisplayItem::Separator => true,
             })
             .collect();
 

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -6,11 +6,21 @@ pub(crate) mod layer_manager;
 mod layout;
 mod overlays;
 
+use std::any::TypeId;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 
 use crate::window::entry;
 use std::time::{Duration, Instant};
+
+/// Marker types for strongly-typed system window and overlay resolution.
+pub mod system_tags {
+    pub struct DebugLog;
+    pub struct SystemPanel;
+    pub struct CommandPalette;
+    pub struct HelpOverlay;
+    pub struct ExitConfirm;
+}
 
 use crate::Rect;
 use crate::events::{Event, MouseEvent, MouseEventKind};
@@ -22,9 +32,7 @@ use super::WindowKey;
 use super::entry::{Window, WindowState};
 use crate::actions::{EventResult, SystemTask, TermWmAction};
 use crate::app_context::AppContext;
-use crate::components::{
-    Component, ComponentAction, ComponentContext, MenuItem, Overlay, WmComponent,
-};
+use crate::components::{Component, ComponentAction, ComponentContext, Overlay, WmComponent};
 use crate::hitbox_registry::{ComponentOwner, HitboxRegistry};
 use crate::keybindings::KeyBindings;
 use crate::layout::floating::*;
@@ -260,6 +268,15 @@ impl MonocleMode {
             MonocleMode::Off => "Off",
         }
     }
+
+    /// Action-oriented label for the command palette — describes what clicking will do.
+    pub fn action_label(self) -> &'static str {
+        match self {
+            MonocleMode::Auto => "Enable Monocle Mode",
+            MonocleMode::On => "Disable Monocle Mode",
+            MonocleMode::Off => "Set Monocle Mode Auto",
+        }
+    }
 }
 
 pub struct WindowManager<
@@ -317,9 +334,9 @@ pub struct WindowManager<
     system_task_handle: Option<TaskHandle<SystemTask>>,
     pub(crate) last_frame_area: LayoutRect,
     overlays: SlotMap<OverlayKey, O>,
-    help_key: Option<OverlayKey>,
-    exit_confirm_key: Option<OverlayKey>,
-    command_palette_key: Option<OverlayKey>,
+    /// TypeId-keyed registries for strongly-typed system window/overlay resolution.
+    pub system_windows: HashMap<TypeId, WindowKey>,
+    pub system_overlays: HashMap<TypeId, OverlayKey>,
     /// When `Some(instant)`, tab outline mode is active until that instant.
     pub(crate) tab_outline_until: Option<Instant>,
     /// Tracks last cell coordinate passed to `update_snap_preview` for
@@ -808,15 +825,32 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             notification_queue: NotificationQueue::default(),
             semantic_registry,
             overlays: SlotMap::with_key(),
-            help_key: None,
-            exit_confirm_key: None,
-            command_palette_key: None,
+            system_windows: HashMap::new(),
+            system_overlays: HashMap::new(),
             tab_outline_until: None,
             last_snap_cursor: None,
             input_mode: crate::actions::WmInputMode::Passthrough,
             fab_enabled: true,
             tap_swap_state: None,
         }
+    }
+
+    // === TypeId registry accessors ===
+
+    pub fn register_system_window<T: 'static>(&mut self, key: WindowKey) {
+        self.system_windows.insert(TypeId::of::<T>(), key);
+    }
+
+    pub fn get_system_window<T: 'static>(&self) -> Option<WindowKey> {
+        self.system_windows.get(&TypeId::of::<T>()).copied()
+    }
+
+    pub fn register_overlay<T: 'static>(&mut self, key: OverlayKey) {
+        self.system_overlays.insert(TypeId::of::<T>(), key);
+    }
+
+    pub fn get_overlay<T: 'static>(&self) -> Option<OverlayKey> {
+        self.system_overlays.get(&TypeId::of::<T>()).copied()
     }
 
     /// Request a clean shutdown on the next idle tick.
@@ -2211,16 +2245,19 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     pub fn open_help_overlay(&mut self, overlay: O) {
-        self.help_key = Some(self.overlays.insert(overlay));
+        let key = self.overlays.insert(overlay);
+        self.register_overlay::<system_tags::HelpOverlay>(key);
         self.input_mode = crate::actions::WmInputMode::Help;
     }
 
     pub fn open_exit_confirm_overlay(&mut self, overlay: O) {
-        self.exit_confirm_key = Some(self.overlays.insert(overlay));
+        let key = self.overlays.insert(overlay);
+        self.register_overlay::<system_tags::ExitConfirm>(key);
     }
 
     pub fn open_command_palette_overlay(&mut self, overlay: O) {
-        self.command_palette_key = Some(self.overlays.insert(overlay));
+        let key = self.overlays.insert(overlay);
+        self.register_overlay::<system_tags::CommandPalette>(key);
         self.input_mode = crate::actions::WmInputMode::CommandPalette;
     }
 
@@ -2232,7 +2269,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     pub fn set_tab_outline_mode(&mut self, duration: Duration) {
         let expires = Instant::now() + duration;
         self.tab_outline_until = Some(expires);
-        if let Some(key) = self.command_palette_key
+        if let Some(key) = self.get_overlay::<system_tags::CommandPalette>()
             && let Some(overlay) = self.overlays.get_mut(key)
         {
             overlay.set_tab_outline(Some(expires));
@@ -2245,7 +2282,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Clear tab outline mode — restore palette/panels to normal.
     pub fn clear_tab_outline(&mut self) {
         self.tab_outline_until = None;
-        if let Some(key) = self.command_palette_key
+        if let Some(key) = self.get_overlay::<system_tags::CommandPalette>()
             && let Some(overlay) = self.overlays.get_mut(key)
         {
             overlay.set_tab_outline(None);
@@ -2573,120 +2610,156 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         btns
     }
 
-    pub fn wm_menu_items(&self) -> Vec<MenuItem<crate::actions::TermWmAction>> {
+    pub fn wm_menu_items(
+        &self,
+    ) -> Vec<crate::components::MenuDisplayItem<crate::actions::TermWmAction>> {
+        use crate::components::{MenuDisplayItem, MenuItem};
+        use crate::window::WindowState;
+        use crate::window::window_manager::system_tags;
+
+        let debug_log_visible = self
+            .get_system_window::<system_tags::DebugLog>()
+            .is_some_and(|k| self.window_state(k) == Some(WindowState::Mapped));
+        let system_panel_visible = self
+            .get_system_window::<system_tags::SystemPanel>()
+            .is_some_and(|k| self.window_state(k) == Some(WindowState::Mapped));
+
         let mouse_label = if self.mouse_capture_enabled {
-            "Mouse Capture: On"
+            "Mouse: Disable Capture"
         } else {
-            "Mouse Capture: Off"
+            "Mouse: Enable Capture"
         };
         let clipboard_label = if self.clipboard_enabled {
-            "Clipboard Mode: On"
+            "Clipboard: Disable"
         } else {
-            "Clipboard Mode: Off"
+            "Clipboard: Enable"
         };
         let selection_label = if self.window_selection_enabled {
-            "Window Selection: On"
+            "Clipboard: Disable Selection"
         } else {
-            "Window Selection: Off"
+            "Clipboard: Enable Selection"
         };
-        let mut items = vec![
-            MenuItem {
-                label: "Resume".into(),
-                icon: Some("▶"),
-                action: crate::actions::TermWmAction::CloseMenu,
+        let debug_label = if debug_log_visible {
+            "System: Disable Debug Log"
+        } else {
+            "System: Enable Debug Log"
+        };
+        let panel_label = if system_panel_visible {
+            "System: Disable Panel"
+        } else {
+            "System: Enable Panel"
+        };
+
+        fn mi(
+            label: &'static str,
+            icon: Option<&'static str>,
+            action: crate::actions::TermWmAction,
+        ) -> MenuDisplayItem<crate::actions::TermWmAction> {
+            MenuDisplayItem::Item(MenuItem {
+                label: label.into(),
+                icon,
+                action,
                 disabled: false,
-            },
-            MenuItem {
-                label: "New Window".into(),
-                icon: Some("+"),
-                action: crate::actions::TermWmAction::NewWindow,
-                disabled: false,
-            },
-            MenuItem {
-                label: mouse_label.into(),
-                icon: Some("◆"),
-                action: crate::actions::TermWmAction::ToggleMouseCapture,
-                disabled: false,
-            },
-            MenuItem {
-                label: clipboard_label.into(),
-                icon: Some("■"),
-                action: crate::actions::TermWmAction::ToggleClipboardMode,
-                disabled: false,
-            },
-            MenuItem {
-                label: selection_label.into(),
-                icon: Some("●"),
-                action: crate::actions::TermWmAction::ToggleWindowSelection,
-                disabled: false,
-            },
-            MenuItem {
-                label: "Toggle Debug Log".into(),
-                icon: Some("≣"),
-                action: crate::actions::TermWmAction::ToggleDebugWindow,
-                disabled: false,
-            },
-            MenuItem {
-                label: "Toggle System Panel".into(),
-                icon: Some("*"),
-                action: crate::actions::TermWmAction::ToggleSystemPanel,
-                disabled: false,
-            },
-            MenuItem {
-                label: "Help".into(),
-                icon: Some("?"),
-                action: crate::actions::TermWmAction::Help,
-                disabled: false,
-            },
-            MenuItem {
-                label: "Exit UI".into(),
-                icon: Some("⏻"),
-                action: crate::actions::TermWmAction::ExitUi,
-                disabled: false,
-            },
-            MenuItem {
-                label: format!("Monocle Mode: {}", self.monocle_mode.label()).into(),
-                icon: Some("▢"),
-                action: crate::actions::TermWmAction::ToggleMonocle,
-                disabled: false,
-            },
-            MenuItem {
-                label: {
-                    let mode = if self.managed_layout.is_some() {
-                        "Float"
-                    } else {
-                        "Tile"
-                    };
-                    format!("Toggle {mode} Mode").into()
-                },
-                icon: Some("⊞"),
-                action: crate::actions::TermWmAction::ToggleTiling,
-                disabled: self.is_monocle(),
-            },
-        ];
+            })
+        }
 
         let focused = self.focused_window();
         let has_active = self.windows.contains_key(focused);
 
-        if has_active {
-            // Window management buttons from centralized list
-            for btn in self.window_management_buttons() {
-                items.push(MenuItem {
-                    label: btn.label.into(),
-                    icon: Some(btn.symbol),
-                    action: btn.action,
-                    disabled: false,
-                });
+        let mut items: Vec<MenuDisplayItem<crate::actions::TermWmAction>> = vec![
+            // Top group
+            mi("Resume", Some("▶"), crate::actions::TermWmAction::CloseMenu),
+            mi(
+                "New Window",
+                Some("+"),
+                crate::actions::TermWmAction::NewWindow,
+            ),
+            MenuDisplayItem::Separator,
+        ];
+
+        // Window management group (directly below top group)
+        {
+            if has_active {
+                for btn in self.window_management_buttons() {
+                    items.push(MenuDisplayItem::Item(MenuItem {
+                        label: btn.label.into(),
+                        icon: Some(btn.symbol),
+                        action: btn.action,
+                        disabled: false,
+                    }));
+                }
+                for (key, title) in self.window_titles() {
+                    items.push(MenuDisplayItem::Item(MenuItem {
+                        label: format!("Switch to: {}", title).into(),
+                        icon: Some("→"),
+                        action: crate::actions::TermWmAction::FocusWindow(key),
+                        disabled: key == focused,
+                    }));
+                }
             }
-            // Switch-to navigation for all windows
-            for (key, title) in self.window_titles() {
-                items.push(MenuItem {
-                    label: format!("Switch to: {}", title).into(),
-                    icon: Some("→"),
-                    action: crate::actions::TermWmAction::FocusWindow(key),
-                    disabled: key == focused,
-                });
+        }
+
+        // View group
+        {
+            items.push(MenuDisplayItem::Separator);
+            items.push(mi(
+                self.monocle_mode.action_label(),
+                Some("▢"),
+                crate::actions::TermWmAction::ToggleMonocle,
+            ));
+            {
+                let label = if self.managed_layout.is_some() {
+                    "View: Enable Tiling"
+                } else {
+                    "View: Disable Tiling"
+                };
+                let mut item = mi(label, Some("⊞"), crate::actions::TermWmAction::ToggleTiling);
+                if self.is_monocle()
+                    && let MenuDisplayItem::Item(ref mut mi) = item
+                {
+                    mi.disabled = true;
+                }
+                items.push(item);
             }
+        }
+
+        // Settings group
+        {
+            items.push(MenuDisplayItem::Separator);
+            items.push(mi(
+                mouse_label,
+                Some("◆"),
+                crate::actions::TermWmAction::ToggleMouseCapture,
+            ));
+            items.push(mi(
+                clipboard_label,
+                Some("■"),
+                crate::actions::TermWmAction::ToggleClipboardMode,
+            ));
+            items.push(mi(
+                selection_label,
+                Some("●"),
+                crate::actions::TermWmAction::ToggleWindowSelection,
+            ));
+            items.push(mi(
+                debug_label,
+                Some("≣"),
+                crate::actions::TermWmAction::ToggleDebugWindow,
+            ));
+            items.push(mi(
+                panel_label,
+                Some("*"),
+                crate::actions::TermWmAction::ToggleSystemPanel,
+            ));
+
+            // Help/Exit as last group
+            items.push(MenuDisplayItem::Separator);
+            items.push(mi("Help", Some("?"), crate::actions::TermWmAction::Help));
+            items.push(mi(
+                "Exit UI",
+                Some("⏻"),
+                crate::actions::TermWmAction::ExitUi,
+            ));
         }
 
         items

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2709,9 +2709,9 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             ));
             {
                 let label = if self.managed_layout.is_some() {
-                    "View: Enable Tiling"
+                    "View: Float Windows"
                 } else {
-                    "View: Disable Tiling"
+                    "View: Tile Windows"
                 };
                 let mut item = mi(label, Some("⊞"), crate::actions::TermWmAction::ToggleTiling);
                 if self.is_monocle()

--- a/crates/term-wm-core/src/window/window_manager/overlays.rs
+++ b/crates/term-wm-core/src/window/window_manager/overlays.rs
@@ -1,46 +1,56 @@
+use std::any::TypeId;
+
 use crate::components::{Component, Overlay, WmComponent};
 use crate::events::Event;
 use term_wm_layout_engine::LayoutRect;
 
 use super::{OverlayKey, WindowManager};
 use crate::actions::{ConfirmAction, EventResult, TermWmAction};
+use crate::window::window_manager::system_tags;
 
 impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> WindowManager<C, L, O> {
     pub fn close_exit_confirm(&mut self) {
-        if let Some(key) = self.exit_confirm_key.take() {
+        if let Some(key) = self
+            .system_overlays
+            .remove(&TypeId::of::<system_tags::ExitConfirm>())
+        {
             self.overlays.remove(key);
         }
     }
 
     pub fn exit_confirm_visible(&self) -> bool {
-        self.exit_confirm_key.is_some()
+        self.system_overlays
+            .contains_key(&TypeId::of::<system_tags::ExitConfirm>())
     }
 
     pub fn help_overlay_visible(&self) -> bool {
-        self.help_key.is_some()
+        self.system_overlays
+            .contains_key(&TypeId::of::<system_tags::HelpOverlay>())
     }
 
     pub fn help_key(&self) -> Option<OverlayKey> {
-        self.help_key
+        self.get_overlay::<system_tags::HelpOverlay>()
     }
 
     pub fn command_palette_key(&self) -> Option<OverlayKey> {
-        self.command_palette_key
+        self.get_overlay::<system_tags::CommandPalette>()
     }
 
     pub fn close_help_overlay(&mut self) {
-        if let Some(key) = self.help_key.take() {
+        if let Some(key) = self
+            .system_overlays
+            .remove(&TypeId::of::<system_tags::HelpOverlay>())
+        {
             self.overlays.remove(key);
         }
         self.input_mode = crate::actions::WmInputMode::Passthrough;
     }
 
-    // TODO: Drag handling/clipboard selection, etc. should be moved into the component
     pub fn handle_help_event(&mut self, event: &Event) -> bool {
         if let Event::Mouse(mouse) = event {
             self.hover = Some((mouse.column, mouse.row));
         }
-        let Some(key) = self.help_key else {
+        let Some(key) = self.get_overlay::<system_tags::HelpOverlay>() else {
             return false;
         };
         let ctx = self
@@ -85,35 +95,38 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             self.hover = Some((mouse.column, mouse.row));
         }
         self.overlays
-            .get_mut(self.exit_confirm_key?)?
+            .get_mut(self.get_overlay::<system_tags::ExitConfirm>()?)?
             .handle_confirm_event(event)
     }
 
     pub fn command_palette_visible(&self) -> bool {
-        self.command_palette_key.is_some()
+        self.system_overlays
+            .contains_key(&TypeId::of::<system_tags::CommandPalette>())
     }
 
     pub fn command_palette_bounds(&self) -> Option<LayoutRect> {
-        self.command_palette_key
+        self.get_overlay::<system_tags::CommandPalette>()
             .and_then(|key| self.overlays.get(key))
             .and_then(|o| o.render_area())
     }
 
     pub fn help_overlay_bounds(&self) -> Option<LayoutRect> {
-        self.help_key
+        self.get_overlay::<system_tags::HelpOverlay>()
             .and_then(|key| self.overlays.get(key))
             .and_then(|o| o.render_area())
     }
 
     pub fn close_command_palette(&mut self) {
-        if let Some(key) = self.command_palette_key.take() {
+        if let Some(key) = self
+            .system_overlays
+            .remove(&TypeId::of::<system_tags::CommandPalette>())
+        {
             self.overlays.remove(key);
         }
         self.input_mode = crate::actions::WmInputMode::Passthrough;
     }
 
     pub fn handle_command_palette_event(&mut self, event: &Event) -> Option<TermWmAction> {
-        // Build context BEFORE mutable borrow of overlays
         if let Event::Mouse(mouse) = event {
             self.hover = Some((mouse.column, mouse.row));
         }
@@ -123,9 +136,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .with_screen_area(self.managed_area())
             .with_hover_pos(self.hover);
 
-        let key = self.command_palette_key?;
+        let key = self.get_overlay::<system_tags::CommandPalette>()?;
         let palette = self.overlays.get_mut(key)?;
-        // handle_events is on Component (supertrait of Overlay)
         match palette.handle_events(event, &ctx) {
             EventResult::Action(action) => {
                 self.close_command_palette();

--- a/crates/term-wm-sys-ui-components/src/wm_command_palette.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_command_palette.rs
@@ -10,8 +10,8 @@ use term_wm_core::{
     actions::{EventResult, TermWmAction},
     command_menu::{CommandRegistry, ContextMask, FuzzyMatch, MruRanker},
     components::{
-        Component, ComponentAction, ComponentContext, ComponentQuery, ComponentResponse, MenuItem,
-        Overlay, WmComponent,
+        Component, ComponentAction, ComponentContext, ComponentQuery, ComponentResponse,
+        MenuDisplayItem, Overlay, WmComponent,
     },
     hitbox_registry::HitboxId,
     window::WindowKey,
@@ -79,23 +79,39 @@ impl WmCommandPaletteComponent {
         self.dialog.set_visible(false);
     }
 
-    pub fn set_items(&mut self, items: Vec<term_wm_core::components::MenuItem<TermWmAction>>) {
-        self.registry = CommandRegistry::new();
+    pub fn set_items(
+        &mut self,
+        items: Vec<term_wm_core::components::MenuDisplayItem<TermWmAction>>,
+    ) {
         use term_wm_core::command_menu::{CommandAction, CommandName, CommandNode, ContextMask};
-        for item in items {
-            let stable_id = format!("core:{}", item.label.replace(' ', "_").to_lowercase());
-            let node = CommandNode {
-                stable_id,
-                name: CommandName::Static(item.label.to_string()),
-                description: None,
-                action: CommandAction::AppAction(item.action),
-                icon: item.icon,
-                required_context: ContextMask::NONE,
-                owner_id: None,
-                disabled: item.disabled,
-            };
-            self.registry.register(node);
+        use term_wm_core::components::MenuDisplayItem;
+        self.registry = CommandRegistry::new();
+        let mut active_nodes = Vec::new();
+        for display_item in items {
+            match display_item {
+                MenuDisplayItem::Item(item) => {
+                    let stable_id = format!("core:{}", item.label.replace(' ', "_").to_lowercase());
+                    let node = CommandNode {
+                        stable_id,
+                        name: CommandName::Static(item.label.to_string()),
+                        description: None,
+                        action: CommandAction::AppAction(item.action),
+                        icon: item.icon,
+                        required_context: ContextMask::NONE,
+                        owner_id: None,
+                        disabled: item.disabled,
+                    };
+                    let id = self.registry.register(node);
+                    active_nodes
+                        .push(term_wm_ui_components::command_palette::ActivePaletteNode::Node(id));
+                }
+                MenuDisplayItem::Separator => {
+                    active_nodes
+                        .push(term_wm_ui_components::command_palette::ActivePaletteNode::Separator);
+                }
+            }
         }
+        self.palette.active_nodes = active_nodes;
         self.palette.mark_data_dirty();
     }
 
@@ -122,7 +138,7 @@ impl WmCommandPaletteComponent {
     }
 
     fn compute_content_dimensions(&self) -> (u16, u16) {
-        let item_count = self.palette.filtered_items.len();
+        let item_count = self.palette.display_nodes.len();
         let max_label_width = self
             .palette
             .filtered_items
@@ -305,7 +321,7 @@ impl Overlay<TermWmAction> for WmCommandPaletteComponent {
         self.palette.mark_data_dirty();
     }
 
-    fn set_menu_items(&mut self, items: Vec<MenuItem<TermWmAction>>) {
+    fn set_menu_items(&mut self, items: Vec<MenuDisplayItem<TermWmAction>>) {
         self.set_items(items);
     }
 
@@ -339,7 +355,9 @@ impl WmComponent for WmCommandPaletteComponent {
                 self.palette.query_dirty = true;
             }
             ComponentAction::SetMenuItems(items) => {
-                self.set_items(items.clone());
+                let display_items: Vec<MenuDisplayItem<TermWmAction>> =
+                    items.iter().cloned().map(MenuDisplayItem::Item).collect();
+                self.set_items(display_items);
             }
             ComponentAction::SetManagedArea(area) => self.set_managed_area(*area),
             _ => {}
@@ -390,18 +408,18 @@ mod tests {
     fn set_items_populates_registry() {
         let mut palette = WmCommandPaletteComponent::new();
         palette.set_items(vec![
-            MenuItem {
+            MenuDisplayItem::Item(MenuItem {
                 icon: None,
                 label: "New Window".into(),
                 action: TermWmAction::NewWindow,
                 disabled: false,
-            },
-            MenuItem {
+            }),
+            MenuDisplayItem::Item(MenuItem {
                 icon: None,
                 label: "Close".into(),
                 action: TermWmAction::CloseWindow(Default::default()),
                 disabled: false,
-            },
+            }),
         ]);
         assert!(!palette.registry.arena().is_empty());
     }
@@ -443,18 +461,18 @@ mod tests {
     fn selecting_disabled_item_returns_no_action() {
         let mut palette = WmCommandPaletteComponent::new();
         palette.set_items(vec![
-            MenuItem {
+            MenuDisplayItem::Item(MenuItem {
                 icon: None,
                 label: "Enabled".into(),
                 action: TermWmAction::NewWindow,
                 disabled: false,
-            },
-            MenuItem {
+            }),
+            MenuDisplayItem::Item(MenuItem {
                 icon: None,
                 label: "Disabled".into(),
                 action: TermWmAction::CloseWindow(Default::default()),
                 disabled: true,
-            },
+            }),
         ]);
         palette.show();
         palette.refresh_if_dirty();

--- a/crates/term-wm-ui-components/src/command_palette.rs
+++ b/crates/term-wm-ui-components/src/command_palette.rs
@@ -7,7 +7,7 @@ use term_wm_core::actions::{EventResult, TermWmAction};
 use term_wm_core::command_menu::{
     CommandNodeId, CommandRegistry, ContextMask, FuzzyMatch, MruRanker,
 };
-use term_wm_core::components::{Component, ComponentContext, MenuItem};
+use term_wm_core::components::{Component, ComponentContext, MenuDisplayItem, MenuItem};
 use term_wm_core::events::{Event, KeyCode, KeyKind, KeyModifiers};
 use term_wm_core::keybindings::{KeyBindings, KeyCombo};
 use term_wm_core::window::WindowKey;
@@ -27,6 +27,22 @@ pub struct PaletteItem {
     pub disabled: bool,
 }
 
+/// Sum type for the palette's active node sequence — carries separators
+/// alongside registry IDs so the cache rebuild never needs positional metadata.
+#[derive(Debug, Clone)]
+pub enum ActivePaletteNode {
+    Node(CommandNodeId),
+    Separator,
+}
+
+/// Sum type for the palette's display list — items that pass context filtering
+/// plus explicit separator markers.
+#[derive(Debug, Clone)]
+pub enum PaletteDisplayNode {
+    Item(PaletteItem),
+    Separator,
+}
+
 /// A universal, fuzzy-searchable Command Palette component.
 ///
 /// The search bar is rendered directly; the item list is wrapped in a
@@ -36,15 +52,34 @@ pub struct CommandPaletteComponent {
     pub query: String,
     pub cursor: usize,
     pub filtered_items: Vec<PaletteItem>,
+    /// Full display list for the next render (includes separators when
+    /// the query is empty, items-only during active search).
+    pub display_nodes: Vec<PaletteDisplayNode>,
     pub selected: usize,
     pub data_dirty: bool,
     pub query_dirty: bool,
     pub current_context_mask: ContextMask,
-    active_ids: Vec<CommandNodeId>,
-    display_items: Vec<(String, String, String, bool)>,
+    pub active_nodes: Vec<ActivePaletteNode>,
+    display_cache: Vec<DisplayCacheEntry>,
     nav_keys: KeyBindings,
     list_scroll: ScrollViewComponent<MenuComponent>,
+    last_display_sel: usize,
     last_list_area: LayoutRect,
+}
+
+/// Internal cache entry parallel to `active_nodes`.
+#[derive(Debug, Clone)]
+enum DisplayCacheEntry {
+    Item {
+        display_name: String,
+        description: String,
+        searchable_text: String,
+        disabled: bool,
+        stable_id: String,
+        icon: Option<&'static str>,
+        action: TermWmAction,
+    },
+    Separator,
 }
 
 impl Default for CommandPaletteComponent {
@@ -78,21 +113,43 @@ impl CommandPaletteComponent {
             query: String::new(),
             cursor: 0,
             filtered_items: Vec::new(),
+            display_nodes: Vec::new(),
             selected: 0,
             data_dirty: true,
             query_dirty: true,
             current_context_mask: ContextMask::NONE,
-            active_ids: Vec::new(),
-            display_items: Vec::new(),
+            active_nodes: Vec::new(),
+            display_cache: Vec::new(),
             nav_keys,
             list_scroll,
+            last_display_sel: 0,
             last_list_area: LayoutRect::default(),
         }
     }
 
     /// Sync CommandPaletteComponent's selected index from the inner MenuComponent.
+    /// Maps from display_nodes index (may include separators) to filtered_items index.
     fn sync_selected(&mut self) {
-        self.selected = self.list_scroll.content.borrow().selected();
+        let menu_selected = self.list_scroll.content.borrow().selected();
+        // Find the nth PaletteItem in display_nodes at position menu_selected
+        let item_count = self
+            .display_nodes
+            .iter()
+            .take(menu_selected)
+            .filter(|n| matches!(n, PaletteDisplayNode::Item(_)))
+            .count();
+        self.selected = item_count.min(self.filtered_items.len().saturating_sub(1));
+    }
+
+    /// Map a filtered_items index to its position in display_nodes
+    fn display_index(&self, item_idx: usize) -> usize {
+        self.display_nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, n)| matches!(n, PaletteDisplayNode::Item(_)))
+            .nth(item_idx)
+            .map(|(i, _)| i)
+            .unwrap_or(item_idx)
     }
 
     pub fn mark_data_dirty(&mut self) {
@@ -100,45 +157,142 @@ impl CommandPaletteComponent {
     }
 
     pub fn rebuild_data_cache(&mut self, registry: &CommandRegistry) {
-        self.active_ids = registry.build_item_list(self.current_context_mask);
-        self.display_items = self
-            .active_ids
-            .iter()
-            .filter_map(|id| {
-                let node = registry.get(*id)?;
-                let display_name = node.name.format(self.current_context_mask);
-                let desc = node.description.clone().unwrap_or_default();
-                let icon_text = node.icon.unwrap_or("");
-                let searchable_text = if icon_text.is_empty() {
-                    display_name.clone()
-                } else {
-                    format!("{} {}", icon_text, display_name)
-                };
-                Some((display_name, desc, searchable_text, node.disabled))
-            })
-            .collect();
+        let mut collapsed: Vec<DisplayCacheEntry> = Vec::new();
+        for node in &self.active_nodes {
+            match node {
+                ActivePaletteNode::Node(id) => {
+                    let Some(cmd_node) = registry.get(*id) else {
+                        continue;
+                    };
+                    if (self.current_context_mask & cmd_node.required_context)
+                        != cmd_node.required_context
+                    {
+                        continue;
+                    }
+                    let display_name = cmd_node.name.format(self.current_context_mask);
+                    let desc = cmd_node.description.clone().unwrap_or_default();
+                    let icon_text = cmd_node.icon.unwrap_or("");
+                    let searchable_text = if icon_text.is_empty() {
+                        display_name.clone()
+                    } else {
+                        format!("{} {}", icon_text, display_name)
+                    };
+                    let action = match &cmd_node.action {
+                        term_wm_core::command_menu::CommandAction::AppAction(a) => a.clone(),
+                    };
+                    collapsed.push(DisplayCacheEntry::Item {
+                        display_name,
+                        description: desc,
+                        searchable_text,
+                        disabled: cmd_node.disabled,
+                        stable_id: cmd_node.stable_id.clone(),
+                        icon: cmd_node.icon,
+                        action,
+                    });
+                }
+                ActivePaletteNode::Separator => {
+                    // Collapse rules applied inline:
+                    // No leading separator
+                    if collapsed.is_empty() {
+                        continue;
+                    }
+                    // No consecutive separators
+                    if matches!(collapsed.last(), Some(DisplayCacheEntry::Separator)) {
+                        continue;
+                    }
+                    collapsed.push(DisplayCacheEntry::Separator);
+                }
+            }
+        }
+        // No trailing separator
+        if matches!(collapsed.last(), Some(DisplayCacheEntry::Separator)) {
+            collapsed.pop();
+        }
+        self.display_cache = collapsed;
         self.data_dirty = false;
         self.query_dirty = true;
     }
 
     pub fn rerank(&mut self, fmatch: &mut FuzzyMatch, mru: &MruRanker) {
-        let indices = fmatch.score(&self.query, &self.display_items);
-        self.filtered_items = indices
+        // Build searchable texts from non-separator cache entries
+        let item_indices: Vec<usize> = self
+            .display_cache
             .iter()
-            .filter_map(|&i| {
-                let id = self.active_ids.get(i)?;
-                let (display_name, description, _, is_disabled) = self.display_items.get(i)?;
-                let node_ref = self.registry_getter_placeholder(*id, display_name, description);
-                Some(PaletteItem {
-                    stable_id: node_ref.0,
-                    display_name: node_ref.1,
-                    description: node_ref.2,
-                    action: node_ref.3,
-                    icon: node_ref.4,
-                    disabled: *is_disabled,
-                })
+            .enumerate()
+            .filter_map(|(i, e)| match e {
+                DisplayCacheEntry::Item { .. } => Some(i),
+                DisplayCacheEntry::Separator => None,
             })
             .collect();
+        let searchable: Vec<(String, String, String, bool)> = item_indices
+            .iter()
+            .filter_map(|&i| match &self.display_cache[i] {
+                DisplayCacheEntry::Item {
+                    display_name,
+                    description,
+                    searchable_text,
+                    disabled,
+                    ..
+                } => Some((
+                    display_name.clone(),
+                    description.clone(),
+                    searchable_text.clone(),
+                    *disabled,
+                )),
+                DisplayCacheEntry::Separator => None,
+            })
+            .collect();
+
+        self.filtered_items = if self.query.is_empty() {
+            // Empty query: all items in cache order
+            item_indices
+                .iter()
+                .filter_map(|&i| match &self.display_cache[i] {
+                    DisplayCacheEntry::Item {
+                        display_name,
+                        description,
+                        disabled,
+                        stable_id,
+                        icon,
+                        ..
+                    } => Some(PaletteItem {
+                        stable_id: stable_id.clone(),
+                        display_name: display_name.clone(),
+                        description: description.clone(),
+                        action: TermWmAction::CloseMenu,
+                        icon: *icon,
+                        disabled: *disabled,
+                    }),
+                    _ => None,
+                })
+                .collect()
+        } else {
+            let indices = fmatch.score(&self.query, &searchable);
+            indices
+                .iter()
+                .filter_map(|&idx| {
+                    let cache_idx = item_indices.get(idx)?;
+                    match self.display_cache.get(*cache_idx)? {
+                        DisplayCacheEntry::Item {
+                            display_name,
+                            description,
+                            disabled,
+                            stable_id,
+                            icon,
+                            ..
+                        } => Some(PaletteItem {
+                            stable_id: stable_id.clone(),
+                            display_name: display_name.clone(),
+                            description: description.clone(),
+                            action: TermWmAction::CloseMenu,
+                            icon: *icon,
+                            disabled: *disabled,
+                        }),
+                        _ => None,
+                    }
+                })
+                .collect()
+        };
         self.filtered_items.sort_by(|a, b| {
             let wa = mru.weight(&a.stable_id);
             let wb = mru.weight(&b.stable_id);
@@ -147,41 +301,40 @@ impl CommandPaletteComponent {
         self.selected = self
             .selected
             .min(self.filtered_items.len().saturating_sub(1));
+
+        // Build display_nodes for rendering
+        if self.query.is_empty() {
+            self.display_nodes = self
+                .display_cache
+                .iter()
+                .map(|e| match e {
+                    DisplayCacheEntry::Item {
+                        display_name,
+                        description,
+                        disabled,
+                        stable_id,
+                        icon,
+                        action,
+                        ..
+                    } => PaletteDisplayNode::Item(PaletteItem {
+                        stable_id: stable_id.clone(),
+                        display_name: display_name.clone(),
+                        description: description.clone(),
+                        action: action.clone(),
+                        icon: *icon,
+                        disabled: *disabled,
+                    }),
+                    DisplayCacheEntry::Separator => PaletteDisplayNode::Separator,
+                })
+                .collect();
+        } else {
+            self.display_nodes = self
+                .filtered_items
+                .iter()
+                .map(|pi| PaletteDisplayNode::Item(pi.clone()))
+                .collect();
+        }
         self.query_dirty = false;
-    }
-
-    fn extract_palette_data(
-        id: CommandNodeId,
-        display_name: &str,
-        description: &str,
-        registry: &CommandRegistry,
-    ) -> Option<(String, String, String, TermWmAction, Option<&'static str>)> {
-        let node = registry.get(id)?;
-        let action = match &node.action {
-            term_wm_core::command_menu::CommandAction::AppAction(a) => a.clone(),
-        };
-        Some((
-            node.stable_id.clone(),
-            display_name.to_string(),
-            description.to_string(),
-            action,
-            node.icon,
-        ))
-    }
-
-    fn registry_getter_placeholder(
-        &self,
-        _id: CommandNodeId,
-        display_name: &str,
-        description: &str,
-    ) -> (String, String, String, TermWmAction, Option<&'static str>) {
-        (
-            String::new(),
-            display_name.to_string(),
-            description.to_string(),
-            TermWmAction::CloseMenu,
-            None,
-        )
     }
 
     pub fn selected_action(&self) -> Option<&TermWmAction> {
@@ -204,25 +357,76 @@ impl CommandPaletteComponent {
         &mut self,
         fmatch: &mut FuzzyMatch,
         mru: &MruRanker,
-        registry: &CommandRegistry,
+        _registry: &CommandRegistry,
     ) {
-        let indices = fmatch.score(&self.query, &self.display_items);
-        self.filtered_items = indices
+        // Build searchable texts from non-separator cache entries
+        let item_indices: Vec<usize> = self
+            .display_cache
             .iter()
-            .filter_map(|&i| {
-                let id = *self.active_ids.get(i)?;
-                let (ref display_name, ref desc, _, _disabled) = self.display_items[i];
-                let data = Self::extract_palette_data(id, display_name, desc, registry)?;
-                Some(PaletteItem {
-                    stable_id: data.0,
-                    display_name: data.1,
-                    description: data.2,
-                    action: data.3,
-                    icon: data.4,
-                    disabled: _disabled,
-                })
+            .enumerate()
+            .filter_map(|(i, e)| match e {
+                DisplayCacheEntry::Item { .. } => Some(i),
+                DisplayCacheEntry::Separator => None,
             })
             .collect();
+        let searchable: Vec<(String, String, String, bool)> = item_indices
+            .iter()
+            .filter_map(|&i| match &self.display_cache[i] {
+                DisplayCacheEntry::Item {
+                    display_name,
+                    description,
+                    searchable_text,
+                    disabled,
+                    ..
+                } => Some((
+                    display_name.clone(),
+                    description.clone(),
+                    searchable_text.clone(),
+                    *disabled,
+                )),
+                DisplayCacheEntry::Separator => None,
+            })
+            .collect();
+
+        // Resolve PaletteItem from cache entry
+        let resolve_item = |cache_idx: usize| -> Option<PaletteItem> {
+            match self.display_cache.get(cache_idx)? {
+                DisplayCacheEntry::Item {
+                    display_name,
+                    description,
+                    disabled,
+                    stable_id,
+                    icon,
+                    action,
+                    ..
+                } => Some(PaletteItem {
+                    stable_id: stable_id.clone(),
+                    display_name: display_name.clone(),
+                    description: description.clone(),
+                    action: action.clone(),
+                    icon: *icon,
+                    disabled: *disabled,
+                }),
+                _ => None,
+            }
+        };
+
+        if self.query.is_empty() {
+            self.filtered_items = item_indices
+                .iter()
+                .filter_map(|&i| resolve_item(i))
+                .collect();
+        } else {
+            let indices = fmatch.score(&self.query, &searchable);
+            self.filtered_items = indices
+                .iter()
+                .filter_map(|&idx| {
+                    let cache_idx = *item_indices.get(idx)?;
+                    resolve_item(cache_idx)
+                })
+                .collect();
+        }
+
         self.filtered_items.sort_by(|a, b| {
             let wa = mru.weight(&a.stable_id);
             let wb = mru.weight(&b.stable_id);
@@ -231,6 +435,39 @@ impl CommandPaletteComponent {
         self.selected = self
             .selected
             .min(self.filtered_items.len().saturating_sub(1));
+
+        // Build display_nodes for rendering
+        if self.query.is_empty() {
+            self.display_nodes = self
+                .display_cache
+                .iter()
+                .map(|e| match e {
+                    DisplayCacheEntry::Item {
+                        display_name,
+                        description,
+                        disabled,
+                        stable_id,
+                        icon,
+                        action,
+                        ..
+                    } => PaletteDisplayNode::Item(PaletteItem {
+                        stable_id: stable_id.clone(),
+                        display_name: display_name.clone(),
+                        description: description.clone(),
+                        action: action.clone(),
+                        icon: *icon,
+                        disabled: *disabled,
+                    }),
+                    DisplayCacheEntry::Separator => PaletteDisplayNode::Separator,
+                })
+                .collect();
+        } else {
+            self.display_nodes = self
+                .filtered_items
+                .iter()
+                .map(|pi| PaletteDisplayNode::Item(pi.clone()))
+                .collect();
+        }
         self.query_dirty = false;
     }
 
@@ -308,27 +545,50 @@ impl Component<TermWmAction> for CommandPaletteComponent {
             return;
         }
 
-        // Build MenuItems from filtered_items and set on the inner MenuComponent
-        let menu_items: Vec<MenuItem<TermWmAction>> = self
-            .filtered_items
+        // Build MenuDisplayItems from display_nodes and set on the inner MenuComponent
+        let menu_items: Vec<MenuDisplayItem<TermWmAction>> = self
+            .display_nodes
             .iter()
-            .map(|p| MenuItem {
-                icon: p.icon,
-                label: Cow::Owned(p.display_name.clone()),
-                action: p.action.clone(),
-                disabled: p.disabled,
+            .map(|node| match node {
+                PaletteDisplayNode::Item(p) => MenuDisplayItem::Item(MenuItem {
+                    icon: p.icon,
+                    label: Cow::Owned(p.display_name.clone()),
+                    action: p.action.clone(),
+                    disabled: p.disabled,
+                }),
+                PaletteDisplayNode::Separator => MenuDisplayItem::Separator,
             })
             .collect();
-        self.list_scroll.content.borrow_mut().set_items(menu_items);
         self.list_scroll
             .content
             .borrow_mut()
-            .set_selected(self.selected);
+            .set_display_items(menu_items);
+        let display_sel = self.display_index(self.selected);
+        self.list_scroll
+            .content
+            .borrow_mut()
+            .set_selected(display_sel);
 
-        // Set content height for ScrollViewComponent
-        let total = self.filtered_items.len();
+        // Set content height for ScrollViewComponent and auto-scroll to keep selected item visible
+        let total = self.display_nodes.len();
         let handle = self.list_scroll.scroll_handle();
-        handle.scroll.borrow_mut().content_height = total;
+        {
+            let mut scroll = handle.scroll.borrow_mut();
+            scroll.content_height = total;
+
+            // Only auto-scroll when the selection index changes (not on manual scroll)
+            if display_sel != self.last_display_sel {
+                let list_height = bounds.height.saturating_sub(1) as usize;
+                if list_height > 0 {
+                    if display_sel < scroll.offset_y {
+                        scroll.offset_y = display_sel;
+                    } else if display_sel >= scroll.offset_y.saturating_add(list_height) {
+                        scroll.offset_y = display_sel.saturating_sub(list_height).saturating_add(1);
+                    }
+                }
+            }
+        }
+        self.last_display_sel = display_sel;
 
         // Clear background
         let menu_style = Style::default()
@@ -807,5 +1067,157 @@ mod tests {
         };
 
         assert_eq!(searchable_text_empty, "System Panel");
+    }
+
+    fn make_palette_with_many_items(count: usize) -> CommandPaletteComponent {
+        let mut palette = CommandPaletteComponent::new();
+        palette.data_dirty = false;
+        palette.query_dirty = false;
+        let items: Vec<PaletteItem> = (0..count)
+            .map(|i| PaletteItem {
+                stable_id: format!("item:{}", i),
+                display_name: format!("Item {}", i),
+                description: String::new(),
+                action: TermWmAction::CloseMenu,
+                icon: None,
+                disabled: false,
+            })
+            .collect();
+        palette.filtered_items = items.clone();
+        palette.display_nodes = items.into_iter().map(PaletteDisplayNode::Item).collect();
+        palette
+    }
+
+    fn render_palette(palette: &mut CommandPaletteComponent, height: u16) {
+        let area = ratatui::prelude::Rect::new(0, 0, 80, height);
+        let buffer = ratatui::buffer::Buffer::empty(area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buffer, area);
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        palette.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn auto_scroll_starts_at_offset_zero() {
+        let mut palette = make_palette_with_many_items(20);
+        render_palette(&mut palette, 6);
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let scroll = handle.scroll.borrow();
+            assert_eq!(scroll.offset_y, 0);
+            assert_eq!(scroll.content_height, 20);
+        }
+    }
+
+    #[test]
+    fn auto_scroll_advances_when_selection_moves_past_viewport() {
+        let mut palette = make_palette_with_many_items(20);
+        let ctx = ComponentContext::new(true);
+
+        // Navigate to item 7 (display_sel=7). List height = 6 - 1 = 5 rows.
+        // 7 >= 0 + 5 = 5, so offset should snap to 7 - 5 + 1 = 3.
+        palette.selected = 7;
+        palette.update(TermWmAction::MenuDown, &ctx, &mut VecDeque::new());
+        // update wrapped to 8
+        render_palette(&mut palette, 6);
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let scroll = handle.scroll.borrow();
+            assert_eq!(
+                scroll.offset_y, 4,
+                "offset should advance to keep item 8 visible at bottom"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_scroll_goes_back_when_selection_moves_up() {
+        let mut palette = make_palette_with_many_items(20);
+        // First navigate down to item 15
+        palette.selected = 15;
+        render_palette(&mut palette, 6);
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let scroll = handle.scroll.borrow();
+            assert_eq!(scroll.offset_y, 11, "offset should be at 11 for item 15");
+        }
+
+        // Now navigate back up to item 0
+        palette.selected = 0;
+        render_palette(&mut palette, 6);
+        {
+            let handle2 = palette.list_scroll.scroll_handle();
+            let scroll2 = handle2.scroll.borrow();
+            assert_eq!(
+                scroll2.offset_y, 0,
+                "offset should reset to 0 when selection moves to top"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_scroll_does_not_override_manual_scroll() {
+        let mut palette = make_palette_with_many_items(20);
+
+        // Render initially so last_display_sel is set
+        palette.selected = 0;
+        render_palette(&mut palette, 6);
+
+        // Manually scroll down (simulate user scrolling with mouse)
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let mut scroll = handle.scroll.borrow_mut();
+            scroll.offset_y = 8;
+        }
+
+        // Re-render with same selection -- auto-scroll should NOT fire
+        render_palette(&mut palette, 6);
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let scroll = handle.scroll.borrow();
+            assert_eq!(
+                scroll.offset_y, 8,
+                "manual scroll should be preserved when selection unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_scroll_engages_again_after_manual_scroll_when_selection_changes() {
+        let mut palette = make_palette_with_many_items(20);
+
+        // Render initially so last_display_sel is set
+        palette.selected = 0;
+        render_palette(&mut palette, 6);
+
+        // Manually scroll down
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let mut scroll = handle.scroll.borrow_mut();
+            scroll.offset_y = 8;
+        }
+
+        // Change selection past viewport
+        palette.selected = 15;
+        render_palette(&mut palette, 6);
+        {
+            let handle = palette.list_scroll.scroll_handle();
+            let scroll = handle.scroll.borrow();
+            // display_sel=15, list_height=5, offset was 8. 15 >= 8 + 5 = 13 -> snap to 15 - 5 + 1 = 11
+            assert_eq!(
+                scroll.offset_y, 11,
+                "auto-scroll should re-engage when selection changes"
+            );
+        }
     }
 }

--- a/crates/term-wm-ui-components/src/menu.rs
+++ b/crates/term-wm-ui-components/src/menu.rs
@@ -6,14 +6,14 @@ use term_wm_core::events::{Event, KeyKind, MouseEventKind};
 
 use crate::helpers::{color_to_ratatui, layout_rect_to_clipped_rect, safe_set_string};
 use term_wm_core::actions::{EventResult, TermWmAction};
-use term_wm_core::components::{Component, ComponentContext, MenuItem};
+use term_wm_core::components::{Component, ComponentContext, MenuDisplayItem, MenuItem};
 use term_wm_core::keybindings::KeyBindings;
 use term_wm_core::window::WindowKey;
 use term_wm_layout_engine::LayoutRect;
 
 #[derive(Debug)]
 pub struct MenuComponent {
-    items: Vec<MenuItem<TermWmAction>>,
+    items: Vec<MenuDisplayItem<TermWmAction>>,
     selected: usize,
     nav_keys: KeyBindings,
     pub show_header: bool,
@@ -30,11 +30,16 @@ impl MenuComponent {
     }
 
     pub fn set_items(&mut self, items: Vec<MenuItem<TermWmAction>>) {
-        self.items = items;
-        self.selected = self.selected.min(self.items.len().saturating_sub(1));
+        self.items = items.into_iter().map(MenuDisplayItem::Item).collect();
+        self.selected = clamp_selected(self.selected, &self.items);
     }
 
-    pub fn items(&self) -> &[MenuItem<TermWmAction>] {
+    pub fn set_display_items(&mut self, items: Vec<MenuDisplayItem<TermWmAction>>) {
+        self.items = items;
+        self.selected = clamp_selected(self.selected, &self.items);
+    }
+
+    pub fn items(&self) -> &[MenuDisplayItem<TermWmAction>] {
         &self.items
     }
 
@@ -43,17 +48,30 @@ impl MenuComponent {
     }
 
     pub fn set_selected(&mut self, index: usize) {
-        self.selected = index.min(self.items.len().saturating_sub(1));
+        self.selected = clamp_selected(index, &self.items);
     }
 
     pub fn selected_action(&self) -> Option<&TermWmAction> {
-        self.items.get(self.selected).and_then(|item| {
-            if item.disabled {
-                None
-            } else {
-                Some(&item.action)
+        match self.items.get(self.selected)? {
+            MenuDisplayItem::Item(item) if !item.disabled => Some(&item.action),
+            _ => None,
+        }
+    }
+
+    /// Move selection to the next non-separator index (wrapping).
+    fn advance_selection(&mut self, direction: isize) {
+        let total = self.items.len();
+        if total == 0 {
+            return;
+        }
+        let mut idx = self.selected as isize;
+        for _ in 0..total {
+            idx = (idx + direction).rem_euclid(total as isize);
+            if !matches!(self.items[idx as usize], MenuDisplayItem::Separator) {
+                self.selected = idx as usize;
+                return;
             }
-        })
+        }
     }
 
     pub fn handle_key_event(&mut self, event: &Event) -> EventResult<TermWmAction> {
@@ -76,14 +94,14 @@ impl MenuComponent {
         {
             EventResult::Action(TermWmAction::MenuDown)
         } else if self.nav_keys.matches(TermWmAction::MenuSelect, key) {
-            let is_disabled = self
-                .items
-                .get(self.selected)
-                .is_none_or(|item| item.disabled);
-            if is_disabled {
-                EventResult::Ignored
-            } else {
+            let selectable = match self.items.get(self.selected) {
+                Some(MenuDisplayItem::Item(item)) => !item.disabled,
+                _ => false,
+            };
+            if selectable {
                 EventResult::Action(TermWmAction::MenuSelect)
+            } else {
+                EventResult::Ignored
             }
         } else {
             EventResult::Ignored
@@ -142,6 +160,7 @@ impl MenuComponent {
             .min(self.items.len().saturating_sub(offset_y) as u16)
             as usize;
 
+        // Clear area background
         for row in 0..area.height {
             let y = area.y.saturating_add(row);
             if y < bounds.y || y >= bounds.y.saturating_add(bounds.height) {
@@ -169,45 +188,81 @@ impl MenuComponent {
             if y < bounds.y || y >= bounds.y.saturating_add(bounds.height) {
                 break;
             }
-            let item = &self.items[abs_idx];
-            let is_selected = abs_idx == self.selected;
-            let is_hovered = hovered_idx == Some(abs_idx);
-            let row_style = if item.disabled && !is_selected {
-                disabled_style
-            } else if is_selected {
-                selected_style
-            } else if is_hovered {
-                hovered_style
-            } else {
-                menu_style
-            };
-            for col in 0..area.width {
-                let x = area.x.saturating_add(col);
-                if x >= bounds.x.saturating_add(bounds.width) {
-                    break;
+
+            match &self.items[abs_idx] {
+                MenuDisplayItem::Separator => {
+                    let sep_style = Style::default()
+                        .bg(color_to_ratatui(theme.menu_bg))
+                        .fg(color_to_ratatui(theme.text_disabled));
+                    for col in 0..area.width {
+                        let x = area.x.saturating_add(col);
+                        if x >= bounds.x.saturating_add(bounds.width) {
+                            break;
+                        }
+                        if let Some(cell) = buffer.cell_mut((x, y)) {
+                            cell.reset();
+                            cell.set_symbol("─");
+                            cell.set_style(sep_style);
+                        }
+                    }
                 }
-                if let Some(cell) = buffer.cell_mut((x, y)) {
-                    cell.reset();
-                    cell.set_symbol(" ");
-                    cell.set_style(row_style);
+                MenuDisplayItem::Item(item) => {
+                    let is_selected = abs_idx == self.selected;
+                    let is_hovered = hovered_idx == Some(abs_idx);
+                    let row_style = if item.disabled && !is_selected {
+                        disabled_style
+                    } else if is_selected {
+                        selected_style
+                    } else if is_hovered {
+                        hovered_style
+                    } else {
+                        menu_style
+                    };
+                    for col in 0..area.width {
+                        let x = area.x.saturating_add(col);
+                        if x >= bounds.x.saturating_add(bounds.width) {
+                            break;
+                        }
+                        if let Some(cell) = buffer.cell_mut((x, y)) {
+                            cell.reset();
+                            cell.set_symbol(" ");
+                            cell.set_style(row_style);
+                        }
+                    }
+                    let marker = if is_selected {
+                        ">"
+                    } else if is_hovered {
+                        "\u{25b8}"
+                    } else {
+                        " "
+                    };
+                    let line = if let Some(icon) = item.icon {
+                        format!("{marker} {icon} {label}", label = item.label)
+                    } else {
+                        format!("{marker}   {label}", label = item.label)
+                    };
+                    let text: String = line.chars().take(inner_width as usize).collect();
+                    safe_set_string(buffer, bounds, inner_x, y, &text, row_style);
                 }
             }
-            let marker = if is_selected {
-                ">"
-            } else if is_hovered {
-                "\u{25b8}"
-            } else {
-                " "
-            };
-            let line = if let Some(icon) = item.icon {
-                format!("{marker} {icon} {label}", label = item.label)
-            } else {
-                format!("{marker}   {label}", label = item.label)
-            };
-            let text: String = line.chars().take(inner_width as usize).collect();
-            safe_set_string(buffer, bounds, inner_x, y, &text, row_style);
         }
     }
+}
+
+/// Clamp selection index to a valid non-separator position.
+fn clamp_selected(mut idx: usize, items: &[MenuDisplayItem<TermWmAction>]) -> usize {
+    if items.is_empty() {
+        return 0;
+    }
+    idx = idx.min(items.len().saturating_sub(1));
+    // If the clamped position is a separator, move up until we find an item.
+    while matches!(items.get(idx), Some(MenuDisplayItem::Separator)) {
+        if idx == 0 {
+            break;
+        }
+        idx -= 1;
+    }
+    idx
 }
 
 impl Component<TermWmAction> for MenuComponent {
@@ -267,10 +322,13 @@ impl Component<TermWmAction> for MenuComponent {
                     let idx = visual_idx + offset_y;
                     if idx < self.items.len() {
                         self.selected = idx;
-                        if self.items[idx].disabled {
-                            return EventResult::Consumed;
+                        match &self.items[idx] {
+                            MenuDisplayItem::Separator => return EventResult::Consumed,
+                            MenuDisplayItem::Item(item) if item.disabled => {
+                                return EventResult::Consumed;
+                            }
+                            _ => return EventResult::Action(TermWmAction::MenuSelect),
                         }
-                        return EventResult::Action(TermWmAction::MenuSelect);
                     }
                 }
             }
@@ -287,20 +345,10 @@ impl Component<TermWmAction> for MenuComponent {
     ) {
         match action {
             TermWmAction::MenuUp | TermWmAction::MenuPrev => {
-                let total = self.items.len();
-                if total > 0 {
-                    self.selected = if self.selected == 0 {
-                        total - 1
-                    } else {
-                        self.selected - 1
-                    };
-                }
+                self.advance_selection(-1);
             }
             TermWmAction::MenuDown | TermWmAction::MenuNext => {
-                let total = self.items.len();
-                if total > 0 {
-                    self.selected = (self.selected + 1) % total;
-                }
+                self.advance_selection(1);
             }
             _ => {}
         }

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -295,6 +295,7 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
             self.wm.transition_window(debug_key, WindowState::Unmapped);
             self.wm.set_window_title(debug_key, "Debug Log");
             self.debug_key = Some(debug_key);
+            self.wm.register_system_window::<term_wm_core::window::window_manager::system_tags::DebugLog>(debug_key);
             install_panic_hook();
             crate::logging::init_default();
         }
@@ -311,6 +312,7 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
             self.wm.transition_window(sys_key, WindowState::Unmapped);
             self.wm.set_window_title(sys_key, "System Panel");
             self.system_panel_key = Some(sys_key);
+            self.wm.register_system_window::<term_wm_core::window::window_manager::system_tags::SystemPanel>(sys_key);
         }
     }
 
@@ -463,21 +465,26 @@ impl<C: Component<TermWmAction>>
     }
 
     fn open_command_palette(&mut self) {
+        use term_wm_core::components::MenuDisplayItem;
         let mut palette = WmCommandPaletteComponent::new();
         palette.show();
         let items = self.wm.wm_menu_items();
         let supported = self.wm.supported_menu_actions();
+        // Filter out items not in the supported set; keep separators.
         let items: Vec<_> = items
             .into_iter()
-            .filter(|item| {
-                supported.contains(&item.action)
-                    || matches!(
-                        item.action,
-                        TermWmAction::FocusWindow(_)
-                            | TermWmAction::MaximizeWindow(_)
-                            | TermWmAction::MinimizeWindow(_)
-                            | TermWmAction::CloseWindow(_)
-                    )
+            .filter(|entry| match entry {
+                MenuDisplayItem::Item(item) => {
+                    supported.contains(&item.action)
+                        || matches!(
+                            item.action,
+                            TermWmAction::FocusWindow(_)
+                                | TermWmAction::MaximizeWindow(_)
+                                | TermWmAction::MinimizeWindow(_)
+                                | TermWmAction::CloseWindow(_)
+                        )
+                }
+                MenuDisplayItem::Separator => true,
             })
             .collect();
         palette.set_items(items);


### PR DESCRIPTION
=== Separator support through the full component stack ===

- Overlay::set_menu_items: Changed trait signature from Vec<MenuItem<Msg>> to Vec<MenuDisplayItem<Msg>> (components.rs, macros.rs) so Separator variants are preserved across trait boundaries instead of being erased.

- MenuComponent: Stores Vec<MenuDisplayItem> internally. New set_display_items() accepts the sum type directly; set_items() wraps MenuItem into MenuDisplayItem::Item. Renders Separator variants as horizontal lines ("─"). Selection skips separators via advance_selection() and clamp_selected() helpers. (menu.rs)

- CommandPaletteComponent: New ActivePaletteNode / PaletteDisplayNode sum types carry separators through the full pipeline: set_items → active_nodes → rebuild_data_cache → display_cache → rerank → display_nodes → render. Collapse rules remove leading, trailing, and consecutive separators. display_index() maps filtered_items indices to display_nodes positions accounting for separators. (command_palette.rs)

- WmCommandPaletteComponent: set_items() now accepts Vec<MenuDisplayItem>, registers both Item and Separator variants into active_nodes for the palette's data pipeline. compute_content_dimensions() uses display_nodes.len() instead of filtered_items.len() for correct dialog height. (wm_command_palette.rs)

- term_wm_app.rs / focus.rs: Menu item filtering uses MenuDisplayItem sum type, preserving separators through supported-action filter.

=== TypeId registry for system windows/overlays ===

- Replaced hardcoded fields (debug_key, system_panel_key, help_key, exit_confirm_key, command_palette_key) with system_windows: HashMap<TypeId, WindowKey> and system_overlays: HashMap<TypeId, OverlayKey>.

- New system_tags module with marker types: DebugLog, SystemPanel, CommandPalette, HelpOverlay, ExitConfirm.

- Generic accessors: register_system_window<T>(), get_system_window<T>(), register_overlay<T>(), get_overlay<T>().

- wm_menu_items() resolves DebugLog/SystemPanel visibility internally via get_system_window() instead of external parameters.

- overlays.rs: All overlay operations use get_overlay::<T>() / system_overlays.remove() instead of Option field access.

=== Auto-scroll viewport to selection ===

- Added last_display_sel field to CommandPaletteComponent.
- Render clamps scroll.offset_y when display_sel changes: top clamp (if selection above viewport) and bottom clamp (if below).
- Manual mouse scrolls are preserved — auto-scroll only fires on selection index changes, not on every render frame.
- 5 new tests covering: initial offset, scroll-down tracking, scroll-up reset, manual scroll preservation, re-engagement on change.

=== Command palette group reordering ===

- Window management buttons (Close, Maximize, Minimize, Switch to:) moved directly below the top group (Resume, New Window).
- Help and Exit UI moved to the last group, after View section (Monocle, Tiling).