### PR TITLE
feat: Add key monitor applet to system panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target/
 lcov.info
 *.save
 samply.json
+
+DEBUG.sh
+*.log
+

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -398,9 +398,14 @@ where
 
                 frame_pacer.notify_pending(Instant::now());
 
-                // Pre-compute the keybinding action using the configured
-                // KeyBindings from WindowManager (not hardcoded defaults).
-                // CommandPalette actions are handled when the WM overlay is open.
+                // PRE-LAYER: Global app event observer.
+                // Runs before all layer checks so the app can observe or consume
+                // EVERY event — including those later consumed by overlays,
+                // keybindings, or direct-mode PTY routing.
+                if app.handle_app_event(&evt) {
+                    update_selection_snapshot(app);
+                    return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
+                }
 
                 // Layer 1: Active overlays (exit confirm, selection preview, help)
                 if app.wm().exit_confirm_visible() {
@@ -546,9 +551,7 @@ where
                     return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
                 }
 
-                // If keyboard capture is disabled for the focused window, key events
-
-                // Layer 2b: Direct mode check — intercepts ALL other keys
+                // Layer 2c: Direct mode check — forward key events straight to PTY
                 if let Event::Key(key) = &evt {
                     let focus_id = app.wm().focused_window();
                     if app.wm().direct_mode(focus_id)
@@ -566,12 +569,6 @@ where
                             None,
                         );
                     }
-                }
-
-                // Layer 2c: App-level event handler (before WM actions, after overlays)
-                if app.handle_app_event(&evt) {
-                    update_selection_snapshot(app);
-                    return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
                 }
 
                 // Mouse capture check

--- a/crates/term-wm-sys-ui-components/src/wm_system_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_system_panel.rs
@@ -1,65 +1,99 @@
+use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::rc::Rc;
 
-use ratatui::style::Color;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
 use term_wm_core::actions::{EventResult, TermWmAction};
 use term_wm_core::component_context::ComponentContext;
 use term_wm_core::components::{Component, SelectionStatus};
+use term_wm_core::events::{Event, KeyCode, KeyEvent};
 use term_wm_core::impl_component_delegate;
 use term_wm_core::window::WindowKey;
 use term_wm_layout_engine::LayoutRect;
+use term_wm_ui_components::helpers::{downcast_ratatui, layout_rect_to_clipped_rect};
 use term_wm_ui_components::{
     ButtonComponent, CanvasScrollView, CanvasSizingPolicy, LabelComponent, ScrollViewComponent,
     VerticalStackComponent,
 };
 
 /// Local enum wrapping all child types used in the system panel stack.
