### PR TITLE
feat: Dynamic Command Palette titles, SUPER key forwarding, unicode-safe truncation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "term-wm-pty-engine",
  "term-wm-render",
  "tracing",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3145,6 +3146,7 @@ dependencies = [
  "term-wm-render",
  "textwrap",
  "tracing",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+unicode-width = "0.2.2"
 vt100 = "0.16.2"
 vte = "0.15.0"
 webbrowser = "1.2.1"

--- a/crates/term-wm-console/Cargo.toml
+++ b/crates/term-wm-console/Cargo.toml
@@ -16,6 +16,7 @@ term-wm-crossterm-adapter = { workspace = true }
 term-wm-layout-engine = { workspace = true }
 term-wm-render = { workspace = true }
 tracing = { workspace = true }
+unicode-width = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -16,7 +16,9 @@ use term_wm_core::layout::tiling::SplitHandle;
 use term_wm_core::layout::{Direction, FloatingPane, RectSpec, RegionMap};
 use term_wm_core::term_color::lerp_color;
 use term_wm_core::theme::{Color, Theme};
+use term_wm_core::utils::truncate_with_ellipsis;
 use term_wm_core::window::{ComponentTag, WindowKey, WindowManager, WindowSurface};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Render context for window chrome (owned by console, not core).
 pub struct ChromeCtx<'a> {
@@ -1191,19 +1193,26 @@ fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
                 cell.set_style(header_style);
             }
         }
-        let title_len = title.len() as u16;
         let header_width = header_right.saturating_sub(header_left).saturating_add(1);
