### PR TITLE
fix: Resolve window layout state-erasure, void lifecycle, and insertion priority bugs

### DIFF
--- a/crates/term-wm-core/src/layout/tiling.rs
+++ b/crates/term-wm-core/src/layout/tiling.rs
@@ -104,11 +104,30 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
         self.root.remove_void_by_id(void_id)
     }
 
+    /// Unified topological fallback: consumes the first available Void node.
+    /// Returns true if a Void was successfully filled.
+    pub fn consume_first_void(&mut self, insert: Id, area: Rect) -> bool {
+        let voids = self.void_regions(area);
+        if !voids.is_empty() {
+            let target_void_id = voids[0].0;
+            self.replace_void_by_id(target_void_id, LayoutNode::leaf(insert));
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn swap_nodes(&mut self, source: &Id, target: &Id) -> bool {
         self.root.swap_leaves(source, target)
     }
 
     pub fn insert_window_balanced(&mut self, insert: Id, area: Rect) {
+        // 1. Unified topological fallback — fill voids before splitting
+        if self.consume_first_void(insert, area) {
+            return;
+        }
+
+        // 2. Existing largest-leaf split logic
         let regions = self.regions(area);
         if regions.is_empty() {
             self.split_root(insert, InsertPosition::Right);
@@ -266,6 +285,55 @@ impl<Id: Copy + Eq + Ord> LayoutPlan<Id> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn insert_window_balanced_consumes_void_before_splitting_leaf() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+
+        // Construct tree: Split [ Leaf(1), Void(42) ]
+        let root = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::leaf(1), LayoutNode::Void(42)],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        let mut layout = TilingLayout::new(root);
+
+        assert_eq!(
+            layout.void_regions(area).len(),
+            1,
+            "Initial tree must contain 1 void"
+        );
+
+        // Insert window 2 into tree with void
+        layout.insert_window_balanced(2, area);
+
+        // Assert: Void node was consumed, no new splits were created
+        assert_eq!(
+            layout.void_regions(area).len(),
+            0,
+            "Void must be completely consumed"
+        );
+        let leaves = layout.root().collect_leaves();
+        assert_eq!(leaves, vec![1, 2], "Window 2 must occupy the vacant slot");
+
+        if let LayoutNode::Split { children, .. } = layout.root() {
+            assert_eq!(
+                children.len(),
+                2,
+                "Topology must remain a 2-child split (no nesting)"
+            );
+            assert_eq!(children[0].unwrap_leaf(), Some(1));
+            assert_eq!(children[1].unwrap_leaf(), Some(2));
+        } else {
+            panic!("Root must remain a Split");
+        }
+    }
 
     #[test]
     fn tiling_handle_event_direct() {

--- a/crates/term-wm-core/src/window/window_manager/chrome.rs
+++ b/crates/term-wm-core/src/window/window_manager/chrome.rs
@@ -29,10 +29,17 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 // Was tiled: restore Void → Leaf in layout tree
                 self.clear_floating_rect(key);
                 let void_id = self.window(key).and_then(|w| w.void_id());
+
+                let mut restored = false;
                 if let Some(vid) = void_id
                     && let Some(ref mut layout) = self.managed_layout
                 {
-                    layout.replace_void_by_id(vid, LayoutNode::leaf(key));
+                    restored = layout.replace_void_by_id(vid, LayoutNode::leaf(key));
+                }
+
+                // Force re-attachment if the Void node was destroyed (e.g., during minimize)
+                if !restored && self.window_state(key) == Some(WindowState::Mapped) {
+                    self.reattach_to_tiling_layout(key);
                 }
             }
 
@@ -104,5 +111,83 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             }
             self.windows.remove(key);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Rect;
+    use crate::app_context::AppContext;
+    use crate::components::NoopComponent;
+    use crate::window::WindowState;
+    use crate::wm_config::WmConfig;
+    use std::sync::Arc;
+
+    fn make_wm() -> WindowManager<NoopComponent> {
+        WindowManager::<NoopComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        )
+    }
+
+    #[test]
+    fn maximize_minimize_unmaximize_retains_window() {
+        let mut wm = make_wm();
+
+        let key_a = wm.create_window(NoopComponent);
+        let key_b = wm.create_window(NoopComponent);
+        wm.transition_window(key_a, WindowState::Mapped);
+        wm.transition_window(key_b, WindowState::Mapped);
+
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // 1. Maximize window A (creates Void in tree, stores void_id)
+        wm.toggle_maximize(key_a);
+        assert!(wm.window(key_a).is_some_and(|w| w.is_maximized()));
+        assert!(wm.is_window_floating(key_a));
+
+        // 2. Minimize window A (destroys Void, clears void_id)
+        wm.minimize_window(key_a);
+        assert_eq!(wm.window_state(key_a), Some(WindowState::Iconic));
+
+        // 3. Restore window A (state -> Mapped)
+        wm.restore_minimized(key_a);
+        assert_eq!(wm.window_state(key_a), Some(WindowState::Mapped));
+
+        // 4. Unmaximize window A (toggle_maximize — void_id pointer is now stale/None)
+        wm.toggle_maximize(key_a);
+        assert!(!wm.window(key_a).is_some_and(|w| w.is_maximized()));
+        assert!(!wm.is_window_floating(key_a));
+
+        // Assert: Window A was forcefully reattached to tiling layout via fallback
+        assert!(
+            wm.layout_contains(key_a),
+            "Window A must be reattached to tiling layout despite stale void_id"
+        );
+        assert!(
+            wm.z_order.contains(&key_a),
+            "Window A must remain in z_order"
+        );
+
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        let reg = wm.region(key_a);
+        assert!(
+            reg.width > 0 && reg.height > 0,
+            "Window A must have a valid rendered region after unmaximize"
+        );
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -485,7 +485,17 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             active_keys.push(floating_key);
         }
 