+#[derive(Clone)]
 enum PanelChild {
     Label(LabelComponent),
     Button(ButtonComponent),
     Spacer(SpacerComponent),
+    KeyMonitor(KeyMonitorComponent),
+    Separator(SeparatorComponent),
 }
 
 impl_component_delegate!(PanelChild {
     Label,
     Button,
     Spacer,
+    KeyMonitor,
+    Separator,
 });
 
 /// A system panel with utility buttons, built from declarative components.
 pub struct WmSystemPanelComponent {
+    children: Vec<PanelChild>,
     scroll_view: ScrollViewComponent<CanvasScrollView<VerticalStackComponent<PanelChild>>>,
+}
+
+fn build_scroll_view(
+    children: Vec<PanelChild>,
+) -> ScrollViewComponent<CanvasScrollView<VerticalStackComponent<PanelChild>>> {
+    let mut stack = VerticalStackComponent::<PanelChild>::new();
+    for child in children {
+        stack.add(child);
+    }
+    ScrollViewComponent::new(CanvasScrollView::new(
+        stack,
+        CanvasSizingPolicy::FitViewportWidth,
+    ))
 }
 
 impl WmSystemPanelComponent {
     pub fn new() -> Self {
-        let mut stack = VerticalStackComponent::<PanelChild>::new();
-        stack.add(PanelChild::Label(
-            LabelComponent::new("Notification test panel").with_color(Color::DarkGray),
-        ));
-        stack.add(PanelChild::Spacer(SpacerComponent::new(1)));
-        stack.add(PanelChild::Label(
-            LabelComponent::new("Click below to send a test toast:").with_color(Color::DarkGray),
-        ));
-        stack.add(PanelChild::Spacer(SpacerComponent::new(1)));
-        stack.add(PanelChild::Button(ButtonComponent::new(
-            "  Send Notification  ",
-            TermWmAction::SendNotification("Hello from System Panel!".to_string()),
-        )));
-        stack.add(PanelChild::Spacer(SpacerComponent::new(1)));
-        stack.add(PanelChild::Label(
-            LabelComponent::new("Debug utilities:").with_color(Color::DarkGray),
-        ));
-        stack.add(PanelChild::Spacer(SpacerComponent::new(1)));
-        stack.add(PanelChild::Button(ButtonComponent::new(
-            "  Trigger Panic  ",
-            TermWmAction::Callback(|| panic!("Manual panic from system panel")),
-        )));
+        let children = vec![
+            PanelChild::Spacer(SpacerComponent::new(1)),
+            PanelChild::Separator(SeparatorComponent::new()),
+            PanelChild::Spacer(SpacerComponent::new(1)),
+            PanelChild::Label(
+                LabelComponent::new("Click below to send a test toast:")
+                    .with_color(Color::DarkGray),
+            ),
+            PanelChild::Spacer(SpacerComponent::new(1)),
+            PanelChild::Button(ButtonComponent::new(
+                "  Send Notification  ",
+                TermWmAction::SendNotification("Hello from System Panel!".to_string()),
+            )),
+            PanelChild::Spacer(SpacerComponent::new(1)),
+            PanelChild::Separator(SeparatorComponent::new()),
+            PanelChild::Spacer(SpacerComponent::new(1)),
+            PanelChild::Label(LabelComponent::new("Debug utilities:").with_color(Color::DarkGray)),
+            PanelChild::Spacer(SpacerComponent::new(1)),
+            PanelChild::Button(ButtonComponent::new(
+                "  Trigger Panic  ",
+                TermWmAction::Callback(|| panic!("Manual panic from system panel")),
+            )),
+        ];
+        let scroll_view = build_scroll_view(children.clone());
+        Self {
+            children,
+            scroll_view,
+        }
+    }
 
-        let scroll_view = ScrollViewComponent::new(CanvasScrollView::new(
-            stack,
-            CanvasSizingPolicy::FitViewportWidth,
-        ));
-        Self { scroll_view }
+    /// Attach a key-monitor applet that displays the most recently pressed key.
+    /// The shared `state` is populated externally (e.g. by the event loop).
+    pub fn with_key_monitor(mut self, state: Rc<RefCell<Option<KeyEvent>>>) -> Self {
+        self.children
+            .insert(0, PanelChild::KeyMonitor(KeyMonitorComponent::new(state)));
+        self.scroll_view = build_scroll_view(self.children.clone());
+        self
     }
 }
 
@@ -108,7 +142,179 @@ impl Component<TermWmAction> for WmSystemPanelComponent {
     }
 }
 
