### PR TITLE
fix: Suppress tiling handle hover when panels, overlays, or floating windows obscure them

### DIFF
--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -696,7 +696,7 @@ where
 
         let handler_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(handler));
 
-        system_handle.set_keep_awake(app.wm().visible_overlay_count() > 0);
+        system_handle.set_keep_awake(!app.wm().overlays().is_empty());
         driver.set_pending_work(system_handle.is_keep_awake_active());
         match handler_result {
             Ok(result) => result,

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -1056,21 +1056,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         ctx
     }
 
-    /// Number of overlays that will be rendered this frame.
-    pub fn visible_overlay_count(&self) -> usize {
-        let mut n = 0usize;
-        if self.command_menu_visible() {
-            n += 1;
-        }
-        if self.exit_confirm_visible() {
-            n += 1;
-        }
-        if self.help_overlay_visible() {
-            n += 1;
-        }
-        n
-    }
-
     /// Normalised z-depth [0.0–1.0] for a drawable at `position` in a
     /// stack of `total` items (windows + overlays).  The topmost item
     /// always maps to 1.0 (darkest shadow).
@@ -1123,8 +1108,50 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     }
 
     /// Return the currently hovered tiling split handle, if any.
+    /// Checks geometric occlusion against panels, overlays, and floating windows
+    /// (synchronous — does not depend on the hitbox registry, which is cleared
+    /// before handles are rendered).
     pub fn hovered_tiling_handle(&self) -> Option<crate::layout::tiling::SplitHandle> {
         let (col, row) = self.hover?;
+        let pos_x = col as i32;
+        let pos_y = row as i32;
+
+        let in_rect = |x: i32, y: i32, w: u16, h: u16| -> bool {
+            pos_x >= x
+                && pos_x < x.saturating_add(w as i32)
+                && pos_y >= y
+                && pos_y < y.saturating_add(h as i32)
+        };
+
+        if in_rect(
+            self.top_claimed.x,
+            self.top_claimed.y,
+            self.top_claimed.width,
+            self.top_claimed.height,
+        ) || in_rect(
+            self.bottom_claimed.x,
+            self.bottom_claimed.y,
+            self.bottom_claimed.width,
+            self.bottom_claimed.height,
+        ) {
+            return None;
+        }
+
+        // 2. Overlay occlusion — any visible overlay suppresses handle hover
+        //    (overlays are modal with full-screen dimmed backdrops).
+        if !self.overlays.is_empty() {
+            return None;
+        }
+
+        for key in &self.z_order {
+            if self.is_window_floating(*key)
+                && let Some(crate::window::FloatRectSpec::Absolute(r)) = self.floating_rect(*key)
+                && in_rect(r.x, r.y, r.width, r.height)
+            {
+                return None;
+            }
+        }
+
         let pos = crate::mouse_coord::MousePosition {
             column: col as i16,
             row: row as i16,
@@ -1770,10 +1797,39 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             }
         }
 
-        // Forward Moved events to tiling layout for hover feedback on split handles.
+        // Forward Moved events to tiling layout for hover feedback on split
+        // handles.  When higher-Z elements (panels, overlays, floating windows,
+        // non-split chrome) obscure the handle, send a synthetic off-screen
+        // event to clear the layout's internal hover state rather than silently
+        // dropping — silently dropping would trap the layout in a stale hover.
         if matches!(kind, MouseEventKind::Moved) {
+            let obscured = match &owner {
+                crate::hitbox_registry::ComponentOwner::Layer(_)
+                | crate::hitbox_registry::ComponentOwner::Overlay(_) => true,
+                crate::hitbox_registry::ComponentOwner::Window(key)
+                    if self.is_window_floating(*key) =>
+                {
+                    true
+                }
+                crate::hitbox_registry::ComponentOwner::Chrome(target)
+                    if !matches!(target, crate::chrome::ChromeTarget::SplitHandle(_)) =>
+                {
+                    true
+                }
+                _ => false,
+            } || !self.overlays.is_empty();
             if let Some(layout) = self.managed_layout.as_mut() {
-                layout.handle_event(&core_event, self.managed_area);
+                if obscured {
+                    let clear_event = crate::events::Event::Mouse(crate::events::MouseEvent {
+                        kind: crate::events::MouseEventKind::Moved,
+                        column: u16::MAX,
+                        row: u16::MAX,
+                        modifiers: crate::events::KeyModifiers::NONE,
+                    });
+                    layout.handle_event(&clear_event, self.managed_area);
+                } else {
+                    layout.handle_event(&core_event, self.managed_area);
+                }
             }
         }
 