-        if title_len <= header_width {
-            let start_x = header_left + (header_width - title_len) / 2;
-            let buf_w = buffer.area.width as usize;
-            let rel_y = header_y as usize - buffer.area.y as usize;
-            for (idx, ch) in title.chars().enumerate() {
-                let x = start_x + idx as u16;
-                let rel_x = x as usize - buffer.area.x as usize;
-                let cell = &mut buffer.content[rel_y * buf_w + rel_x];
-                cell.set_symbol(&ch.to_string());
-                cell.set_style(header_style);
+        let display_title = truncate_with_ellipsis(title, header_width as usize);
+        let start_x = header_left + (header_width.saturating_sub(display_title.width() as u16)) / 2;
+        let buf_w = buffer.area.width as usize;
+        let rel_y = header_y as usize - buffer.area.y as usize;
+        let mut cx = start_x;
+        for c in display_title.chars() {
+            let cw = c.width().unwrap_or(0) as u16;
+            if cw == 0 {
+                continue;
             }
+            let rel_x = cx as usize - buffer.area.x as usize;
+            buffer.content[rel_y * buf_w + rel_x].set_symbol(&c.to_string());
+            buffer.content[rel_y * buf_w + rel_x].set_style(header_style);
+            for i in 1..cw {
+                let span_x = rel_x + i as usize;
+                buffer.content[rel_y * buf_w + span_x].set_symbol("");
+                buffer.content[rel_y * buf_w + span_x].set_style(header_style);
+            }
+            cx += cw;
         }
         {
             let buf_w = buffer.area.width as usize;

--- a/crates/term-wm-core/Cargo.toml
+++ b/crates/term-wm-core/Cargo.toml
@@ -26,3 +26,4 @@ term-wm-pty-engine = { workspace = true }
 term-wm-render = { workspace = true }
 textwrap = "0.16"
 tracing = { workspace = true }
+unicode-width = { workspace = true }

--- a/crates/term-wm-core/src/actions.rs
+++ b/crates/term-wm-core/src/actions.rs
@@ -126,6 +126,11 @@ pub enum TermWmAction {
     CancelSwap,
     /// Execute an inline callback.
     Callback(fn()),
+    /// Send the OpenCommandPalette key combo bytes to the given window.
+    SendSuperKeyToWindow(WindowKey),
+    /// Send the OpenCommandPalette key combo bytes to the focused window
+    /// (payload-free for palette-layer keybinding).
+    SendSuperKeyToFocusedWindow,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -221,7 +226,9 @@ impl TermWmAction {
             | TermWmAction::BeginTapSwap(_)
             | TermWmAction::TapSwapTarget(_)
             | TermWmAction::ConfirmSwap
-            | TermWmAction::CancelSwap => Category::Windows,
+            | TermWmAction::CancelSwap
+            | TermWmAction::SendSuperKeyToWindow(_)
+            | TermWmAction::SendSuperKeyToFocusedWindow => Category::Windows,
 
             TermWmAction::MenuUp
             | TermWmAction::MenuDown
@@ -268,6 +275,7 @@ impl TermWmAction {
             TermWmAction::CyclePrevWindow => Some(55),
             TermWmAction::NewWindow => Some(50),
             TermWmAction::HintToggle => Some(40),
+            TermWmAction::SendSuperKeyToFocusedWindow => Some(45),
 
             _ => None,
         }
@@ -339,6 +347,8 @@ impl fmt::Display for TermWmAction {
             TermWmAction::ConfirmSwap => "Confirm swap",
             TermWmAction::CancelSwap => "Cancel swap",
             TermWmAction::Callback(_) => "Callback",
+            TermWmAction::SendSuperKeyToWindow(_) => "Send SUPER key to window",
+            TermWmAction::SendSuperKeyToFocusedWindow => "Send SUPER key to focused window",
         };
         write!(f, "{}", s)
     }

--- a/crates/term-wm-core/src/keybindings.rs
+++ b/crates/term-wm-core/src/keybindings.rs
@@ -85,7 +85,8 @@ impl Default for KeyBindings {
             CloseHelp: [ (KeyCode::Esc, KeyModifiers::NONE), (KeyCode::Enter, KeyModifiers::NONE), (KeyCode::Char('q'), KeyModifiers::NONE) ],
             FocusNext: [ (KeyCode::Tab, KeyModifiers::NONE) ],
             FocusPrev: [ (KeyCode::Tab, KeyModifiers { shift: true, control: false, alt: false }) ],
-            OpenCommandPalette: [ (KeyCode::Char('g'), KeyModifiers { control: true, shift: false, alt: false }) ],
+            OpenCommandPalette: [ (KeyCode::Char('a'), KeyModifiers { control: true, shift: false, alt: false }) ],
+            SendSuperKeyToFocusedWindow: [ (KeyCode::Char('a'), KeyModifiers { control: true, shift: false, alt: false }) ],
             MenuUp: [ (KeyCode::Up, KeyModifiers::NONE) ],
             MenuDown: [ (KeyCode::Down, KeyModifiers::NONE) ],
             MenuSelect: [ (KeyCode::Enter, KeyModifiers::NONE) ],
@@ -247,6 +248,8 @@ impl KeyBindings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actions::ActionLayer;
+    use crate::events::{KeyEvent, KeyKind};
 
     #[test]
     fn default_keybindings_is_not_empty() {
@@ -255,5 +258,16 @@ mod tests {
             !kb.combos_for(TermWmAction::CloseHelp).is_empty(),
             "CloseHelp should have at least one keybinding"
         );
+    }
+
+    #[test]
+    fn send_super_key_matches_open_command_palette() {
+        let kb = KeyBindings::default();
+        let global_combo = kb
+            .first_combo(TermWmAction::OpenCommandPalette)
+            .expect("OpenCommandPalette must have a default keybinding");
+        let test_key = KeyEvent::new(global_combo.code, global_combo.mods, KeyKind::Press);
+        let found = kb.action_for_key_in_layer(&test_key, ActionLayer::CommandPalette);
+        assert_eq!(found, Some(TermWmAction::SendSuperKeyToFocusedWindow));
     }
 }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::time::{Duration, Instant};
 
-use crate::events::{Event, KeyKind, MouseEventKind};
+use crate::events::{Event, KeyEvent, KeyKind, MouseEventKind};
 use term_wm_render::RenderTarget;
 
 use std::collections::VecDeque;
@@ -119,6 +119,29 @@ fn dispatch_action<
         TermWmAction::PasteClipboard => {
             if let Some(text) = app.wm().clipboard_mut().and_then(|cb| cb.get().ok()) {
                 queue.push_back((key, TermWmAction::ClipboardPaste(text)));
+            }
+        }
+        TermWmAction::SendSuperKeyToWindow(target) => {
+            let kb = app.wm().keybindings();
+            if let Some(combo) = kb.first_combo(TermWmAction::OpenCommandPalette) {
+                let bytes =
+                    KeyEvent::new(combo.code, combo.mods, KeyKind::Press).to_pty_bytes(false);
+                if !bytes.is_empty() {
+                    queue.push_back((target, TermWmAction::KeyToBytes(bytes)));
+                }
+            }
+        }
+        TermWmAction::SendSuperKeyToFocusedWindow => {
+            if let Some(combo) = app
+                .wm()
+                .keybindings()
+                .first_combo(TermWmAction::OpenCommandPalette)
+            {
+                let bytes =
+                    KeyEvent::new(combo.code, combo.mods, KeyKind::Press).to_pty_bytes(false);
+                if !bytes.is_empty() {
+                    queue.push_back((key, TermWmAction::KeyToBytes(bytes)));
+                }
             }
         }
         action => {
@@ -464,13 +487,19 @@ where
                         .keybindings()
                         .matches(TermWmAction::OpenCommandPalette, key)
                 {
-                    if app.wm().command_palette_visible() {
-                        app.wm().close_command_palette();
-                    } else {
+                    // When palette is visible, don't close — fall through to palette barrier
+                    // where the CommandPalette-layer keybinding handles the SUPER combo.
+                    if !app.wm().command_palette_visible() {
                         app.open_command_palette();
+                        update_selection_snapshot(app);
+                        return flush_state_changes(
+                            app,
+                            driver,
+                            ControlFlow::Continue,
+                            false,
+                            None,
+                        );
                     }
-                    update_selection_snapshot(app);
-                    return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
                 }
 
                 // In tab outline mode, any non-focus key closes the palette immediately.
@@ -525,7 +554,8 @@ where
                         );
                     }
 
-                    if let Some(action) = app.wm().handle_command_palette_event(&evt) {
+                    let palette_handled = app.wm().handle_command_palette_event(&evt);
+                    if let Some(action) = palette_handled {
                         let key = app.wm().focused_window();
                         let mut actions = std::collections::VecDeque::new();
                         // NewWindow returns Result — propagate the error
@@ -535,6 +565,32 @@ where
                             actions.push_back((key, action));
                         }
                         drain_action_queue(app, &mut actions);
+                    } else if let Event::Key(key) = &evt {
+                        // SendSuperKeyToFocusedWindow is bound in the CommandPalette layer.
+                        // Only intercept it specifically — not FocusNext/FocusPrev (Tab/Shift+Tab),
+                        // which need to reach handle_focus_event below.
+                        if app
+                            .wm()
+                            .keybindings()
+                            .matches(TermWmAction::SendSuperKeyToFocusedWindow, key)
+                        {
+                            let focused_key = app.wm().focused_window();
+                            let mut actions = std::collections::VecDeque::new();
+                            actions.push_back((
+                                focused_key,
+                                TermWmAction::SendSuperKeyToFocusedWindow,
+                            ));
+                            drain_action_queue(app, &mut actions);
+                            app.wm().close_command_palette();
+                            update_selection_snapshot(app);
+                            return flush_state_changes(
+                                app,
+                                driver,
+                                ControlFlow::Continue,
+                                false,
+                                None,
+                            );
+                        }
                     }
                     // Focus routing while menu is open (Tab/Shift+Tab)
                     if matches!(&evt, Event::Key(_)) && app.wm().handle_focus_event(&evt) {

--- a/crates/term-wm-core/src/utils/mod.rs
+++ b/crates/term-wm-core/src/utils/mod.rs
@@ -5,6 +5,38 @@ pub mod selectable_text;
 
 pub use keyboard_normalizer::KeyboardNormalizer;
 
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Truncate a string to a maximum cellular width, appending `…` (U+2026)
+/// if the string exceeds the bound. Safe for multi-width Unicode characters.
+/// Returns an empty string when `max_width` is 0.
+pub fn truncate_with_ellipsis(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    if value.width() <= max_width {
+        return value.to_string();
+    }
+    let target = max_width.saturating_sub(1);
+    let mut current = 0;
+    let mut out = String::new();
+    for c in value.chars() {
+        let cw = c.width().unwrap_or(0);
+        if current + cw > target {
+            break;
+        }
+        current += cw;
+        out.push(c);
+    }
+
+    // TODO: Not a fan of Unicode characters (or any strings) being hardcoded
+    // into the core, but the Command Palette and several other places
+    // currently use them.
+    // Unicode ellipsis
+    out.push('\u{2026}');
+    out
+}
+
 /// Truncate a string to a maximum character width.
 /// Pure string manipulation — no rendering dependencies.
 pub fn truncate_to_width(value: &str, width: usize) -> String {
@@ -12,4 +44,49 @@ pub fn truncate_to_width(value: &str, width: usize) -> String {
         return value.to_string();
     }
     value.chars().take(width).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_returns_empty() {
+        assert_eq!(truncate_with_ellipsis("", 10), "");
+    }
+
+    #[test]
+    fn zero_max_width_returns_empty() {
+        assert_eq!(truncate_with_ellipsis("hello", 0), "");
+    }
+
+    #[test]
+    fn fits_exactly_returns_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncates_with_ellipsis() {
+        assert_eq!(truncate_with_ellipsis("hello world", 8), "hello w…");
+    }
+
+    #[test]
+    fn single_char_target() {
+        assert_eq!(truncate_with_ellipsis("ab", 1), "…");
+    }
+
+    #[test]
+    fn cjk_fits_one_char_plus_ellipsis() {
+        assert_eq!(truncate_with_ellipsis("日本語", 3), "日…");
+    }
+
+    #[test]
+    fn cjk_rejected_when_no_room() {
+        assert_eq!(truncate_with_ellipsis("日本語", 2), "…");
+    }
+
+    #[test]
+    fn cjk_mixed_truncation() {
+        assert_eq!(truncate_with_ellipsis("ab日本語", 6), "ab日…");
+    }
 }

--- a/crates/term-wm-core/src/window/window_manager/focus.rs
+++ b/crates/term-wm-core/src/window/window_manager/focus.rs
@@ -86,6 +86,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                                 | crate::actions::TermWmAction::MaximizeWindow(_)
                                 | crate::actions::TermWmAction::MinimizeWindow(_)
                                 | crate::actions::TermWmAction::CloseWindow(_)
+                                | crate::actions::TermWmAction::SendSuperKeyToWindow(_)
+                                | crate::actions::TermWmAction::SendSuperKeyToFocusedWindow
                         )
                 }
                 MenuDisplayItem::Separator => true,

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2736,17 +2736,57 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         // Window management group (directly below top group)
         {
             if has_active {
-                for btn in self.window_management_buttons() {
+                let raw_title = self.window_title(focused);
+                let title = crate::utils::truncate_with_ellipsis(&raw_title, 25);
+                let super_key = self
+                    .keybindings()
+                    .combos_for(crate::actions::TermWmAction::OpenCommandPalette)
+                    .first()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "Super".to_string());
+
+                // Send SUPER key to window
+                items.push(MenuDisplayItem::Item(MenuItem {
+                    label: format!("Send {} to {}", super_key, title).into(),
+                    icon: Some("S"),
+                    action: crate::actions::TermWmAction::SendSuperKeyToWindow(focused),
+                    disabled: false,
+                }));
+
+                // Close window
+                items.push(MenuDisplayItem::Item(MenuItem {
+                    label: format!("Close {}", title).into(),
+                    icon: Some("X"),
+                    action: crate::actions::TermWmAction::CloseWindow(focused),
+                    disabled: false,
+                }));
+
+                // Maximize / Restore
+                let is_maxed = self.window(focused).is_some_and(|w| w.is_maximized());
+                if !self.is_monocle() {
                     items.push(MenuDisplayItem::Item(MenuItem {
-                        label: btn.label.into(),
-                        icon: Some(btn.symbol),
-                        action: btn.action,
+                        label: (if is_maxed {
+                            format!("Restore {}", title)
+                        } else {
+                            format!("Maximize {}", title)
+                        })
+                        .into(),
+                        icon: Some(if is_maxed { "─" } else { "▢" }),
+                        action: crate::actions::TermWmAction::MaximizeWindow(focused),
+                        disabled: false,
+                    }));
+                    items.push(MenuDisplayItem::Item(MenuItem {
+                        label: format!("Minimize {}", title).into(),
+                        icon: Some("_"),
+                        action: crate::actions::TermWmAction::MinimizeWindow(focused),
                         disabled: false,
                     }));
                 }
-                for (key, title) in self.window_titles() {
+
+                // Switch to windows
+                for (key, switch_title) in self.window_titles() {
                     items.push(MenuDisplayItem::Item(MenuItem {
-                        label: format!("Switch to: {}", title).into(),
+                        label: format!("Switch to: {}", switch_title).into(),
                         icon: Some("→"),
                         action: crate::actions::TermWmAction::FocusWindow(key),
                         disabled: key == focused,

--- a/crates/term-wm-ui-components/src/text_renderer.rs
+++ b/crates/term-wm-ui-components/src/text_renderer.rs
@@ -1049,7 +1049,7 @@ mod tests {
         // (w + usable - 1) / usable gave 2, truncating the third line.
         let line = Line::from(vec![
             ratatui::text::Span::raw(
-                "To send Ctrl+G to the currently focused application, press Ctrl+G",
+                "To send Ctrl+A to the currently focused application, press Ctrl+A",
             ),
             ratatui::text::Span::raw(
                 " twice quickly. (The second press is forwarded to the active window.)",

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -495,6 +495,8 @@ impl<C: Component<TermWmAction>>
                                 | TermWmAction::MaximizeWindow(_)
                                 | TermWmAction::MinimizeWindow(_)
                                 | TermWmAction::CloseWindow(_)
+                                | TermWmAction::SendSuperKeyToWindow(_)
+                                | TermWmAction::SendSuperKeyToFocusedWindow
                         )
                 }
                 MenuDisplayItem::Separator => true,


### PR DESCRIPTION
Command Palette:
- Replace hardcoded "Close Window" / "Minimize Window" / "Maximize Window" / "Restore Window" labels with the actual window title (e.g., "Close htop")
- Add "Send <SUPER> to <title>" item with icon "S" above Close, where SUPER is dynamically resolved from the OpenCommandPalette keybinding display string
- Truncate long window titles to 25 cells using the new centralised function

SUPER Key Forwarding (data-driven keybinding):
- Add SendSuperKeyToWindow(WindowKey) for the command palette menu item
- Add SendSuperKeyToFocusedWindow (payload-free) for palette-layer keybinding
- When palette is open and SUPER is pressed, forward the key bytes to the focused terminal, then close the palette (avoids double-dispatch)
- Same Ctrl+A combo works in Global layer (OpenCommandPalette) and CommandPalette layer (SendSuperKeyToFocusedWindow), selected by context
- Pre-barrier no longer closes palette on SUPER — falls through to barrier
- Show "Ctrl+A  Send SUPER key to focused window" in bottom hints at priority 45 (after Tab/Shift+Tab at 70/65)

Centralized Unicode-Safe Truncation:
- Add truncate_with_ellipsis() to utils/mod.rs using unicode-width for cellular-width-safe iteration with … (U+2026) ellipsis
- Guards max_width == 0 → empty string; measures width via UnicodeWidthStr
- Replaces inline .chars().take(N) hack in wm_menu_items
- Replaces all-or-nothing chrome header title rendering: titles now always visible, truncated to fit header width with ellipsis when necessary
- Rendering uses mutable cx accumulator advancing by each character's cellular width, clearing spanned cells for multi-width graphemes

Dependencies:
- Add unicode-width = "0.2" to workspace, term-wm-core, term-wm-console

Keybinding change:
- OpenCommandPalette default changed from Ctrl+G to Ctrl+A

Tests:
- truncate_with_ellipsis: 8 unit tests (empty, zero-width, exact fit, truncation, single-char, CJK fit/reject/mixed)
- send_super_key_matches_open_command_palette: verifies both layers share the same Ctrl+A combo
- Existing 90 integration tests continue to pass