+/// Format a `KeyEvent` into a human-readable display string.
+///
+/// Examples: `Ctrl+A`, `Alt+Tab`, `Shift+Enter`, `Ctrl+Shift+F1`, `Esc`.
+fn format_key_event(key: &KeyEvent) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    if key.modifiers.control {
+        parts.push("Ctrl".to_string());
+    }
+    if key.modifiers.alt {
+        parts.push("Alt".to_string());
+    }
+
+    match key.code {
+        KeyCode::Char(c) => {
+            // For Char keys, the case already reflects Shift; don't add redundant prefix.
+            // Non-alphabetic chars with shift (e.g. '!') are already the shifted form.
+            parts.push(c.to_string());
+        }
+        _ => {
+            if key.modifiers.shift {
+                parts.push("Shift".to_string());
+            }
+            let name = match key.code {
+                KeyCode::Enter => "Enter",
+                KeyCode::Tab => "Tab",
+                KeyCode::Esc => "Esc",
+                KeyCode::Backspace => "Backspace",
+                KeyCode::Left => "Left",
+                KeyCode::Right => "Right",
+                KeyCode::Up => "Up",
+                KeyCode::Down => "Down",
+                KeyCode::Home => "Home",
+                KeyCode::End => "End",
+                KeyCode::PageUp => "PageUp",
+                KeyCode::PageDown => "PageDown",
+                KeyCode::Delete => "Delete",
+                KeyCode::Insert => "Insert",
+                KeyCode::F(n) => {
+                    parts.push(format!("F{}", n));
+                    return parts.join("+");
+                }
+                _ => {
+                    parts.push(format!("{:?}", key.code));
+                    return parts.join("+");
+                }
+            };
+            parts.push(name.to_string());
+        }
+    }
+
+    parts.join("+")
+}
+
+/// A single-line label that displays the last key pressed, sourced from
+/// externally-populated shared state.
+#[derive(Clone)]
+struct KeyMonitorComponent {
+    state: Rc<RefCell<Option<KeyEvent>>>,
+}
+
+impl KeyMonitorComponent {
+    fn new(state: Rc<RefCell<Option<KeyEvent>>>) -> Self {
+        Self { state }
+    }
+}
+
+impl Component<TermWmAction> for KeyMonitorComponent {
+    fn desired_height(&self, _width: u16) -> u16 {
+        1
+    }
+
+    fn render(
+        &mut self,
+        backend: &mut dyn term_wm_render::RenderBackend,
+        area: LayoutRect,
+        _ctx: &ComponentContext,
+        _registry: &mut term_wm_core::hitbox_registry::HitboxRegistry,
+    ) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let display = self
+            .state
+            .borrow()
+            .as_ref()
+            .map(format_key_event)
+            .unwrap_or_else(|| "—".to_string());
+        let rect = layout_rect_to_clipped_rect(area);
+        let backend = downcast_ratatui(backend);
+        let line = Line::from(vec![
+            Span::raw("Last key pressed: "),
+            Span::styled(display, Style::default().fg(Color::Cyan)),
+        ]);
+        let para = Paragraph::new(line);
+        para.render(rect, &mut backend.buffer);
+    }
+
+    fn handle_events(
+        &mut self,
+        _event: &Event,
+        _ctx: &ComponentContext,
+    ) -> EventResult<TermWmAction> {
+        EventResult::Ignored
+    }
+
+    fn update(
+        &mut self,
+        _action: TermWmAction,
+        _ctx: &ComponentContext,
+        _actions: &mut VecDeque<(WindowKey, TermWmAction)>,
+    ) {
+    }
+
+    fn destroy(&mut self) {}
+}
+
+/// A horizontal separator line drawn across the full width.
+#[derive(Clone)]
+struct SeparatorComponent;
+
+impl SeparatorComponent {
+    fn new() -> Self {
+        Self
+    }
+}
+
+impl Component<TermWmAction> for SeparatorComponent {
+    fn desired_height(&self, _width: u16) -> u16 {
+        1
+    }
+
+    fn render(
+        &mut self,
+        backend: &mut dyn term_wm_render::RenderBackend,
+        area: LayoutRect,
+        _ctx: &ComponentContext,
+        _registry: &mut term_wm_core::hitbox_registry::HitboxRegistry,
+    ) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let rect = layout_rect_to_clipped_rect(area);
+        let backend = downcast_ratatui(backend);
+        let line = "─".repeat(area.width as usize);
+        let para = Paragraph::new(Line::from(Span::styled(
+            line,
+            Style::default().fg(Color::DarkGray),
+        )));
+        para.render(rect, &mut backend.buffer);
+    }
+
+    fn handle_events(
+        &mut self,
+        _event: &Event,
+        _ctx: &ComponentContext,
+    ) -> EventResult<TermWmAction> {
+        EventResult::Ignored
+    }
+
+    fn update(
+        &mut self,
+        _action: TermWmAction,
+        _ctx: &ComponentContext,
+        _actions: &mut VecDeque<(WindowKey, TermWmAction)>,
+    ) {
+    }
+
+    fn destroy(&mut self) {}
+}
+
 /// A simple spacer component that takes up a fixed number of rows.