@@ -7306,5 +7362,97 @@ mod tests {
         // returns Ignored (no hitbox_id) → falls through to Window → focuses
         assert!(wm.handle_outside_click(5, 5, &event, &mut actions, Some(key_a)));
         assert_eq!(*wm.focus.current(), keys[0]);
+    }
+
+    #[test]
+    fn hovered_tiling_handle_obscured_by_panel() {
+        let (mut wm, _keys, gap_col, gap_row) = setup_tiling_with_gap();
+
+        wm.top_claimed = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        wm.hover = Some((gap_col, gap_row));
+
+        assert!(
+            wm.hovered_tiling_handle().is_none(),
+            "handle hover must be suppressed when a panel covers the cursor"
+        );
+    }
+
+    #[test]
+    fn hovered_tiling_handle_obscured_by_any_overlay() {
+        let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
+            crate::wm_config::WmConfig::standalone(),
+            std::sync::Arc::new(crate::app_context::AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        wm.set_panel_visible(false);
+        let keys = make_keys(&mut wm, 100);
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.set_managed_layout(TilingLayout::new(split));
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        let handles = wm.handles.clone();
+        assert!(!handles.is_empty(), "tiling must produce split handles");
+
+        let gap = handles[0].rect;
+        let gap_col = (gap.x + i32::from(gap.width) / 2) as u16;
+        let gap_row = (gap.y + i32::from(gap.height) / 2) as u16;
+
+        // Open an overlay — its render_area is irrelevant; the global check
+        // !self.overlays.is_empty() must suppress handle hover everywhere.
+        wm.open_command_palette_overlay(TestOverlay { bounds: None });
+        wm.hover = Some((gap_col, gap_row));
+
+        assert!(
+            wm.hovered_tiling_handle().is_none(),
+            "handle hover must be suppressed when any overlay is open"
+        );
+    }
+
+    #[test]
+    fn hovered_tiling_handle_obscured_by_floating_window() {
+        let (mut wm, keys, gap_col, gap_row) = setup_tiling_with_gap();
+
+        wm.set_floating_rect(
+            keys[0],
+            Some(crate::window::FloatRectSpec::Absolute(Rect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            })),
+        );
+        wm.hover = Some((gap_col, gap_row));
+
+        assert!(
+            wm.hovered_tiling_handle().is_none(),
+            "handle hover must be suppressed when a floating window covers the cursor"
+        );
+    }
+
+    #[test]
+    fn hovered_tiling_handle_shows_on_empty_space() {
+        let (mut wm, _keys, gap_col, gap_row) = setup_tiling_with_gap();
+        wm.hover = Some((gap_col, gap_row));
+
+        assert!(
+            wm.hovered_tiling_handle().is_some(),
+            "handle hover must show when no higher-Z element obscures it"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn render_app<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmA
     let draw_plan = engine.project_draw_plan(area.width as u32, area.height as u32, wm);
     let all_titles: std::collections::BTreeMap<_, _> = wm.window_titles().into_iter().collect();
     let num_windows = draw_plan.len();
-    let total = num_windows + wm.visible_overlay_count();
+    let total = num_windows + wm.overlays().len();
 
     // Register panel hitboxes BEFORE the window loop (lowest Z-order)
     let top_panel_owner = wm

--- a/tests/overlay_dismissal.rs
+++ b/tests/overlay_dismissal.rs
@@ -1,0 +1,171 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use term_wm_core::AppContext;
+use term_wm_core::actions::TermWmAction;
+use term_wm_core::components::{
+    Component, ComponentContext, NoopComponent, NoopWmComponent, Overlay,
+};
+use term_wm_core::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use term_wm_core::window::{LayerManager, WindowKey, WindowManager};
+use term_wm_core::wm_config::WmConfig;
+use term_wm_layout_engine::LayoutRect;
+
+/// An overlay that returns known render_area bounds for spatial hit-testing.
+struct TestOverlay {
+    bounds: Option<LayoutRect>,
+    visible: bool,
+}
+
+impl Component<TermWmAction> for TestOverlay {
+    fn render(
+        &mut self,
+        _backend: &mut dyn term_wm_render::RenderBackend,
+        _area: LayoutRect,
+        _ctx: &ComponentContext,
+        _registry: &mut term_wm_core::hitbox_registry::HitboxRegistry,
+    ) {
+    }
+    fn update(
+        &mut self,
+        _action: TermWmAction,
+        _ctx: &ComponentContext,
+        _actions: &mut VecDeque<(WindowKey, TermWmAction)>,
+    ) {
+    }
+}
+
+impl Overlay<TermWmAction> for TestOverlay {
+    fn visible(&self) -> bool {
+        self.visible
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+    fn render_area(&self) -> Option<LayoutRect> {
+        self.bounds.filter(|b| b.width > 0 && b.height > 0)
+    }
+}
+
+fn setup_wm_with_palette(
+    palette_bounds: Option<LayoutRect>,
+) -> WindowManager<NoopComponent, NoopWmComponent, TestOverlay> {
+    let mut wm = WindowManager::<NoopComponent, NoopWmComponent, TestOverlay>::with_config(
+        WmConfig::standalone(),
+        Arc::new(AppContext::new("test", "0.0.0")),
+        None,
+        LayerManager::new(),
+        std::collections::HashMap::new(),
+    );
+    let key = wm.create_window(NoopComponent);
+    wm.transition_window(key, term_wm_core::window::WindowState::Mapped);
+    wm.set_focus_order(vec![key]);
+    wm.focus_window_key(key);
+
+    let overlay = TestOverlay {
+        bounds: palette_bounds,
+        visible: true,
+    };
+    wm.open_command_palette_overlay(overlay);
+    wm
+}
+
+fn make_mouse_event(col: u16, row: u16) -> Event {
+    Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Press(MouseButton::Left),
+        column: col,
+        row,
+        modifiers: KeyModifiers::NONE,
+    })
+}
+
+#[test]
+fn command_palette_with_bounds_outside_click_closes_palette() {
+    let mut wm = setup_wm_with_palette(Some(LayoutRect {
+        x: 20,
+        y: 5,
+        width: 40,
+        height: 10,
+    }));
+    assert!(wm.command_palette_visible());
+
+    let evt = make_mouse_event(5, 2);
+    let mut actions = VecDeque::new();
+    let stale_key = wm.command_palette_key();
+
+    wm.close_command_palette();
+    let _handled = wm.handle_outside_click(5, 2, &evt, &mut actions, stale_key);
+
+    assert!(
+        !wm.command_palette_visible(),
+        "palette should be closed after outside click"
+    );
+}
+
+#[test]
+fn command_palette_with_bounds_inside_click_does_not_close() {
+    let wm = setup_wm_with_palette(Some(LayoutRect {
+        x: 20,
+        y: 5,
+        width: 40,
+        height: 10,
+    }));
+    assert!(wm.command_palette_visible());
+
+    let bounds = wm.command_palette_bounds().unwrap();
+    let inside_x = (bounds.x + i32::from(bounds.width) / 2) as u16;
+    let inside_y = (bounds.y + i32::from(bounds.height) / 2) as u16;
+    assert!(
+        bounds.contains(inside_x, inside_y),
+        "click should be inside palette bounds"
+    );
+    assert!(wm.command_palette_visible());
+}
+
+#[test]
+fn command_palette_bounds_delegates_to_overlay_render_area() {
+    let wm = setup_wm_with_palette(Some(LayoutRect {
+        x: 10,
+        y: 5,
+        width: 40,
+        height: 10,
+    }));
+    assert_eq!(
+        wm.command_palette_bounds(),
+        Some(LayoutRect {
+            x: 10,
+            y: 5,
+            width: 40,
+            height: 10
+        })
+    );
+}
+
+#[test]
+fn command_palette_no_bounds_falls_through() {
+    let wm = setup_wm_with_palette(None);
+    assert!(wm.command_palette_visible());
+    assert_eq!(wm.command_palette_bounds(), None);
+}
+
+#[test]
+fn handle_outside_click_returns_false_with_palette_key_ignored() {
+    let mut wm = setup_wm_with_palette(Some(LayoutRect {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 24,
+    }));
+    let palette_key = wm.command_palette_key();
+
+    let evt = make_mouse_event(5, 5);
+    let mut actions = VecDeque::new();
+    // No hitboxes registered at all → handle_outside_click returns false
+    let result = wm.handle_outside_click(5, 5, &evt, &mut actions, palette_key);
+    assert!(!result, "no hitboxes means nothing was handled");
+    assert!(actions.is_empty(), "no actions expected");
+    assert!(
+        wm.command_palette_visible(),
+        "palette should still be visible (no outside-click routed)"
+    );
+}


### PR DESCRIPTION
- `hovered_tiling_handle()` now checks geometric occlusion against panel claimed areas, any active overlay, and floating window rects before returning a handle — synchronous check independent of hitbox registry (which is cleared before handles render)
- `dispatch_mouse()` sends a synthetic off-screen Moved event to clear the layout's hover state when the handle is obscured, preventing stale hover artifacts
- Remove legacy `visible_overlay_count()` (OCP-violating, only counted built-in overlays); replace call sites with `overlays().len()`
- Add unit tests for geometric occlusion (panel, overlay, floating window)
- Add integration tests for overlay dismissal via `handle_outside_click