-        self.z_order.retain(|key| active_keys.contains(key));
+        // Retain only windows that are not Unmapped — uses window_state authority,
+        // not geometric active_keys, to avoid purging Iconic/Shaded from z_order.
+        self.z_order = self
+            .z_order
+            .iter()
+            .filter(|k| {
+                self.window_state(**k)
+                    .is_some_and(|s| s != WindowState::Unmapped)
+            })
+            .copied()
+            .collect();
         for &key in &active_keys {
             if !self.z_order.contains(&key) {
                 self.z_order.push(key);
@@ -808,6 +818,9 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 if let Some(w) = self.windows.get_mut(key) {
                     w.clear_void_id();
                 }
+            } else if layout.root().unwrap_leaf() == Some(key) {
+                // Single-leaf root — nullify the entire layout tree
+                self.managed_layout = None;
             } else {
                 let _ = layout.root_mut().remove_leaf(key);
                 layout.root_mut().cleanup_after_removal();
@@ -845,7 +858,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             return;
         };
 
-        // Try spatial placement via floating_rect
+        // 1. SPATIAL PLACEMENT — explicit coordinates preempt hole-filling
         if let Some(rect) = floating_info {
             let (cx, cy) = rect.center();
             let regions = layout.regions(self.managed_area);
@@ -864,7 +877,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             }
         }
 