+#[derive(Clone)]
 struct SpacerComponent {
     height: u16,
 }
@@ -135,7 +341,7 @@ impl Component<TermWmAction> for SpacerComponent {
 
     fn handle_events(
         &mut self,
-        _event: &term_wm_core::events::Event,
+        _event: &Event,
         _ctx: &ComponentContext,
     ) -> EventResult<TermWmAction> {
         EventResult::Ignored
@@ -157,12 +363,11 @@ mod tests {
     use super::*;
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
-    use term_wm_core::events::{Event, KeyCode, KeyEvent, KeyKind, KeyModifiers};
+    use term_wm_core::events::{KeyKind, KeyModifiers};
 
     #[test]
     fn system_panel_new_constructs() {
         let panel = WmSystemPanelComponent::new();
-        // Panel wraps a ScrollViewComponent<VerticalStackComponent>; just verify it builds
         let _ = &panel;
     }
 
@@ -239,6 +444,191 @@ mod tests {
     fn system_panel_destroy_is_noop() {
         let mut panel = WmSystemPanelComponent::new();
         panel.destroy();
+    }
+
+    #[test]
+    fn with_key_monitor_builds() {
+        let state = Rc::new(RefCell::new(None));
+        let panel = WmSystemPanelComponent::new().with_key_monitor(state);
+        let _ = &panel;
+    }
+
+    #[test]
+    fn key_monitor_desired_height() {
+        let state = Rc::new(RefCell::new(None));
+        let monitor = KeyMonitorComponent::new(state);
+        assert_eq!(monitor.desired_height(40), 1);
+    }
+
+    #[test]
+    fn key_monitor_handle_events_ignored() {
+        let state = Rc::new(RefCell::new(None));
+        let mut monitor = KeyMonitorComponent::new(state);
+        let ctx = ComponentContext::new(true);
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+            KeyKind::Press,
+        ));
+        assert!(monitor.handle_events(&event, &ctx).is_ignored());
+    }
+
+    #[test]
+    fn key_monitor_render_no_panic_with_key() {
+        let state = Rc::new(RefCell::new(Some(KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers {
+                shift: false,
+                control: true,
+                alt: false,
+            },
+            KeyKind::Press,
+        ))));
+        let mut monitor = KeyMonitorComponent::new(state);
+        let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 1));
+        let ctx = ComponentContext::new(true).with_screen_area(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 1,
+        });
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        monitor.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 1,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn key_monitor_render_skips_zero_area() {
+        let state = Rc::new(RefCell::new(None));
+        let mut monitor = KeyMonitorComponent::new(state);
+        let buffer = Buffer::empty(Rect::new(0, 0, 40, 1));
+        let mut backend =
+            term_wm_console::RatatuiBackend::new_simple(buffer, Rect::new(0, 0, 40, 1));
+        let ctx = ComponentContext::new(true);
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        monitor.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 1,
+            },
+            &ctx,
+            &mut registry,
+        );
+        monitor.render(
+            &mut backend,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 0,
+            },
+            &ctx,
+            &mut registry,
+        );
+    }
+
+    #[test]
+    fn key_monitor_update_is_noop() {
+        let state = Rc::new(RefCell::new(None));
+        let mut monitor = KeyMonitorComponent::new(state);
+        let ctx = ComponentContext::new(true);
+        let mut actions = VecDeque::new();
+        monitor.update(TermWmAction::Quit, &ctx, &mut actions);
+    }
+
+    #[test]
+    fn key_monitor_destroy_is_noop() {
+        let state = Rc::new(RefCell::new(None));
+        let mut monitor = KeyMonitorComponent::new(state);
+        monitor.destroy();
+    }
+
+    #[test]
+    fn format_key_event_ctrl_a() {
+        let key = KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers {
+                shift: false,
+                control: true,
+                alt: false,
+            },
+            KeyKind::Press,
+        );
+        assert_eq!(format_key_event(&key), "Ctrl+a");
+    }
+
+    #[test]
+    fn format_key_event_alt_tab() {
+        let key = KeyEvent::new(
+            KeyCode::Tab,
+            KeyModifiers {
+                shift: false,
+                control: false,
+                alt: true,
+            },
+            KeyKind::Press,
+        );
+        assert_eq!(format_key_event(&key), "Alt+Tab");
+    }
+
+    #[test]
+    fn format_key_event_shift_enter() {
+        let key = KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers {
+                shift: true,
+                control: false,
+                alt: false,
+            },
+            KeyKind::Press,
+        );
+        assert_eq!(format_key_event(&key), "Shift+Enter");
+    }
+
+    #[test]
+    fn format_key_event_plain_char() {
+        let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE, KeyKind::Press);
+        assert_eq!(format_key_event(&key), "x");
+    }
+
+    #[test]
+    fn format_key_event_esc() {
+        let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE, KeyKind::Press);
+        assert_eq!(format_key_event(&key), "Esc");
+    }
+
+    #[test]
+    fn format_key_event_f1() {
+        let key = KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE, KeyKind::Press);
+        assert_eq!(format_key_event(&key), "F1");
+    }
+
+    #[test]
+    fn format_key_event_ctrl_shift_f5() {
+        let key = KeyEvent::new(
+            KeyCode::F(5),
+            KeyModifiers {
+                shift: true,
+                control: true,
+                alt: false,
+            },
+            KeyKind::Press,
+        );
+        assert_eq!(format_key_event(&key), "Ctrl+Shift+F5");
     }
 
     #[test]

