### PR TITLE
Bump release target to v0.9.1-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
-## [0.9.0-alpha] - 2026-07-31
+## [0.9.1-alpha] - 2026-07-31
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "clap",
  "libc",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3071,7 +3071,7 @@ version = "0.0.0"
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3185,21 +3185,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3215,11 +3215,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.0-alpha"
+version = "0.9.1-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -80,21 +80,21 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.0-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.0-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.0-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.0-alpha" }
-term-wm = { path = ".", version = "0.9.0-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.0-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.0-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.0-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.0-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.0-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.0-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.0-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.0-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.0-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.0-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.1-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.1-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.1-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.1-alpha" }
+term-wm = { path = ".", version = "0.9.1-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.1-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.1-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.1-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.1-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.1-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.1-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.1-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.1-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.1-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.1-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }


### PR DESCRIPTION
This changes v0.9.0-alpha to v0.9.1-alpha so that it can be published, as the 0.9.0-test release was blocking it.

When cargo publish verifies term-session-client at 0.9.0-alpha, it resolves term-wm-pty-engine = "^0.9.0-alpha" against crates.io and picks the highest matching version — which is the stale 0.9.0-test (in semver pre-release ordering -test > -alpha). That old crate's key_to_bytes/mouse_event_to_bytes expect its own local types, not the term_wm_events types your code passes → E0308. Same failure awaits term-wm-core and term-wm-ui-components, which also call key_to_bytes with shared types.