-        // Absolute fallback: window was never floating — use current_focus
+        // 2. UNIFIED TOPOLOGICAL FALLBACK — fill voids before splitting
+        if layout.consume_first_void(key, self.managed_area) {
+            return;
+        }
+
+        // 3. ABSOLUTE FALLBACK — window was never floating, no voids — use current_focus
         if current_focus == key {
             layout.split_root(key, InsertPosition::Right);
             return;
@@ -895,6 +913,164 @@ mod tests {
             crate::window::LayerManager::new(),
             std::collections::HashMap::new(),
         )
+    }
+
+    #[test]
+    fn register_managed_layout_retains_iconic_windows_in_z_order() {
+        let mut wm = make_wm();
+
+        let key_a = wm.create_window(NoopComponent);
+        let key_b = wm.create_window(NoopComponent);
+        wm.transition_window(key_a, WindowState::Mapped);
+        wm.transition_window(key_b, WindowState::Mapped);
+
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        assert!(wm.z_order.contains(&key_a));
+        assert!(wm.z_order.contains(&key_b));
+
+        // Minimize window A -> Iconic state (produces no active geometry in tiling tree)
+        wm.minimize_window(key_a);
+        assert_eq!(wm.window_state(key_a), Some(WindowState::Iconic));
+
+        // Re-run layout pass
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // Assert: Iconic window A MUST remain in z_order tracking
+        assert!(
+            wm.z_order.contains(&key_a),
+            "Iconic window must not be purged from z_order during geometric layout registration"
+        );
+
+        // Unmap window B -> Unmapped state
+        wm.transition_window(key_b, WindowState::Unmapped);
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // Assert: Only Unmapped windows are pruned
+        assert!(
+            !wm.z_order.contains(&key_b),
+            "Unmapped window must be pruned from z_order"
+        );
+        assert!(
+            wm.z_order.contains(&key_a),
+            "Iconic window must still be present"
+        );
+    }
+
+    #[test]
+    fn single_leaf_minimization_nullifies_layout() {
+        let mut wm = make_wm();
+
+        // 1. Tile single window A
+        let key = wm.create_window(NoopComponent);
+        wm.transition_window(key, WindowState::Mapped);
+        wm.tile_window_key(key);
+
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        assert!(
+            wm.managed_layout.is_some(),
+            "must have layout after first tile"
+        );
+
+        // 2. Minimize window A
+        wm.minimize_window(key);
+        assert_eq!(wm.window_state(key), Some(WindowState::Iconic));
+
+        // Assert: managed_layout is explicitly None (root nullified, no root Void leftover)
+        assert!(
+            wm.managed_layout.is_none(),
+            "single-leaf minimization must nullify layout tree to None"
+        );
+
+        // 3. Restore window A
+        wm.restore_minimized(key);
+        assert_eq!(wm.window_state(key), Some(WindowState::Mapped));
+
+        // Assert: Window A reattaches as a clean root Leaf (no 50/50 split with Void)
+        assert!(
+            wm.managed_layout.is_some(),
+            "must have layout after restore"
+        );
+        if let Some(ref layout) = wm.managed_layout {
+            assert_eq!(
+                layout.root().unwrap_leaf(),
+                Some(key),
+                "restored window must be the fresh root leaf"
+            );
+            assert!(
+                layout.void_regions(wm.managed_area).is_empty(),
+                "restored root layout must contain zero void dead space"
+            );
+        }
+    }
+
+    #[test]
+    fn reattach_spatial_intent_preempts_void_consumption() {
+        let mut wm = make_wm();
+
+        let key_a = wm.create_window(NoopComponent);
+        let key_b = wm.create_window(NoopComponent);
+        wm.transition_window(key_a, WindowState::Mapped);
+        wm.transition_window(key_b, WindowState::Mapped);
+
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // Force a Void on the left, Leaf(A) on the right in managed_layout
+        let root = LayoutNode::Split {
+            direction: crate::layout::Direction::Horizontal,
+            children: vec![LayoutNode::Void(99), LayoutNode::leaf(key_a)],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.set_managed_layout(TilingLayout::new(root));
+
+        // Position window B explicitly over window A's region (right half of screen: x=50, y=10)
+        let b_rect = crate::window::FloatRectSpec::Absolute(crate::window::FloatRect {
+            x: 50,
+            y: 10,
+            width: 20,
+            height: 10,
+        });
+        wm.set_floating_rect(key_b, Some(b_rect));
+
+        // Reattach B to tiling layout
+        wm.reattach_to_tiling_layout(key_b);
+
+        // Assert: B split adjacent to A (right side) based on spatial floating_info,
+        // rather than teleporting to fill the Void on the far left.
+        let layout = wm.managed_layout.as_ref().unwrap();
+        let right_sub = layout
+            .root()
+            .node_at_path(&[1])
+            .expect("Right child must exist");
+        assert!(
+            right_sub.collect_leaves().contains(&key_b),
+            "Window B must split window A's leaf on the right due to spatial placement rules"
+        );
     }
 
     #[test]

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -501,7 +501,6 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 self.focus_add(key);
             }
             (WindowState::Mapped, WindowState::Iconic) => {
-                self.z_order.retain(|x| *x != key);
                 self.managed_draw_order.retain(|x| *x != key);
                 if *self.focus.current() == key {
                     self.select_fallback_focus();
@@ -520,9 +519,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                     .windows
                     .values()
                     .any(|w| w.state() == WindowState::Mapped && w.is_floating());
-                let floating_mode = self.managed_layout.is_none();
 
-                if !self.is_window_floating(key) && (has_other_floating || floating_mode) {
+                if !self.is_window_floating(key) && has_other_floating {
                     let index = self.windows.len().saturating_sub(1);
                     let fallback = self.default_cascading_rect(index);
                     self.set_floating_rect(
@@ -557,16 +555,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                     self.managed_draw_order.push(key);
                 }
 
-                // If floating windows are present or there's no tiling layout,
-                // and this window has no floating spec, assign a default
-                // cascading rect so it floats with the rest of the workspace.
                 let has_other_floating = self
                     .windows
                     .values()
                     .any(|w| w.state() == WindowState::Mapped && w.is_floating());
-                let floating_mode = self.managed_layout.is_none();
 
-                if !self.is_window_floating(key) && (has_other_floating || floating_mode) {
+                if !self.is_window_floating(key) && has_other_floating {
                     let index = self.windows.len().saturating_sub(1);
                     let fallback = self.default_cascading_rect(index);
                     self.set_floating_rect(
@@ -3779,6 +3773,108 @@ mod tests {
         );
     }
 
+    // ── BUG 1: minimize+restore then focus-other causes window to disappear ──────
+
+    #[test]
+    fn tiled_maximize_minimize_restore_focus_other_stays_in_tree() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 2);
+        for &k in &keys {
+            wm.transition_window(k, WindowState::Mapped);
+        }
+        let split = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![LayoutNode::Leaf(keys[0]), LayoutNode::Leaf(keys[1])],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        wm.managed_layout = Some(TilingLayout::new(split));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        wm.focus_window_key(keys[0]);
+
+        // Maximize tiled window
+        wm.toggle_maximize(keys[0]);
+        assert!(wm.windows.get(keys[0]).unwrap().is_maximized());
+
+        // Minimize (void removed, void_id cleared)
+        wm.minimize_window(keys[0]);
+        assert_eq!(wm.window_state(keys[0]), Some(WindowState::Iconic));
+
+        // Restore (comes back maximized floating — is_window_floating returns true)
+        wm.restore_minimized(keys[0]);
+        assert_eq!(wm.window_state(keys[0]), Some(WindowState::Mapped));
+
+        // Focus the OTHER window → triggers auto-unmaximize on keys[0]
+        wm.focus_window_key(keys[1]);
+        assert_eq!(wm.focused_window(), keys[1]);
+
+        // After auto-unmaximize, keys[0] should NOT be maximized or floating
+        let w0 = wm.windows.get(keys[0]).unwrap();
+        assert!(!w0.is_maximized(), "should no longer be maximized");
+        assert!(!w0.is_floating(), "should be tiled (not floating)");
+
+        // After auto-unmaximize, keys[0] MUST still be in the tiling layout tree
+        // (this assertion FAILS on current code — Bug 1)
+        assert!(
+            wm.managed_layout
+                .as_ref()
+                .is_some_and(|l| l.root().subtree_any(|k| k == keys[0])),
+            "must remain in tiling layout after unmaximize"
+        );
+    }
+
+    // ── BUG 2: minimize+restore single tiled window creates half-screen void ────
+
+    #[test]
+    fn minimize_restore_single_tiled_window_takes_full_area() {
+        use crate::layout::{LayoutNode, TilingLayout};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::standalone(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        wm.transition_window(keys[0], WindowState::Mapped);
+        wm.managed_layout = Some(TilingLayout::new(LayoutNode::leaf(keys[0])));
+        wm.register_managed_layout(LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        // Minimize (Leaf becomes Void, managed_layout stays Some(Void))
+        wm.minimize_window(keys[0]);
+        assert_eq!(wm.window_state(keys[0]), Some(WindowState::Iconic));
+
+        // Restore (reattach_to_tiling_layout called)
+        wm.restore_minimized(keys[0]);
+        assert_eq!(wm.window_state(keys[0]), Some(WindowState::Mapped));
+
+        // After restore, the tree should have the window as a single Leaf root
+        // (this assertion FAILS on current code — Bug 2 creates a 50/50 split with Void)
+        assert!(
+            wm.managed_layout
+                .as_ref()
+                .is_some_and(|l| l.root().unwrap_leaf() == Some(keys[0])),
+            "single window should be a Leaf root, not a split with Void"
+        );
+    }
+
     // ── No-op safety ──────────────────────────────────────────────────
 
     #[test]
@@ -5773,7 +5869,7 @@ mod tests {
     }
 
     #[test]
-    fn transition_window_mapped_to_iconic_removes_from_z_order() {
+    fn transition_window_mapped_to_iconic_retains_z_order() {
         let mut wm = WindowManager::<TestComponent>::with_config(
             WmConfig::standalone(),
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -5788,7 +5884,10 @@ mod tests {
 
         wm.transition_window(target, WindowState::Iconic);
         assert_eq!(wm.window_state(target), Some(WindowState::Iconic));
-        assert!(!wm.z_order.contains(&target), "removed from z_order");
+        assert!(
+            wm.z_order.contains(&target),
+            "Iconic windows persist in z_order"
+        );
         assert!(
             !wm.managed_draw_order.contains(&target),
             "removed from draw order"
@@ -5808,7 +5907,10 @@ mod tests {
         let keys = mapped_keys(&mut wm, 100);
         let target = keys[1];
         wm.transition_window(target, WindowState::Iconic);
-        assert!(!wm.z_order.contains(&target), "was removed");
+        assert!(
+            wm.z_order.contains(&target),
+            "Iconic windows persist in z_order"
+        );
 
         wm.transition_window(target, WindowState::Mapped);
         assert_eq!(wm.window_state(target), Some(WindowState::Mapped));


### PR DESCRIPTION
Three critical SEV-1/SEV-2 bugs in window manager layout/state coordination:

1. State Eradication via Geometric Filtering (SEV-1) register_managed_layout used active_keys (geometry-derived) to prune z_order, permanently purging windows that failed to produce a render region (e.g. Iconic/ Shaded windows). Now uses WindowState authority — only Unmapped windows are removed from z_order. Iconic (minimized) windows persist in z_order tracking.

2. Topological Disconnect on Unmaximize (SEV-1) toggle_maximize assumed the Void placeholder was permanent. If the window was minimized while maximized, detach_from_tiling_layout destroyed the Void and cleared void_id. Unmaximize silently aborted re-insertion, leaving the window orphaned. Now falls back to reattach_to_tiling_layout when the stale void pointer fails to restore.

3. Fragmented Insertion Pipeline (SEV-2) Two insertion paths (reattach_to_tiling_layout for state-restoration, and insert_window_balanced for manual tile/snap) both ignored existing Void nodes, forcing deep nesting on the focused leaf while stranding dead space.

Fixes:
- Add TilingLayout::consume_first_void — unified primitive that fills the first available Void node. Used by both insertion paths (DRY).
- reattach_to_tiling_layout: spatial intent → void consumption → absolute fallback
- insert_window_balanced: void consumption → largest-leaf split
- detach_from_tiling_layout: single-leaf root nullifies managed_layout to None instead of leaving a persistent root Void that forced 50/50 dead splits
- transition_window(Mapped→Iconic): don't remove from z_order (Iconic persists)
- transition_window(Iconic→Mapped/Unmapped→Mapped): remove the || floating_mode condition — a nullified layout no longer implies "floating mode", the window should reattach (creating a fresh single-leaf layout)

Tests added:
- insert_window_balanced_consumes_void_before_splitting_leaf (tiling.rs)
- maximize_minimize_unmaximize_retains_window (chrome.rs)
- register_managed_layout_retains_iconic_windows_in_z_order (layout.rs)
- single_leaf_minimization_nullifies_layout (layout.rs)
- reattach_spatial_intent_preempts_void_consumption (layout.rs)
- tiled_maximize_minimize_restore_focus_other_stays_in_tree (mod.rs)
- minimize_restore_single_tiled_window_takes_full_area (mod.rs)

Tests updated:
- transition_window_mapped_to_iconic_removes_from_z_order → retains
- transition_window_iconic_to_mapped_restores_z_order: Iconic persists