--- a/crates/term-wm-ui-components/src/button.rs
+++ b/crates/term-wm-ui-components/src/button.rs
@@ -12,7 +12,7 @@ use term_wm_layout_engine::LayoutRect;
 use crate::helpers::layout_rect_to_clipped_rect;
 
 /// A clickable button rendered as styled borders + label.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ButtonComponent {
     label: String,
     action: TermWmAction,

--- a/crates/term-wm-ui-components/src/label.rs
+++ b/crates/term-wm-ui-components/src/label.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 use term_wm_core::actions::{EventResult, TermWmAction};
@@ -11,10 +11,11 @@ use term_wm_layout_engine::LayoutRect;
 use crate::helpers::layout_rect_to_clipped_rect;
 
 /// A single-line text label.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LabelComponent {
     text: String,
     color: Color,
+    bold: bool,
 }
 
 impl LabelComponent {
@@ -22,11 +23,17 @@ impl LabelComponent {
         Self {
             text: text.into(),
             color: Color::White,
+            bold: false,
         }
     }
 
     pub fn with_color(mut self, color: Color) -> Self {
         self.color = color;
+        self
+    }
+
+    pub fn with_bold(mut self) -> Self {
+        self.bold = true;
         self
     }
 }
@@ -48,10 +55,11 @@ impl Component<TermWmAction> for LabelComponent {
         }
         let rect = layout_rect_to_clipped_rect(area);
         let backend = crate::helpers::downcast_ratatui(backend);
-        let para = Paragraph::new(Line::from(Span::styled(
-            self.text.as_str(),
-            Style::default().fg(self.color),
-        )));
+        let mut style = Style::default().fg(self.color);
+        if self.bold {
+            style = style.add_modifier(Modifier::BOLD);
+        }
+        let para = Paragraph::new(Line::from(Span::styled(self.text.as_str(), style)));
         para.render(rect, &mut backend.buffer);
     }
 

