### PR TITLE
docs: Overhaul READMEs, add compatibility guide, standardize Direct Mode naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1840,7 +1840,6 @@ checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
 dependencies = [
  "memchr",
  "unicode-segmentation",
-]
 
 [[package]]
 name = "num-conv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
 dependencies = [
  "memchr",
  "unicode-segmentation",
+]
 
 [[package]]
 name = "num-conv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "clap",
  "libc",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3071,7 +3071,7 @@ version = "0.0.0"
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3185,21 +3185,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3215,11 +3215,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1829,7 +1829,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2595,7 +2595,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2890,7 +2890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3005,7 +3005,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3278,7 +3278,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4040,7 +4040,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.0-test"
+version = "0.9.0-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -57,6 +57,7 @@ dirs = "5.0"
 hostname = "0.4.2"
 indoc = "2.0.7"
 insta = "1.48.0"
+interprocess = "2.4.3"
 libc = "0.2.186"
 line-ending = "1.5.1"
 linkify = "0.11.0"
@@ -77,21 +78,21 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.0-test" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.0-test" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.0-test" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.0-test" }
-term-wm = { path = ".", version = "0.9.0-test" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.0-test" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.0-test" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.0-test" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.0-test" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.0-test" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.0-test" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.0-test" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.0-test" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.0-test" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.0-test" }
+term-session = { path = "crates/term-session", version = "0.9.0-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.0-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.0-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.0-alpha" }
+term-wm = { path = ".", version = "0.9.0-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.0-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.0-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.0-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.0-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.0-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.0-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.0-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.0-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.0-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.0-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](#)
 
 <div align="center">
-  <img src="https://github.com/jzombie/live-assets/blob/main/term-wm-0.8.12-alpha-mac.png?raw=true" alt="term-wm v0.8.12-alpha on macOS" /><br />
-  <em>pictured: term-wm v0.8.12-alpha on macOS</em>
+  <img src="https://github.com/jzombie/live-assets/blob/main/term-wm-0.9.0-alpha-mac.png?raw=true" alt="term-wm v0.9.0-alpha on macOS" /><br />
+  <em>pictured: term-wm v0.9.0-alpha on macOS</em>
 </div>
 
 **term-wm** is a modular, high-performance window manager and multiplexer that operates entirely within your terminal emulator. 

--- a/README.md
+++ b/README.md
@@ -1,193 +1,85 @@
-
 # term-wm
 
-[![made-with-rust][rust-logo]][rust-src-page] [![crates.io][crates-badge]][crates-page] [![MIT licensed][mit-license-badge]][mit-license-page] [![Apache 2.0 licensed][apache-2.0-license-badge]][apache-2.0-license-page] [![CodeQL][codeql-badge]][codeql-page] [![Dependabot][dependabot-badge]][dependabot-page] [![Coverage][coveralls-badge]][coveralls-page]
-
-**WORK IN PROGRESS. API SUBJECT TO CHANGE.**
-
-A cross-platform terminal multiplexer, window manager, and [Ratatui](https://crates.io/crates/ratatui) framework with a message-passing component model, event loop, and runtime.
-
-It is controllable via mouse and keyboard and works the same over SSH, Mac, Linux, and Windows.
+[![macOS](https://img.shields.io/badge/macOS-000000?style=flat-square&logo=apple&logoColor=white)](#)
+[![Linux](https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black)](#)
+[![Windows](https://img.shields.io/badge/Windows-0078D6?style=flat-square&logo=windows&logoColor=white)](#)
+<br>
+[![Made with Rust](https://img.shields.io/badge/Made%20with-Rust-orange?style=flat-square)](#)
+[![crates.io](https://img.shields.io/crates/v/term-wm.svg?style=flat-square)](#)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](#)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](#)
 
 <div align="center">
   <img src="https://github.com/jzombie/live-assets/blob/main/term-wm-0.8.12-alpha-mac.png?raw=true" alt="term-wm v0.8.12-alpha on macOS" /><br />
   <em>pictured: term-wm v0.8.12-alpha on macOS</em>
 </div>
 
-`term-wm` serves two distinct purposes:
+**term-wm** is a modular, high-performance window manager and multiplexer that operates entirely within your terminal emulator. 
 
-- **[For Users](#for-users-the-window-manager):** A standalone, keyboard-driven window manager for your terminal shell.
-- **[For Developers](#for-developers-the-library):** A reusable library of TUI primitives for building window-managed Ratatui applications.
+Designed for Linux, macOS, and Windows, it brings the spatial organization of a traditional graphical desktop environment (like GNOME or KDE) directly to the command line. Whether you require mathematically precise tiling for development workflows or overlapping floating windows with mouse support, `term-wm` delivers a native window management experience without requiring a display server.
 
-## Design Philosophy: Retro-Modern
+---
 
-`term-wm` is heavily inspired by the utilitarian beauty of **90's Unix user interfaces** (like [CDE](https://en.wikipedia.org/wiki/Common_Desktop_Environment)) and the cooperative tiling of **Windows 1.0**.
+## System Requirements & Compatibility
 
-It bridges the gap between standard terminal multiplexers and full desktop environments by adapting GUI metaphors to the command line.
+`term-wm` is designed to be highly resilient, running anywhere a standard terminal environment is available, but relies on modern terminal standards for its optimal presentation.
 
-Working with the terminal grid, the project aims to provide a rich window management experience despite the architectural constraints of a text-based terminal. Since terminals lack pixel-perfect positioning and rely on a rigid character cell grid, `term-wm` employs creative layout algorithms to make borders, resizing, and overlapping layers feel fluid and natural, even within the strict boundaries of ANSI/VT standards.
+* **Colors:** Truecolor (24-bit) support is highly recommended. The application will gracefully degrade its color palette in 256-color or 16-color environments, but UI themes and drop shadows are designed against 24-bit depth.
+* **Unicode & Fonts:** Requires a UTF-8 compatible environment and a font capable of rendering standard Unicode box-drawing characters to properly construct window borders and layout splits.
+* **Linux Virtual Terminals (TTY):** `term-wm` is fully usable in raw Linux VTs (e.g., accessed via `Ctrl+Alt+F1`). While the core window management and multiplexing logic remains 100% functional, visual presentation will look significantly different due to the kernel framebuffer's strict font and color limitations.
+* **Non-Standard OS Installs:** Minimal or headless OS installations must ensure a valid `terminfo` database is present and that the `LANG` environment variable is correctly set to a UTF-8 locale to prevent layout corruption.
 
-## For Users: The Window Manager
+See [docs/COMPATIBILITY.md](./docs/COMPATIBILITY.md) for full compatibility details.
 
-As a standalone application, `term-wm` allows you to manage multiple shell sessions, panes, and floating windows with a philosophy centered on **zero-conflict key bindings** with your running applications.
+## Architecture & Core Capabilities
 
-### The "No-Conflict" Philosophy (The `Esc` Super Key)
+`term-wm` is engineered with a strict modular architecture, separating core domain logic from presentation. It features an advanced layout engine, a dedicated frame-pacing rendering pipeline via [Ratatui](https://ratatui.rs/), and a comprehensive suite of terminal UI components.
 
-Unlike other multiplexers that require complex prefix chords (like `Ctrl+b`), `term-wm` uses `Esc` as a context-aware modifier. This ensures that sub-shells and embedded apps (like `vim`, `tmux`, `screen`, etc.) retain their own keybindings without fighting the window manager.
+* **Hybrid Layout Engine:** Seamlessly mix Binary Space Partitioning (BSP) and N-ary tree tiling with a free-floating window layer. Floating windows support mouse-driven repositioning, edge-snapping, and Z-index drop shadows. 
+* **Adaptive Viewports:** Quickly switch to **Maximized** mode to fill the workspace with the focused pane, or engage **Monocle** mode to view a single window full-screen—ideal for narrow viewports or mobile SSH sessions.
+* **Detachable Sessions (via `term-session`):** `term-wm` is a pure layout and rendering engine. To achieve persistent, detachable sessions that survive the UI lifecycle, `term-wm` (or any child application) must be executed within the companion [`term-session`](https://crates.io/crates/term-session) daemon.
+* **Performance & Rendering:** The Core Engine generates a Z-ordered draw plan on every frame. A dedicated frame pacer targets a smooth 60 FPS, while a power profile tracker dynamically scales down the frame rate during idle periods to preserve battery life.
 
-> _Should_ the `Esc` key need to be sent to a child window, pressing `Esc` twice (double-`Esc`) will route it to the window as a single key press.
+## The "No-Conflict" Philosophy (`Ctrl+A` Super Key)
 
-Per-window **direct mode** (toggled via the `[D]` header button) disables all WM key interception, including `Esc`, so keyboard-driven apps receive every keystroke unfiltered. Mouse interaction and window chrome (resize, drag) continue to work.
+Traditional terminal multiplexers often collide with the keybindings of the applications running inside them. `term-wm` is deliberately **minimally invasive**: its keybindings primarily listen for the `Ctrl+A` Super Key plus a small set of scrollback navigation keys, and pass everything else straight through to the running application.
 
-> _In direct mode the double-`Esc` behavior is inverted_ — a single `Esc` is deferred, and a second `Esc` opens the WM overlay.
+* **The Super Key:** The default modifier is `Ctrl+A` (configurable via `KeyBindings`).
+* **Scrollback Keys:** Outside of Direct Mode, the WM also intercepts `PageUp` / `PageDown` / `Home` / `End` (no modifier) for scrollback when a window has scrollback available; arrow keys and other navigation fall through to the child application.
+* **Command Palette:** Press `Ctrl+A` to open the central Command Palette overlay. This fuzzy-searchable menu (powered by `nucleo` with exponential decay scoring for recency) is the primary method for executing actions, opening windows, and altering layouts.
+* **Window Navigation:** While the palette is open, press `Tab` or `Shift+Tab` to instantly cycle focus between active windows. Press `Enter` to activate the selected command.
+* **Key Passthrough:** Pressing `Ctrl+A` while the palette is already open immediately sends the `Ctrl+A` keystroke to the focused child application (`SendSuperKeyToFocusedWindow`).
 
-| Context         | Action         | Behavior                                                                 |
-|-----------------|----------------|--------------------------------------------------------------------------|
-| App Focused     | Tap Esc once   | Enters WM Mode. An overlay appears; keys now control the window manager. |
-| WM Mode         | Tap Esc once   | Dismisses overlay; focus returns to the app.                             |
-| Default         | Double-tap Esc | Routes a single `Esc` through to the focused child window.               |
-| Direct Mode     | Type normally  | All keystrokes, including `Esc`, pass through to the terminal.           |
-| Direct Mode     | Tap Esc once   | Deferred; countdown shown in panel.                                      |
-| Direct Mode     | Double-tap Esc | Opens WM overlay (inverted double-Esc).                                  |
+## Automatic Direct Mode
 
+`term-wm` features zero-configuration input routing. **Direct Mode is automatic.** Driven by the `DirectInputTracker`, `term-wm` continuously monitors the PTY state. When a child application (such as `vim`, `emacs`, or `tmux`) requests the **alternate screen buffer**, enables **mouse tracking**, or defines **custom scroll margins**, the window manager automatically steps out of the way. 
 
-## For Developers: The Library
+All keyboard and mouse events pass through to the application unfiltered, with zero latency. A brief notification toast appears to indicate the transition. The `Ctrl+A` Super Key remains active to summon the Command Palette at any time.
 
-`term-wm` exports its core logic as a crate, allowing you to build complex terminal user interface (TUI) applications without reinventing view navigation or layout engines.
+## Window Snapping with Preview
 
-`term-wm` handles the internals of Ratatui's [Immediate Mode Rendering](https://ratatui.rs/concepts/rendering/) — your components are pure functions of their own state (`render(&self, ...)`), while `term-wm` manages the draw cycle, frame pacing, event routing, focus, and the `Component` lifecycle (`handle_events` → `update` → `render`).
+Floating windows support mouse-driven snapping with a live **ghost preview**. While dragging a window by its title bar, hovering over a snap target shows a dashed outline with a shaded fill and a label describing the pending action.
 
-### Operation Modes
+* **Snap targets:** screen edges (`snap to edge`), screen corners (`snap to corner`), and the top edge (`maximize`).
+* **Auto-snap countdown:** if the pointer leaves the screen area while a snap target is active, the window snaps automatically after a short countdown (default **2 seconds**, configurable via `drag_snap_timeout`). Releasing the button over the target also snaps immediately.
+* **Micro-positioning:** to place a window at a precise position, float it first, move it where you want, then tile it.
 
-The library provides two presets via `WmConfig`:
+## Configuration & Customization
 
-- **`WmConfig::standalone()`** — Full window manager with chrome, panel, floating windows, overlays, and WM mode toggle. Used by the `term-wm` binary.
-- **`WmConfig::embedded()`** — Minimal mode: no floating window management features by default. Designed for embedding term-wm components inside another application.
+`term-wm` provides an extensive configuration system to tailor the environment to your workflow:
 
-### Integration
+* **Action Layers:** Customize keybindings across distinct contextual layers (Global, Command Palette, and Help Overlay).
+* **Theming:** Fully customizable color palettes for all UI components, borders, and system chrome.
+* **Feature Flags:** Toggle system chrome (top/bottom panels), enable/disable clipboard synchronization, toggle mouse capture, and control aesthetic features like floating window drop shadows.
 
-By using `term-wm` primitives, your application gains:
+## Project Origins & Developer API
 
-- Standardized focus cycles.
-- Z-ordering for floating components.
-- A pre-built "Command Palette" pattern for global actions.
+`term-wm` initially began as a distinct application before its underlying rendering and window management mechanics were extracted into a general-purpose multiplexer. Because the system is built as a collection of decoupled crates, its core layout engine and UI components can theoretically be embedded into other Ratatui applications. 
 
-## Build & Installation
-
-### Requirements
-
-- If building from source: [Rust toolchain (stable)](https://rust-lang.org/tools/install/)
-- A terminal emulator supporting Raw Mode and standard ANSI escape sequences (most terminal emulators support this including Windows 11 Command Prompt, macOS, and Ubuntu).
-
-### Building from Source
-
-```bash
-git clone https://github.com/jzombie/term-wm.git
-cd term-wm
-cargo build --release
-```
-
-_There is also a published Rust crate at: https://crates.io/crates/term-wm_
-
-### Running from Source
-
-The easiest way to run the latest build is via [Cargo](https://rust-lang.org/tools/install/), which handles platform differences automatically:
-
-```bash
-cargo run --release
-```
-
-### Installing from Source
-
-To install `term-wm` as an executable system command, you can install it directly to your system.
-
-```bash
-cargo install --path .
-```
-
-**To uninstall:**
-
-```bash
-cargo uninstall term-wm
-```
-
-## Performance & Benchmarking
-
-The project emphasizes high-throughput rendering. Included in the repository is [term-bench](./crates/term-bench/), a tool designed to stress-test terminal emulators and window managers.
-
-**1. Standalone (Native Terminal Performance)**
-
-```bash
-cargo run -p term-bench --release -- --duration 15 --fps 120
-```
-
-**2. Managed (Inside term-wm)** This launches the window manager and immediately feeds the benchmark into the first pane.
-
-```bash
-cargo run --release -- "./target/release/term-bench --duration 15 --fps 120"
-```
-
-_The benchmark reports frame pacing, render times (avg/1% lows), and cell-update throughput._
-
-### Power-Aware Rendering
-
-`term-wm` includes an automatic power profiling system that adjusts the event-loop poll interval based on user activity and PTY data flow, reducing CPU usage when idle:
-
-- **Interactive** (~120 fps, 8ms interval) — active when keyboard input was received within the last 100ms.
-- **Streaming** (~60 fps, 16ms interval) — active when PTY data is flowing (dirty windows pending render) or input was received within the last 500ms.
-- **PowerSaver** (blocks on channel, 3600s interval, default) — no input and no dirty windows; the event loop blocks on the channel with no CPU burn.
-
-The active profile is derived by `UnifiedEventSource::current_profile()` which calls `profile_from_activity(last_event_at, has_dirty_windows)`. The runner detects changes via `PowerProfileTracker` and propagates the new profile to `WindowManager` each frame. The bottom panel receives profile changes via `ComponentAction::SetPowerProfile`. Developers can override `current_profile()` on custom `EventSource` implementations.
-
-#### Low-Level Kernel Sleep & Hardware Interrupt Mechanics
-
-When the system satisfies the criteria for `PowerSaver` mode, user-space execution code ceases entirely, shifting execution weight directly down to the operating system kernel and physical hardware interrupts via a highly coordinated multi-layered synchronization layer:
-
-1. **User-Space Thread Parking (`futex`):** When the main thread calls `self.rx.recv_timeout()` inside `UnifiedEventSource::poll`, it delegates to the concurrency primitives of the crossbeam channel selector. Following a brief spin-lock phase to catch high-frequency back-to-back entries without context switching, the thread invokes an operating system thread-parking mechanic. On Linux, this resolves to a `futex` system call: `syscall(SYS_futex, &lock_address, FUTEX_WAIT_PRIVATE, expected_val, &timeout)`.
-
-2. **Kernel Suspension (0% CPU Burn):** The Linux kernel scheduler takes the main thread out of the CPU core's active execution run-queue and parks it in a passive wait-queue tied to that lock memory address, shifting the task state to `TASK_INTERRUPTIBLE`. At this point, the application consumes exactly 0% CPU cycles and is completely bypassed during standard scheduler cycles.
-
-3. **Hardware Interrupt & PTY Cascade:** When a user initiates hardware input (e.g., striking a key or moving a mouse), the device asserts a physical interrupt request line on the Advanced Programmable Interrupt Controller (APIC), forcing the CPU to branch to the kernel's Interrupt Descriptor Table (IDT). The kernel's input driver processes the raw device packets and pipes the character bytes into the target pseudoterminal (`PTY`) master/slave ring buffer.
-
-4. **Asynchronous Unblock:** The presence of new data in the PTY buffer triggers an active wake signal on the file descriptor being monitored via `epoll_wait`/`poll` by the background `crossterm-input` thread. This background thread awakens, parses the ANSI escape bytes into a core event structure, and drops it into the crossbeam channel via `input_tx.send()`. Recognizing that the primary event loop thread is parked, the channel primitive executes a `FUTEX_WAKE_PRIVATE` system call, shifting the main loop thread's task state back to `TASK_RUNNING` to resume instruction execution.
-
-Additionally, the runner bridges the scheduler's task deadlines into the event source via `set_max_sleep_duration()`. When a background task (e.g. a `SuperPassthrough` timeout, `DragSnap` timer) is scheduled, the runner pushes the task deadline from the `TaskScheduler` into the event source, which clamps its `poll_interval()` against it. This ensures PowerSaver's 3600s interval never blocks past a pending task deadline — the event loop wakes at exactly the right moment without busy-waiting.
-
-#### The Immediate-Mode Visual Phase Lag Illusion
-
-Due to the constraints of an immediate-mode rendering architecture, monitoring the power state via on-screen indicators (such as the status panel or debug log window) reveals a constant "Streaming" text pattern during complete idleness. This is an expected artifact of loop phase ordering, not a failure of the power manager:
-
-1. **Render Pass Execution:** The runner executes an active frame cycle and invokes `output.draw()`. The layout components query the window manager's text configurations while the global profile variable still evaluates to `Streaming`, rasterizing the yellow status indicator text bytes into the cell character grid matrix.
-
-2. **State Consumption & Calibration:** Immediately *after* the frame buffer is successfully drawn and committed, `flush_state_changes()` triggers. It executes `driver.take_dirty_windows()` to flush update vectors and evaluates `current_profile()`. Finding the inactivity thresholds crossed, it mutates the authoritative profile variable down to `PowerSaver`.
-
-3. **Instant Suspension:** The loop boundary yields control back to `EventLoop::run`, which immediately queries `self.driver.poll(poll_interval)`. Since the profile was just scaled down to `PowerSaver`, the main execution thread immediately executes its futex system wait call and drops into deep kernel sleep *before another drawing frame can render*.
-
-Consequently, the terminal cell matrix safely preserves the visual text painted during Step 1. The CPU is completely asleep at 0% utilization, but the display remains frozen on the word "Streaming". When hardware input unblocks the thread, event routing instantly elevates the engine to `Interactive` or `Streaming` *before* the subsequent frame pass, causing the on-screen status to jump from "Streaming" straight to "Interactive"—entirely skipping the visible display of the intermediate `PowerSaver` phase.
+However, the developer-facing library API is currently unsolidified and subject to rapid breaking changes. Stabilizing the developer API, refining the component lifecycle, and documenting the embedded layout engine will be the primary focus of future architectural iterations. (For a glimpse into the internal component design standards, see [AGENTS.md](./AGENTS.md)).
 
 ## License
 
 `term-wm` is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](./LICENSE-APACHE) and [LICENSE-MIT](./LICENSE-MIT) for details.
-
-[rust-src-page]: https://www.rust-lang.org/
-[rust-logo]: https://img.shields.io/badge/Made%20with-Rust-black?logo=Rust
-
-[crates-page]: https://crates.io/crates/term-wm
-[crates-badge]: https://img.shields.io/crates/v/term-wm.svg
-
-[mit-license-page]: ./LICENSE-MIT
-[mit-license-badge]: https://img.shields.io/badge/license-MIT-blue.svg
-
-[apache-2.0-license-page]: ./LICENSE-APACHE
-[apache-2.0-license-badge]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
-
-[codeql-page]: https://github.com/jzombie/term-wm/actions/workflows/github-code-scanning/codeql
-[codeql-badge]: https://github.com/jzombie/term-wm/actions/workflows/github-code-scanning/codeql/badge.svg
-
-[dependabot-page]:https://github.com/jzombie/term-wm/actions/workflows/dependabot/dependabot-updates
-[dependabot-badge]: https://github.com/jzombie/term-wm/actions/workflows/dependabot/dependabot-updates/badge.svg
-
-[coveralls-page]: https://coveralls.io/github/jzombie/term-wm?branch=main
-[coveralls-badge]: https://img.shields.io/coveralls/github/jzombie/term-wm

--- a/crates/term-session-client/README.md
+++ b/crates/term-session-client/README.md
@@ -2,6 +2,14 @@
 
 The client half of [term-session](https://crates.io/crates/term-session): attaches a local terminal to a server-hosted PTY session and renders it live.
 
+> **Library only.** This crate provides the client-side library for the supported
+> functionality; it ships no binary of its own. The runnable binary is currently
+> provided by the [`term-session`](https://crates.io/crates/term-session) crate,
+> which depends on this library. Like the rest of the `term-session` stack, it
+> reuses much of `term-wm`'s internal machinery (the PTY engine, input event
+> types, and the crossterm input adapter) — but it does **not** produce the window
+> manager.
+
 `run_session` connects to a session server over Muxio IPC, attaches to the shared PTY, and:
 
 - renders the PTY screen locally with a `vt100` parser and full-frame ANSI output (Synchronized Output, wide-char handling);
@@ -10,7 +18,7 @@ The client half of [term-session](https://crates.io/crates/term-session): attach
 - captures OSC 52 clipboard sequences from the output stream;
 - cleans up the terminal (leaves alternate screen, restores raw mode) on exit.
 
-Used by term-wm as the backbone of its terminal session persistence, but usable from any terminal program.
+Designed to work alongside term-wm: run `term-wm` as a child process inside `term-session` for persistent, detachable workspaces. Usable from any terminal program.
 
 ## Known limitation
 

--- a/crates/term-session-muxio-service-definitions/Cargo.toml
+++ b/crates/term-session-muxio-service-definitions/Cargo.toml
@@ -10,5 +10,5 @@ publish.workspace = true
 
 [dependencies]
 bitcode = { workspace = true }
-interprocess = "2.4.2"
+interprocess = { workspace = true }
 muxio-rpc-service = { workspace = true }

--- a/crates/term-session-server/README.md
+++ b/crates/term-session-server/README.md
@@ -2,14 +2,26 @@
 
 The detached server half of [term-session](https://crates.io/crates/term-session): a daemon that hosts one PTY per channel and broadcasts it to every attached terminal.
 
+> **Library only.** This crate provides the server-side library for the supported
+> functionality; it ships no binary of its own. The runnable binary is currently
+> provided by the [`term-session`](https://crates.io/crates/term-session) crate,
+> which depends on this library. Like the rest of the `term-session` stack, it
+> reuses much of `term-wm`'s internal machinery (in particular the PTY engine) —
+> but it does **not** produce the window manager.
+
 The server owns the PTY and the child process that runs inside it. It:
 
-- binds to a namespaced channel (`namespace/name`, resolving to a platform-local socket) and detaches from the launching terminal, so the session survives every client disconnecting;
+- binds to a namespaced channel (`namespace/name`, resolving to a platform-local socket), so the session survives every client disconnecting;
 - broadcasts each chunk of PTY output to all subscribed clients — this is what lets multiple terminals show the same live session (duplicates);
 - accepts keystrokes, mouse events, and pastes from any client and feeds them into the shared PTY;
 - constrains the PTY geometry to the smallest size across connected clients and broadcasts resize notifications to all of them;
 - finalizes every subscriber's output stream when the PTY child exits, returning the child's exit code.
 
-Used by term-wm as the backbone of its terminal session persistence, but usable from any terminal program.
+## Platform notes
+
+* **macOS & Linux:** The auto-spawned server detaches into its own session via `setsid()`, so it survives terminal closure and client disconnects. (Other Unix-like systems have not been tested.)
+* **Windows:** `term-session` works on Windows, but it does **not** currently auto-daemonize. The server is spawned with `CREATE_NO_WINDOW` (suppressing the console window) rather than a full process-session detachment, so the server process does not fully detach from the launching console's lifetime.
+
+Designed to work alongside term-wm: run `term-wm` as a child process inside `term-session` for persistent, detachable workspaces. Usable from any terminal program.
 
 See the main [term-session](https://crates.io/crates/term-session) crate for usage.

--- a/crates/term-session/README.md
+++ b/crates/term-session/README.md
@@ -1,20 +1,8 @@
 # term-session
 
-A generic terminal session reproducer: run one PTY in a detached server process and attach as many terminals to it as you like — on the same machine or over SSH.
+A layout-agnostic, headless terminal session host and multiplexer.
 
-> term-wm uses term-session as the backbone of its terminal session persistence. The crate is not tied to term-wm, though: any terminal program can use it to persist or duplicate a live session.
-
-## What it does
-
-One process runs the server (`--server`). It owns the PTY and the child process that runs inside it. Any number of client processes attach to the server over IPC, receive a live broadcast of the PTY's output, and forward keystrokes, mouse events, and pastes back into the shared session. Because every client streams from the same server, all attached terminals show the same live session — duplicates in real time.
-
-Session duplication extends across computers: a session lives on the machine that hosts the server, so a client that can reach that machine can attach. `ssh` into the host and run `term-session --channel <name>` and you have the same session on a different machine.
-
-## Channels
-
-Sessions are addressed by a channel name (`namespace/name`, e.g. `default/main`). Channels resolve to a platform-local socket (`GenericNamespaced`: `$XDG_RUNTIME_DIR` / `~/.term-wm` on Linux, `/tmp` on macOS, named pipes on Windows), so no filesystem path is ever involved.
-
-The server binds to a channel and detaches from the launching terminal (its own session/process group on Unix, `DETACHED_PROCESS` on Windows), so it keeps running — and keeps the session alive — even after every client disconnects. Reconnecting, or attaching a second terminal, picks up the same session.
+`term-session` provides the persistence layer for terminal applications. It operates similarly to `tmux` or `GNU screen`, ensuring that running processes survive client disconnects. Unlike traditional window managers, `term-session` enforces **no layout paradigm**. It is a pure session daemon.
 
 ## Usage
 
@@ -26,9 +14,17 @@ term-session --server --channel work/dev -- vim foo.txt   # start a server runni
 
 In client mode `term-session` first probes the channel for a live server and, if none is running, spawns a detached one automatically (`connect_or_spawn_server`). The program to run and the PTY size are forwarded to the server at spawn time. The channel can also be set via the `TERM_WM_CHANNEL` environment variable.
 
-## Crate layout
+## Architecture & Capabilities
 
-- `term-session` — this crate: the CLI, the `auto_spawn` helper, and the shared session entry points.
-- `term-session-server` — the detached daemon that hosts one PTY per channel and broadcasts it to every subscriber.
-- `term-session-client` — attaches a local terminal to a server session, renders it with a `vt100` parser, and forwards local input back into the shared session.
-- `term-session-muxio-service-definitions` — the shared Muxio wire types (`Spawn`, subscribe output, stream input, channel handling).
+* **Concurrent Display Heads:** Supports multiple independent clients connecting to and rendering a single running session simultaneously.
+* **Muxio IPC Integration:** Utilizes the Muxio IPC framework and Bitcode serialization over OS-native transports (Linux abstract sockets, macOS `/tmp`, Windows named pipes) to route PTY state between the background server and attached clients.
+* **Shared Mechanics:** Reuses a large part of `term-wm`'s internals — the PTY engine (`term-wm-pty-engine`: spawning, scrollback tracking, `vt100` parsing), the input event types (`term-wm-events`), and the crossterm input adapter (`term-wm-crossterm-adapter`). `term-session` does **not** produce the window manager: there is no layout engine, no tiling, and no window chrome — only the persistence and multiplexing layer.
+
+## Platform Notes
+
+* **macOS & Linux:** The auto-spawned server detaches into its own session via `setsid()`, so it survives terminal closure and client disconnects. (Other Unix-like systems have not been tested.)
+* **Windows:** `term-session` works on Windows, but it does **not** currently auto-daemonize. The server is spawned with `CREATE_NO_WINDOW` (which suppresses the console window) rather than a full process-session detachment, so the server process does not fully detach from the launching console's lifetime the way it does on macOS and Linux.
+
+## Integration with term-wm
+
+To deploy a persistent, tiling terminal workspace, run `term-wm` as a child process inside `term-session`. This architecture guarantees that the window manager and its layout state survive terminal emulator restarts or SSH disconnects.

--- a/crates/term-session/src/main.rs
+++ b/crates/term-session/src/main.rs
@@ -6,6 +6,9 @@ use term_session_client::run_session;
 use term_session_muxio_service_definitions::ChannelName;
 use term_session_server::SessionServerConfig;
 
+const CHANNEL_ENV_VAR: &str = "TERM_WM_CHANNEL";
+const DEFAULT_CHANNEL: &str = "default/main";
+
 #[derive(Parser, Debug)]
 #[command(name = "term-session", about = "term-wm session manager")]
 struct Cli {
@@ -47,14 +50,17 @@ fn run_server_mode(channel: &ChannelName, cli: &Cli) -> io::Result<()> {
     Ok(())
 }
 
+/// Resolve the channel from the CLI arg, falling back to the env var, then the default.
+fn resolve_channel(cli_channel: Option<String>, env_channel: Option<String>) -> String {
+    cli_channel
+        .or(env_channel)
+        .unwrap_or_else(|| DEFAULT_CHANNEL.to_string())
+}
+
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
-    let channel_input = cli
-        .channel
-        .clone()
-        .or_else(|| std::env::var("TERM_WM_CHANNEL").ok())
-        .unwrap_or_else(|| "default/main".to_string());
+    let channel_input = resolve_channel(cli.channel.clone(), std::env::var(CHANNEL_ENV_VAR).ok());
 
     let channel = ChannelName::parse(&channel_input).map_err(|e| {
         io::Error::new(io::ErrorKind::InvalidInput, format!("Invalid channel: {e}"))
@@ -73,4 +79,30 @@ fn main() -> io::Result<()> {
     let socket_name = connect_or_spawn_server(&channel, &spawn_cfg)?;
 
     run_session(&socket_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_channel_takes_precedence_over_env() {
+        assert_eq!(
+            resolve_channel(Some("work/dev".to_string()), Some("other/chan".to_string())),
+            "work/dev"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_env_channel() {
+        assert_eq!(
+            resolve_channel(None, Some("work/dev".to_string())),
+            "work/dev"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_default_channel() {
+        assert_eq!(resolve_channel(None, None), DEFAULT_CHANNEL);
+    }
 }

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -1111,7 +1111,7 @@ where
     (inner_bounds, chrome_registry)
 }
 
-/// Render window chrome (borders, title bar, hover-aware buttons, direct mode indicator).
+/// Render window chrome (borders, title bar, hover-aware buttons, Direct Mode indicator).
 fn render_window(buffer: &mut Buffer, rect: LayoutRect, ctx: ChromeCtx<'_>) {
     use ratatui::style::{Color, Modifier, Style};
 

--- a/crates/term-wm-core/src/chrome/target.rs
+++ b/crates/term-wm-core/src/chrome/target.rs
@@ -16,7 +16,7 @@ pub enum ChromeTarget {
     MaximizeButton(WindowKey),
     /// Minimize button in the window header.
     MinimizeButton(WindowKey),
-    /// Toggle direct mode button in the window header.
+    /// Toggle Direct Mode button in the window header.
 
     /// Tiling layout split handle seam.
     SplitHandle(HitboxId),

--- a/crates/term-wm-core/src/component_context.rs
+++ b/crates/term-wm-core/src/component_context.rs
@@ -248,7 +248,7 @@ impl ComponentContext {
         self.overlay
     }
 
-    /// Returns whether the component's window is in direct mode.
+    /// Returns whether the component's window is in Direct Mode.
     pub const fn direct_mode(&self) -> bool {
         self.direct_mode
     }

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -363,7 +363,7 @@ where
                 let status = if enabled { "enabled" } else { "disabled" };
                 let title = app.wm().window_title(key);
                 app.wm().push_notification(
-                    format!("Direct mode {} for {}", status, title),
+                    format!("Direct Mode {} for {}", status, title),
                     Duration::from_secs(3),
                 );
             }
@@ -611,14 +611,14 @@ where
                     return flush_state_changes(app, driver, ControlFlow::Continue, false, None);
                 }
 
-                // Layer 2c: Direct mode check — forward key events straight to PTY
+                // Layer 2c: Direct Mode check — forward key events straight to PTY
                 if let Event::Key(key) = &evt {
                     let focus_id = app.wm().focused_window();
                     if app.wm().direct_mode(focus_id)
                         && !app.wm().command_menu_visible()
                         && matches!(key.kind, KeyKind::Press | KeyKind::Repeat)
                     {
-                        // Direct mode — forward to terminal immediately.
+                        // Direct Mode — forward to terminal immediately.
                         let _ = handle_focused_app_event(&evt, app);
                         update_selection_snapshot(app);
                         return flush_state_changes(
@@ -1154,7 +1154,7 @@ mod tests {
         let consumed = handle_focused_app_event(&evt, &mut app);
         assert!(
             consumed,
-            "Repeat event must route through handle_focused_app_event in direct mode"
+            "Repeat event must route through handle_focused_app_event in Direct Mode"
         );
     }
 

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -655,7 +655,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             .unwrap_or_else(|| self.default_cascading_rect(index))
     }
 
-    /// Direct mode: purely automatic from the PTY state tracker.
+    /// Direct Mode: purely automatic from the PTY state tracker.
     /// Returns true when the application requires unfiltered input
     /// (alternate screen, mouse tracking, custom margins).
     pub fn direct_mode(&self, key: WindowKey) -> bool {
@@ -5559,7 +5559,7 @@ mod tests {
         });
 
         let result = wm.dispatch_focused_event(&click);
-        // In direct mode, content clicks bypass chrome and reach the component.
+        // In Direct Mode, content clicks bypass chrome and reach the component.
         assert!(result.is_some(), "event must route to window component");
     }
 
@@ -5704,7 +5704,7 @@ mod tests {
         wm.focus_app_window(keys[1]);
 
         let win_key = keys[1];
-        assert!(!wm.direct_mode(win_key), "direct mode is off");
+        assert!(!wm.direct_mode(win_key), "Direct Mode is off");
 
         let content = wm.region_for_key(win_key);
         let click = Event::Mouse(MouseEvent {

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -536,7 +536,7 @@ impl Pty {
     }
 
     /// Return an `Arc<dyn DirectInputTracker>` for this PTY's state tracker.
-    /// Used by the window manager to auto-enable direct mode when the
+    /// Used by the window manager to auto-enable Direct Mode when the
     /// application enters alternate screen, enables mouse tracking, etc.
     pub fn direct_input_tracker(&self) -> std::sync::Arc<dyn crate::DirectInputTracker> {
         self.tracker.clone()

--- a/crates/term-wm-sys-ui-components/assets/help.md
+++ b/crates/term-wm-sys-ui-components/assets/help.md
@@ -11,35 +11,38 @@ Welcome to `%PACKAGE%`! This page is a quick reference for navigating the UI.
 
 _See also: [No-Keybinding-Conflict Philosophy](#no-keybinding-conflict-philosophy)_
 
-* **%SUPER%**: Exit the active window context and open the menu (the "WM layer").
+The following keybindings are active in the WM layer. The Command Palette binding works in any mode, including Direct Mode:
 
-While the menu is open:
+* **%SUPER%**: Open (or close) the Command Palette.
+
+While the Command Palette is open:
 
 * **%FOCUS_NEXT% / %FOCUS_PREV%**: Cycle focus between windows.
-* **%MENU_NAV%** or **%MENU_ALT%**: Move up/down in lists and menus.
+* **%MENU_NAV%**: Move up/down in lists and menus.
 * **%MENU_SELECT%**: Activate the selected menu item.
-* **%HELP_MENU%**: Open the full help overlay (Panel menu: Top-left -> Help).
+* **%HELP_MENU%**: Open this help overlay. (Alternatively: press **%SUPER%** to open the Command Palette and search for 'Help').
 
 ## No-Keybinding-Conflict Philosophy
 
-A core goal of `%PACKAGE%` is conflict-free keybindings so you can run terminal
-apps (e.g., `screen`, `tmux`, editors, etc.) without the window manager (WM) stealing their keys.
+A core goal of `%PACKAGE%` is **minimally invasive** keybindings so you can run terminal apps (e.g., `screen`, `tmux`, editors, etc.) without the window manager (WM) stealing their keys.
 
-By default, the WM only watches **%SUPER%**. When you press it, you enter the
-WM layer and can use WM commands (like **%FOCUS_NEXT%** / **%FOCUS_PREV%**).
+By default, the WM's keybindings are **minimally invasive**: it primarily listens for **%SUPER%**, plus a small set of navigation keys — **PageUp / PageDown / Home / End** — which its built-in scrollback consumes when a window is focused and not in Direct Mode. Everything else (including arrow keys) falls through to the running application. Press **%SUPER%** to open the Command Palette and use WM commands (like **%FOCUS_NEXT%** / **%FOCUS_PREV%**).
 
-To send **%SUPER%** to the currently focused application, press **%SUPER%**
-twice quickly. (The second press is forwarded to the active window.)
+To send **%SUPER%** to the currently focused application, press **%SUPER%** while the Command Palette is open (the key is forwarded to the active window).
 
-Per-window **direct mode** (toggled via the `[D]` header button) disables all WM
-key interception, including **%SUPER%**, so keyboard-driven apps receive every
-keystroke unfiltered. In direct mode, a single **%SUPER%** is deferred (a countdown
-appears in the panel); a second **%SUPER%** within the timeout opens the WM overlay.
+Direct Mode is fully automatic — see [Automatic Direct Mode](#automatic-direct-mode) below.
+
+## Automatic Direct Mode
+
+When a terminal application (e.g., `vim`, `tmux`, or `less`) requests the alternate screen buffer, mouse tracking, or custom scroll margins, `%PACKAGE%` automatically enters **Direct Mode**.
+
+* **State Awareness:** A brief notification toast appears on screen to indicate when Direct Mode has been enabled or disabled.
+* **Keyboard Routing:** All keystrokes pass directly to the running application unfiltered, ensuring native shortcuts work without WM interference. **%SUPER%** remains active to open the Command Palette.
+* **Mouse & Selection:** WM-level text selection and right-click pasting are suspended — all mouse events over the terminal pass through to the running application. Window chrome (dragging and resizing via the header and borders) continues to work.
 
 ## Mouse Capture
 
-Mouse capture is enabled by default when supported. To disable it, open the
-menu and toggle `Mouse Capture`.
+Mouse capture is enabled by default when supported. To disable it, open the Command Palette and toggle `Mouse Capture`.
 
 Mouse capture lets `%PACKAGE%` receive mouse input for WM actions like:
 
@@ -53,7 +56,49 @@ Most of these actions are also purely keyboard driven, by initially pressing the
 Notes:
 
 * Mouse interactions work only while `Mouse Capture` is enabled.
-* Use the panel menu (top-left) for common WM actions.
+* Open the Command Palette (%SUPER%) for common WM actions.
+
+## Window Snapping & Drag Preview
+
+While dragging a floating window by its title bar, hovering over a snap target shows a live **ghost preview** — a dashed outline with a shaded fill and a label describing the pending action.
+
+* **Snap targets:** screen edges (`snap to edge`), screen corners (`snap to corner`), and the top edge (`maximize`).
+* **Auto-snap countdown:** if the pointer leaves the screen area while a snap target is active, the window snaps automatically after a short countdown (default 2 seconds). Releasing the button over the target also snaps.
+* **Micro-positioning:** to place a window at a precise position, float it first, move it where you want, then tile it.
+
+## Selection & Clipboard
+
+`%PACKAGE%` provides text selection and clipboard integration for terminal windows.
+
+**Selecting text:** Left-click drag within a terminal window to select text.
+On release, the selection is automatically copied to the system clipboard
+and a brief notification is shown.
+
+**Pasting:** Right-click to paste the system clipboard contents at the cursor position.
+Paste also works via your terminal emulator's standard shortcut (e.g., Ctrl+Shift+V),
+which sends the text as a bracketed-paste event.
+
+**OSC 52 copy:** Terminal applications (e.g., `vim`, `tmux`) can write to the system
+clipboard using the OSC 52 escape sequence. `%PACKAGE%` intercepts these sequences
+automatically.
+
+Notes:
+
+* Selection and right-click paste are available only while **not** in Direct Mode.
+  In Direct Mode, all mouse events pass through to the running application unfiltered.
+* To disable clipboard integration, open the Command Palette (`%SUPER%`) and toggle
+  "Clipboard Mode".
+* To enable or disable window text selection via the Command Palette, toggle
+  "Window Selection: On/Off".
+
+## Environment & Compatibility
+
+`%PACKAGE%` runs natively on Linux, macOS, and Windows. 
+
+* **Colors & Unicode:** Truecolor (24-bit) and a UTF-8 environment with box-drawing support are highly recommended for the intended visual experience.
+* **Linux VT:** The window manager is fully usable in raw Linux Virtual Terminals (e.g., `Ctrl+Alt+F1`). Due to TTY framebuffer limits, expect colors and borders to degrade, but core mechanics will continue to function properly.
+
+See the [compatibility notes](%REPOSITORY%/blob/main/docs/COMPATIBILITY.md) for full details.
 
 ----
 

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -345,7 +345,7 @@ impl<C: Component<TermWmAction>> ScrollViewComponent<C> {
             }
         }
 
-        // Skip in direct mode so scroll passes through to the terminal
+        // Skip in Direct Mode so scroll passes through to the terminal
         // component for encoding and forwarding to the PTY app.
         if !ctx.direct_mode() {
             match mouse.kind {
@@ -1196,11 +1196,11 @@ mod tests {
         let consumed = sv.handle_events(&scroll_down, &ctx);
         assert!(
             consumed.is_ignored(),
-            "scroll must NOT be consumed in direct mode"
+            "scroll must NOT be consumed in Direct Mode"
         );
         assert!(
             sv.content.borrow().received_scroll,
-            "scroll must reach child component in direct mode"
+            "scroll must reach child component in Direct Mode"
         );
     }
 
@@ -1419,11 +1419,11 @@ mod tests {
         let result = sv.handle_events(&page_up, &ctx);
         assert!(
             result.is_ignored(),
-            "direct mode must pass all keys through"
+            "Direct Mode must pass all keys through"
         );
         assert!(
             sv.content.borrow().received_scroll,
-            "key must reach child in direct mode"
+            "key must reach child in Direct Mode"
         );
     }
 

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -89,7 +89,7 @@ impl Component<TermWmAction> for TerminalComponent {
             Event::Mouse(mouse) => {
                 if !ctx.direct_mode() {
                     // Right-click paste (Windows Cmd/PS convention).
-                    // Only in normal mode — in direct mode (tmux, vim, etc.)
+                    // Only in normal mode — in Direct Mode (tmux, vim, etc.)
                     // right-click passes through to the running program.
                     match mouse.kind {
                         MouseEventKind::Press(MouseButton::Right)
@@ -2085,7 +2085,7 @@ mod tests {
             );
         }
 
-        // In direct mode: a Down+Drag must NOT be consumed by selection
+        // In Direct Mode: a Down+Drag must NOT be consumed by selection
         let down = Event::Mouse(MouseEvent {
             kind: MouseEventKind::Press(MouseButton::Left),
             column: (area.x + 1) as u16,
@@ -2095,19 +2095,19 @@ mod tests {
         let result_down = wm.dispatch_focused_event(&down);
         assert!(
             result_down.is_some(),
-            "down must route to component in direct mode, got None"
+            "down must route to component in Direct Mode, got None"
         );
         let (_, down_evt) = result_down.unwrap();
-        // In direct mode, selection is skipped, so Down is not consumed
+        // In Direct Mode, selection is skipped, so Down is not consumed
         // (it falls through to PTY forwarding, which returns Ignored for
         //  press-only mode since the test PTY hasn't enabled mouse tracking)
         assert!(
             !down_evt.is_consumed(),
-            "down must NOT be consumed in direct mode: got {:?}",
+            "down must NOT be consumed in Direct Mode: got {:?}",
             down_evt
         );
 
-        // Drag must also not be consumed (selection is skipped in direct mode)
+        // Drag must also not be consumed (selection is skipped in Direct Mode)
         let drag = Event::Mouse(MouseEvent {
             kind: MouseEventKind::Drag(MouseButton::Left),
             column: (area.x + 5) as u16,
@@ -2117,12 +2117,12 @@ mod tests {
         let result_drag = wm.dispatch_focused_event(&drag);
         assert!(
             result_drag.is_some(),
-            "drag must route to component in direct mode, got None"
+            "drag must route to component in Direct Mode, got None"
         );
         let (_, drag_evt) = result_drag.unwrap();
         assert!(
             !drag_evt.is_consumed(),
-            "drag must NOT be consumed in direct mode: got {:?}",
+            "drag must NOT be consumed in Direct Mode: got {:?}",
             drag_evt
         );
 
@@ -2133,11 +2133,11 @@ mod tests {
             .unwrap();
         assert!(
             !sel_status.active,
-            "selection should not be active after direct mode drag"
+            "selection should not be active after Direct Mode drag"
         );
     }
 
-    /// In direct mode, mouse Down must skip selection and go to PTY encoding.
+    /// In Direct Mode, mouse Down must skip selection and go to PTY encoding.
     #[test]
     fn direct_mode_mouse_down_skips_selection() {
         use term_wm_core::actions::TermWmAction;
@@ -2152,7 +2152,7 @@ mod tests {
         let mut term = TerminalComponent::from_pane(Box::new(pane));
         term.set_selection_enabled(true);
 
-        // Direct mode — selection skipped, PTY encoding expected
+        // Direct Mode — selection skipped, PTY encoding expected
         let ctx = ComponentContext::new(true)
             .with_direct_mode(true)
             .with_screen_area(LayoutRect {
@@ -2173,12 +2173,12 @@ mod tests {
         match result {
             EventResult::Action(TermWmAction::MouseToBytes(_)) => {}
             other => panic!(
-                "in direct mode, Down must produce MouseToBytes (PTY), got {:?}",
+                "in Direct Mode, Down must produce MouseToBytes (PTY), got {:?}",
                 other
             ),
         }
 
-        // Non-direct mode — selection should consume Drag
+        // Non-Direct Mode — selection should consume Drag
         let ctx_normal = ComponentContext::new(true).with_screen_area(LayoutRect {
             x: 0,
             y: 0,
@@ -2213,7 +2213,7 @@ mod tests {
     //
     // These tests verify that right-click mouse events are intercepted by
     // TerminalComponent::handle_events and produce PasteClipboard (in
-    // normal mode) or pass through to PTY encoding (in direct mode).
+    // normal mode) or pass through to PTY encoding (in Direct Mode).
 
     /// Right-click Release in normal mode must produce
     /// PasteClipboard; Press and Drag must be consumed (not forwarded
@@ -2278,7 +2278,7 @@ mod tests {
         );
     }
 
-    /// Right-click in direct mode must NOT produce PasteClipboard — it
+    /// Right-click in Direct Mode must NOT produce PasteClipboard — it
     /// must pass through to PTY encoding (MouseToBytes when the PTY has
     /// enabled mouse tracking).
     #[test]
@@ -2304,7 +2304,7 @@ mod tests {
                 height: 24,
             });
 
-        // Right-click Release in direct mode — must NOT be PasteClipboard
+        // Right-click Release in Direct Mode — must NOT be PasteClipboard
         let release = Event::Mouse(MouseEvent {
             kind: MouseEventKind::Release(MouseButton::Right),
             column: 10,
@@ -2314,17 +2314,17 @@ mod tests {
         let result = term.handle_events(&release, &ctx);
         assert!(
             !matches!(result, EventResult::Action(TermWmAction::PasteClipboard)),
-            "right-click Release in direct mode must NOT produce PasteClipboard, got {:?}",
+            "right-click Release in Direct Mode must NOT produce PasteClipboard, got {:?}",
             result
         );
         // With mouse tracking enabled, Release should produce MouseToBytes
         assert!(
             matches!(result, EventResult::Action(TermWmAction::MouseToBytes(_))),
-            "right-click Release in direct mode should produce MouseToBytes, got {:?}",
+            "right-click Release in Direct Mode should produce MouseToBytes, got {:?}",
             result
         );
 
-        // Right-click Press in direct mode — also not consumed/paste-intercepted
+        // Right-click Press in Direct Mode — also not consumed/paste-intercepted
         let press = Event::Mouse(MouseEvent {
             kind: MouseEventKind::Press(MouseButton::Right),
             column: 10,
@@ -2334,7 +2334,7 @@ mod tests {
         let press_result = term.handle_events(&press, &ctx);
         assert!(
             !matches!(press_result, EventResult::Consumed),
-            "right-click Press in direct mode must NOT be Consumed, got {:?}",
+            "right-click Press in Direct Mode must NOT be Consumed, got {:?}",
             press_result
         );
     }
@@ -2726,7 +2726,7 @@ mod tests {
         let mut term = TerminalComponent::from_pane(Box::new(TestPane::new(200)));
         term.last_mode_suppressed_scroll.set(true);
         term.set_last_max_scrollback(200);
-        // Normal mode, no alt screen, no direct mode
+        // Normal mode, no alt screen, no Direct Mode
         let ctx = make_ctx(0, handle);
         let area = Rect::new(0, 0, 80, 24);
         let buffer = Buffer::empty(area);

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,42 @@
+# Compatibility
+
+`term-wm` runs natively on Linux, macOS, and Windows. This document details the minimum requirements and the behavior of the application in degraded terminal environments.
+
+## Color Support
+
+`term-wm` is designed and themed against **truecolor (24-bit)** output.
+
+- When the `COLORTERM` environment variable contains `truecolor` or `24bit`, the UI renders full RGB colors (`Color::Rgb`).
+- Otherwise, `term-wm` automatically degrades to the nearest **xterm-256** indexed color (`Color::Indexed`).
+
+UI themes and drop shadows are designed against 24-bit depth, so low-color environments will look noticeably flatter.
+
+### Minimum color support
+
+- **Recommended:** Truecolor (24-bit) terminal.
+- **Usable:** 256-color terminals (e.g., `TERM=xterm-256color`).
+- **Degraded but functional:** 16/8-color terminals (e.g., raw Linux VTs), where the kernel console translates or ignores high-color escape sequences.
+
+## Unicode & Fonts
+
+- A **UTF-8** locale is required (`LANG` set to a UTF-8 locale, e.g. `en_US.UTF-8`).
+- The terminal font must render standard **Unicode box-drawing characters** (`─│┌┐└┘├┤┬┴┼` and friends), which construct window borders, layout splits, and system chrome.
+
+## Linux Virtual Terminals (TTY)
+
+`term-wm` is fully usable in raw Linux VTs (e.g., accessed via `Ctrl+Alt+F1`).
+
+- All window-management and multiplexing logic remains fully functional.
+- Visual presentation differs significantly: the kernel framebuffer console has strict font and color limits, so borders, themes, and shadows render with reduced fidelity. The layout remains usable.
+
+## Non-Standard OS Installs
+
+Minimal or headless installations must meet the following for correct operation:
+
+- A valid **`terminfo`** database must be present and include an entry for the terminal in use (`TERM` must resolve to an installed terminfo record).
+- **`LANG`** (and `LC_ALL`) must be set to a UTF-8 locale to prevent layout corruption from non-UTF-8 output.
+- When connecting remotely, `TERM` should match the client's terminal type so size and color reporting are accurate.
+
+## Windows Session Hosting
+
+`term-session` runs on Windows, but it does **not** currently automatically daemonize the session server. The auto-spawned server uses `CREATE_NO_WINDOW` rather than a full process-session detachment, so on Windows the server process remains tied to the launching console's lifetime instead of surviving independently as it does on macOS and Linux (`setsid`).

--- a/docs/WINDOW-BORDERS.txt
+++ b/docs/WINDOW-BORDERS.txt
@@ -77,7 +77,7 @@ Content area = window_rect - (2 columns, 3 rows)
     Maximize (▢): bg = accent     (green), fg = menu_selected_fg (dark)
     Minimize (_): bg = warning_bg (amber), fg = menu_selected_fg (dark)
 
-  (Note: The direct mode toggle is accessed via the menu, not as a header button.)
+  (Note: The Direct Mode toggle is accessed via the menu, not as a header button.)
 
 ===============================================================================
 2. FLOATING WINDOW DRAG & RESIZE HANDLES


### PR DESCRIPTION
Rewrite the root and term-session crate READMEs to reflect the current
architecture, add a dedicated compatibility guide, refresh the in-app
help
overlay, and unify "Direct Mode" capitalization across the codebase.

Top-level README
- Replace the WIP/library-focused content with current feature docs:
  hybrid BSP/N-ary layout engine, floating windows with edge snapping,
  maximized/monocle viewports, and the power-aware frame-pacing
  pipeline.
- Document the "No-Conflict" philosophy around the Ctrl+A Super Key,
  Command Palette, scrollback keys, and automatic Direct Mode.
- Drop the stale Esc-Super-Key keybinding table, install/benchmark
  deep-dives, and legacy badges/link definitions.
- Add a system-requirements summary pointing at docs/COMPATIBILITY.md.

term-session crate docs
- Reframe term-session as a layout-agnostic, headless session host and
  multiplexer (persistence layer), distinct from the window manager.
- Add "library only" notes clarifying that term-session-client and
  term-session-server ship no binaries of their own.
- Add platform notes for session detachment (setsid on macOS/Linux vs
  CREATE_NO_WINDOW without auto-daemonize on Windows).

docs/COMPATIBILITY.md (new)
- Document truecolor vs 256/16-color degradation, UTF-8 and box-drawing
  font requirements, raw Linux VT behavior, terminfo/LANG requirements
  for minimal installs, and Windows session-hosting caveats.

In-app help overlay
- Rework assets/help.md around the Command Palette and automatic Direct
  Mode; add sections for mouse capture, selection & clipboard, window
  snapping, and environment compatibility.

Terminology & minor refactors
- Standardize "Direct Mode" capitalization in comments, doc comments,
  notifications, test assertions, and docs/WINDOW-BORDERS.txt across the
  core, pty-engine, console, and ui-components crates.
- Extract channel resolution in term-session into resolve_channel() with
  CHANNEL_ENV_VAR/DEFAULT_CHANNEL consts plus unit tests.

Cargo
- Bump workspace version 0.9.0-test -> 0.9.0-alpha.
- Promote interprocess to a workspace dependency and bump to 2.4.3.