--- a/run-cage-foot.sh
+++ b/run-cage-foot.sh
@@ -7,4 +7,7 @@
 #
 # See related issue:: https://github.com/jzombie/term-wm/issues/163
 
-cage -s -- foot sh -c "RUST_BACKTRACE=1 cargo run --release"
+unset DISPLAY
+
+# cage -s -- foot sh -c "RUST_BACKTRACE=1 cargo run --release"
+cage -- foot cargo run --release > ~/.local/state/cage.log 2>&1 || echo "[$(date)] Environment crashed with exit code $?" >> ~/.local/state/cage-crash.log

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use term_wm::unified_event_source::{UnifiedEvent, UnifiedEventSource};
 use term_wm::wm_config::WmConfig;
 use term_wm_console::console_render_target::ConsoleRenderTarget;
 use term_wm_core::components::Component;
+use term_wm_core::events::Event;
 use term_wm_ui_facade::{LayerComponent, OverlayComponent};
 
 // TODO: Make this user-configurable
@@ -186,6 +187,10 @@ impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for A
     ) -> &mut term_wm::window::WindowManager<AppRootComponent, LayerComponent, OverlayComponent>
     {
         self.inner.wm()
+    }
+
+    fn handle_app_event(&mut self, event: &Event) -> bool {
+        self.inner.handle_app_event(event)
     }
 
     fn open_help_overlay(&mut self) {

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::io;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crossbeam_channel::{Sender, bounded};
@@ -12,6 +14,7 @@ use term_wm_core::components::Component;
 use term_wm_core::config::AppBuilder;
 use term_wm_core::debug_log::set_global_debug_log;
 use term_wm_core::engine::CoreEngine;
+use term_wm_core::events::{Event, KeyEvent};
 use term_wm_core::io::{EventSource, RenderTarget};
 use term_wm_core::runner::{WindowManagerHost, run_with_defaults};
 use term_wm_core::window::{ClosePolicy, WindowKey, WindowManager, WindowState};
@@ -87,6 +90,8 @@ where
     draw_renderer: DrawPlanRenderer,
     /// Sender for PTY events (wakeup, exit, direct-input transitions).
     pty_wakeup_tx: Sender<UnifiedEvent>,
+    /// Shared state for the key-monitor applet in the system panel.
+    last_key: Rc<RefCell<Option<KeyEvent>>>,
 }
 
 impl<C: Component<TermWmAction>> TermWmApp<C> {
@@ -175,6 +180,7 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
             engine: CoreEngine::new(),
             draw_renderer: DrawPlanRenderer::new(),
             pty_wakeup_tx,
+            last_key: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -302,7 +308,7 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
 
         // System Panel — hidden, toggled via keybinding, persists across close.
         {
-            let sys_panel = WmSystemPanelComponent::new();
+            let sys_panel = WmSystemPanelComponent::new().with_key_monitor(self.last_key.clone());
             let sys_key =
                 self.wm
                     .create_window(AppRootComponent::Core(CoreWmComponent::SystemPanel(
@@ -433,6 +439,13 @@ impl<C: Component<TermWmAction>>
             &mut self.engine,
             &mut self.draw_renderer,
         );
+    }
+
+    fn handle_app_event(&mut self, event: &Event) -> bool {
+        if let Event::Key(key) = event {
+            *self.last_key.borrow_mut() = Some(*key);
+        }
+        false
     }
 
     fn on_panic(&mut self) {


### PR DESCRIPTION
- Add KeyMonitorComponent + format_key_event for live key press display
- Add SeparatorComponent for visual grouping
- Refactor WmSystemPanelComponent to builder pattern (with_key_monitor)
- Add bold support and Clone derive to LabelComponent
- Add Clone derive to ButtonComponent
- Wire shared last_key state through TermWmApp + App (main.rs)
- Move handle_app_event to PRE-LAYER in runner.rs for all-event capture
