### PR TITLE
feat: Add clipboard temp-store fallback, harden OSC 52 relay and simplify session PTY sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.2-alpha] - 2026-08-02
+
+### Added
+
+- **Headless clipboard backing store:** when no system clipboard is available (SSH / remote), `Clipboard::set()` now persists text to a private, owner-only temp file so `get()` can round-trip copy→paste.
+- **`ClipboardConfig`** runtime configuration (`cache_path` + `osc52_limit`) with `Clipboard::with_config()`; `Clipboard::new()`/`with_temp_path()` delegate to it.
+- **Direct unit coverage** for the clipboard subsystem: `ClipboardError` display/conversions, constructor defaults, OSC 52 extractor edge cases, and a PTY reader-loop OSC 52 relay test against an isolated store.
+- `--help` doc comments for the `term-wm` CLI `count`/`cmd` options.
+
+### Changed
+
+- **Clipboard hardened and reorganized:**
+  - Backends orchestrated as an explicit static pipeline (temp store → arboard → **OSC 52 last**, keeping the host terminal emulator as the final clipboard owner on X11) via private per-step helpers.
+  - `Clipboard::set()` is now infallible (`set(&mut self, text: &str)`); the always-`Ok` `Result` was dropped from the signature and all call sites.
+  - One clipboard handle is hoisted above the PTY reader loop and every OSC 52 sequence is relayed synchronously — no debounce, so the tail payload of a burst is never lost.
+  - Module constants consolidated into a single documented block; the file reorganized by concern (Constants → Errors → Config → Orchestrator → Temp-store helpers → OSC 52 protocol).
+- **CLI metadata** for `term-wm`, `term-session`, and `term-bench` sourced from `CARGO_PKG_*`.
+- **Session PTY sizing** simplified: the server spawns terminals at a fallback size and resizes on demand to the smallest geometry across attached clients.
+- Minor UI/help polish: menu icon tweak and help-text wording.
+
+### Removed
+
+- `--embedded` flag and the embedded window-manager build path from the `term-wm` binary (the binary now always builds the standalone UI).
+- Manual `--cols`/`--rows` options from the `term-session` CLI.
+- Redundant `Clipboard::with_options()` multi-argument constructor (replaced by `with_config`).
+
+### Fixed
+
+- OSC 52 payloads over the 1 MB cap are truncated at a valid UTF-8 char boundary instead of being dropped entirely.
+- Clipboard temp store is session-scoped: no unlink on handle drop; cleanup via consume-on-read and OS temp reaping.
+- Clipboard tests no longer touch the real system clipboard or user temp store (isolated `tempfile::tempdir()` paths).
+
+### Security
+
+- OSC 52 emission capped at 1 MB (`DEFAULT_MAX_OSC52_BYTES`) with char-boundary truncation; the temp-file store and arboard always receive the full untruncated text.
+
 ## [0.9.1-alpha] - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,6 +3206,7 @@ dependencies = [
  "ctrlc",
  "libc",
  "portable-pty",
+ "tempfile",
  "term-wm-events",
  "thiserror 2.0.19",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "clap",
  "libc",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3071,7 +3071,7 @@ version = "0.0.0"
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3185,21 +3185,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3216,11 +3216,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.1-alpha"
+version = "0.9.2-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,21 +86,21 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.1-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.1-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.1-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.1-alpha" }
-term-wm = { path = ".", version = "0.9.1-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.1-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.1-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.1-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.1-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.1-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.1-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.1-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.1-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.1-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.1-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.2-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.2-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.2-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.2-alpha" }
+term-wm = { path = ".", version = "0.9.2-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.2-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.2-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.2-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.2-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.2-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.2-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.2-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.2-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.2-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.2-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,13 @@
 name = "term-wm"
 description = "A cross-platform terminal multiplexer, window manager, Ratatui component library, and runtime."
 keywords = ["window-manager", "multiplexer", "terminal", "tui", "cross-platform"]
-categories = ["command-line-utilities", "emulators", "gui", "concurrency", "network-programming"]
+categories = [
+    "command-line-utilities",
+    "emulators",
+    "gui",
+    "concurrency",
+    "network-programming",
+]
 authors.workspace = true
 version.workspace = true
 edition.workspace = true

--- a/crates/term-bench/src/main.rs
+++ b/crates/term-bench/src/main.rs
@@ -23,9 +23,9 @@ const GLYPHS: [&str; 10] = [".", ",", ":", "-", ";", "+", "*", "x", "#", "@"];
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "render-bench",
+    name = env!("CARGO_PKG_NAME"),
     version = env!("CARGO_PKG_VERSION"),
-    about = "Render-heavy benchmark for checking terminal throughput"
+    about = env!("CARGO_PKG_DESCRIPTION")
 )]
 struct BenchCli {
     /// How long to run the benchmark.
@@ -37,7 +37,7 @@ struct BenchCli {
     )]
     duration_seconds: f64,
 
-    /// Target frames per second. Used to pace rendering so comparisons are repeatable.
+    /// Target frames per second to pace rendering so comparisons are repeatable.
     #[arg(short = 'f', long = "fps", value_name = "FPS", default_value_t = 60.0)]
     target_fps: f64,
 }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -488,7 +488,7 @@ pub fn run_session(socket_path: &str) -> io::Result<()> {
 
         // Drain clipboard
         while let Ok(text) = clip_rx.try_recv() {
-            let _ = clipboard.set(&text);
+            clipboard.set(&text);
         }
 
         // Handle SIGINT

--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -37,8 +37,6 @@ const SESSION_EXIT_POLL_INTERVAL: std::time::Duration = std::time::Duration::fro
 pub struct SessionServerConfig {
     pub channel: ChannelName,
     pub cmd: Vec<String>,
-    pub cols: u16,
-    pub rows: u16,
 }
 
 #[derive(Clone)]
@@ -174,8 +172,8 @@ pub async fn run_server(
         let session = Session::spawn(
             SESSION_ID,
             cmd,
-            config.cols,
-            config.rows,
+            FALLBACK_COLS,
+            FALLBACK_ROWS,
             Some(&config.channel),
         )?;
         st.set_session(session);

--- a/crates/term-session/README.md
+++ b/crates/term-session/README.md
@@ -16,7 +16,7 @@ cargo run --release --bin term-session -- --server --channel work -- vim # start
 
 Multiple terminals can attach to the same channel to share one session.
 
-In client mode `term-session` first probes the channel for a live server and, if none is running, spawns a detached one automatically (`connect_or_spawn_server`). The program to run and the PTY size are forwarded to the server at spawn time. The channel can also be set via the `TERM_WM_CHANNEL` environment variable.
+In client mode `term-session` first probes the channel for a live server and, if none is running, spawns a detached one automatically (`connect_or_spawn_server`). The program to run is forwarded to the server at spawn time. The PTY starts at a default size and the server resizes it on demand to the smallest geometry across attached clients. The channel can also be set via the `TERM_WM_CHANNEL` environment variable.
 
 ## Architecture & Capabilities
 

--- a/crates/term-session/src/auto_spawn.rs
+++ b/crates/term-session/src/auto_spawn.rs
@@ -9,8 +9,6 @@ use term_session_muxio_service_definitions::{ChannelName, probe_ipc_endpoint};
 #[derive(Clone, Debug)]
 pub struct ServerSpawnConfig<'a> {
     pub channel: &'a ChannelName,
-    pub cols: u16,
-    pub rows: u16,
     pub cmd: &'a [String],
 }
 
@@ -20,8 +18,6 @@ fn spawn_detached_server(cfg: &ServerSpawnConfig<'_>) -> io::Result<Child> {
     cmd.arg("--server")
         .arg("--channel")
         .arg(cfg.channel.to_string());
-    cmd.arg("--cols").arg(cfg.cols.to_string());
-    cmd.arg("--rows").arg(cfg.rows.to_string());
     if !cfg.cmd.is_empty() {
         cmd.arg("--").args(cfg.cmd);
     }

--- a/crates/term-session/src/main.rs
+++ b/crates/term-session/src/main.rs
@@ -10,9 +10,9 @@ const CHANNEL_ENV_VAR: &str = "TERM_WM_CHANNEL";
 const DEFAULT_CHANNEL: &str = "default/main";
 
 #[derive(Parser, Debug)]
-#[command(name = "term-session", about = "term-wm session manager")]
+#[command(name = env!("CARGO_PKG_NAME"), about = env!("CARGO_PKG_DESCRIPTION"))]
 struct Cli {
-    /// Channel name (namespace/name). Falls back to TERM_WM_CHANNEL env, then "default/main".
+    /// Channel name (namespace/name); falls back to TERM_WM_CHANNEL env, then "default/main".
     #[arg(short, long)]
     channel: Option<String>,
 
@@ -20,16 +20,7 @@ struct Cli {
     #[arg(long)]
     server: bool,
 
-    /// Columns (width) of each terminal
-    #[arg(long = "cols", default_value = "80")]
-    cols: u16,
-
-    /// Rows (height) of each terminal
-    #[arg(long = "rows", default_value = "24")]
-    rows: u16,
-
-    /// Command to run (and its arguments).
-    /// If omitted, launches the default shell.
+    /// Command to run (and its arguments); if omitted, launches the default shell.
     #[arg(num_args = 0..)]
     cmd: Vec<String>,
 }
@@ -40,8 +31,6 @@ fn run_server_mode(channel: &ChannelName, cli: &Cli) -> io::Result<()> {
     let config = SessionServerConfig {
         channel: channel.clone(),
         cmd: cli.cmd.clone(),
-        cols: cli.cols,
-        rows: cli.rows,
     };
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| io::Error::other(format!("runtime: {e}")))?;
@@ -72,8 +61,6 @@ fn main() -> io::Result<()> {
 
     let spawn_cfg = ServerSpawnConfig {
         channel: &channel,
-        cols: cli.cols,
-        rows: cli.rows,
         cmd: &cli.cmd,
     };
     let socket_name = connect_or_spawn_server(&channel, &spawn_cfg)?;

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -2191,9 +2191,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         let Some(text) = self.selection_text.clone() else {
             return;
         };
-        if let Some(cb) = &mut self.clipboard
-            && cb.set(&text).is_ok()
-        {
+        if let Some(cb) = &mut self.clipboard {
+            cb.set(&text);
             self.push_notification(
                 "Selection copied to clipboard",
                 std::time::Duration::from_secs(2),
@@ -2759,7 +2758,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                 // Send SUPER key to window
                 items.push(MenuDisplayItem::Item(MenuItem {
                     label: format!("Send {} to {}", super_key, title).into(),
-                    icon: Some("S"),
+                    icon: Some("A"),
                     action: crate::actions::TermWmAction::SendSuperKeyToWindow(focused),
                     disabled: false,
                 }));

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -20,3 +20,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 vt100 = { workspace = true }
 vte = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/term-wm-pty-engine/src/clipboard.rs
+++ b/crates/term-wm-pty-engine/src/clipboard.rs
@@ -74,6 +74,7 @@ const CLIPBOARD_CACHE_FILENAME: &str = "term-wm-clipboard.txt";
 
 /// Prefix for the per-user subdirectory created under the shared temp dir
 /// on Unix when `$XDG_RUNTIME_DIR` is not available.
+#[cfg(unix)]
 const APP_TEMP_DIR_PREFIX: &str = "term-wm";
 
 /// Length of the OSC 52 header `\x1b]52;` (ESC + ] + "52;").

--- a/crates/term-wm-pty-engine/src/clipboard.rs
+++ b/crates/term-wm-pty-engine/src/clipboard.rs
@@ -426,9 +426,10 @@ impl Clipboard {
     ///    selection thread, whose clipboard ownership is known to be
     ///    unreliable (pastes can silently serve stale data).  The terminal
     ///    emulator then answers paste requests directly.  Oversized
-    ///    payloads are truncated to [`Clipboard::osc52_limit`] bytes at a
-    ///    valid UTF-8 char boundary, so the host still receives output up to
-    ///    the cap; the temp-file store and arboard always receive the full
+    ///    payloads are truncated at a valid UTF-8 char boundary to the OSC 52
+    ///    emission cap (default [`DEFAULT_MAX_OSC52_BYTES`], settable via
+    ///    [`Clipboard::with_options`]), so the host still receives output up
+    ///    to the cap; the temp-file store and arboard always receive the full
     ///    untruncated text.
     ///
     /// Errors from any path are silently ignored — at least one of

--- a/crates/term-wm-pty-engine/src/clipboard.rs
+++ b/crates/term-wm-pty-engine/src/clipboard.rs
@@ -1,6 +1,6 @@
 //! Cross-platform clipboard helper utilities.
 //!
-//! This module provides two clipboard back-ends:
+//! This module provides three clipboard back-ends:
 //!
 //! 1. **OSC 52** – writes the clipboard via the terminal-emulator escape
 //!    sequence `\x1b]52;c;BASE64\x07`.  This works through remote terminals,
@@ -10,8 +10,21 @@
 //! 2. **`arboard`** – a persistent handle for direct access (local fallback
 //!    and clipboard reads).  When running over SSH the arboard handle may not
 //!    initialise; OSC 52 alone is sufficient for copy.
+//!
+//! 3. **Temp-file store** – a best-effort backing store written on `set()`
+//!    when no system clipboard is available (headless / remote), so `get()`
+//!    can round-trip copy→paste on machines (e.g. a bare Ubuntu server over
+//!    SSH) where `arboard` cannot initialise and the host terminal may not
+//!    support OSC 52 reads.
+//!
+//! The temp-file store is **session-scoped, not handle-scoped**: dropping a
+//! [`Clipboard`] never unlinks the store.  A successfully consumed `get()`
+//! removes the file (single-use round-trip); otherwise the store is cleaned
+//! up by the OS (`$XDG_RUNTIME_DIR` is tmpfs and wiped on logout, and the
+//! fallback temp-dir entries are cleaned by the OS).
 
 use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use thiserror::Error;
@@ -28,6 +41,193 @@ pub enum ClipboardError {
 
     #[error("clipboard backend not available (running remotely?)")]
     NotAvailable,
+}
+
+/// Default cap on OSC 52 emission payload size (1 MB).  Payloads larger than
+/// this are truncated at a valid UTF-8 char boundary so the host terminal
+/// still receives output up to the cap.  Local file cache and arboard writes
+/// are never truncated.
+pub const DEFAULT_MAX_OSC52_BYTES: usize = 1024 * 1024;
+
+/// Environment variable pointing to the user-private runtime directory
+/// (set by systemd on modern Linux; `0700`-permissioned, tmpfs-backed).
+const ENV_XDG_RUNTIME_DIR: &str = "XDG_RUNTIME_DIR";
+
+/// Filename of the temp-file clipboard backing store used as a headless
+/// fallback for `get()`.
+const CLIPBOARD_CACHE_FILENAME: &str = "term-wm-clipboard.txt";
+
+/// Prefix for the per-user subdirectory created under the shared temp dir
+/// on Unix when `$XDG_RUNTIME_DIR` is not available.
+const APP_TEMP_DIR_PREFIX: &str = "term-wm";
+
+/// Resolve the default path of the temp-file clipboard store.
+///
+/// Clipboard contents can be sensitive (passwords, tokens), so the store
+/// must never live in a world-readable location.  Resolution order:
+///
+/// 1. `$XDG_RUNTIME_DIR/term-wm-clipboard.txt` — a user-private (`0700`),
+///    RAM-backed (`tmpfs`) directory created by systemd on modern Linux.
+/// 2. `<temp_dir>/term-wm-<uid>/term-wm-clipboard.txt` on Unix — a
+///    user-owned, `0700` subdirectory under the shared temp dir so other
+///    users cannot read the clipboard.
+/// 3. `<temp_dir>/term-wm-clipboard.txt` elsewhere — the platform temp
+///    dir is already user-private on Windows and macOS.
+fn default_temp_path() -> PathBuf {
+    if let Some(runtime_dir) = std::env::var_os(ENV_XDG_RUNTIME_DIR) {
+        let path = PathBuf::from(runtime_dir).join(CLIPBOARD_CACHE_FILENAME);
+        tracing::debug!(
+            "clipboard: resolved store path via XDG_RUNTIME_DIR -> {}",
+            path.display()
+        );
+        return path;
+    }
+    let base = std::env::temp_dir();
+    #[cfg(unix)]
+    let base = base.join(format!("{}-{}", APP_TEMP_DIR_PREFIX, unsafe {
+        libc::getuid()
+    }));
+    let path = base.join(CLIPBOARD_CACHE_FILENAME);
+    tracing::debug!(
+        "clipboard: resolved store path via temp_dir{} -> {}",
+        if cfg!(unix) { " (per-user subdir)" } else { "" },
+        path.display()
+    );
+    path
+}
+
+/// Create the parent directory of the clipboard store with owner-only
+/// permissions (`0700`) on Unix, preventing other users from entering it.
+///
+/// If the directory already exists it is NOT blindly reused: a pre-existing
+/// directory under the predictable `/tmp/term-wm-<uid>` name could have been
+/// created permissively by another user, who could then plant files to steal
+/// or poison clipboard contents.  The existing directory is accepted only
+/// when it is a directory owned by the current user and not writable by
+/// group or others.
+fn ensure_clipboard_store_dir(path: &Path) -> std::io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        match builder.create(parent) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let meta = std::fs::metadata(parent)?;
+                if !meta.is_dir() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "clipboard store: parent path is not a directory",
+                    ));
+                }
+                if meta.uid() != unsafe { libc::geteuid() } {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "clipboard store: parent directory not owned by current user",
+                    ));
+                }
+                if meta.mode() & 0o022 != 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "clipboard store: parent directory is group/other-writable",
+                    ));
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+    #[cfg(not(unix))]
+    std::fs::create_dir_all(parent)
+}
+
+/// Write `text` to the temp-file backing store at `path`.
+///
+/// The file is created with owner-only permissions (`0600`) on Unix, and
+/// the permissions are pinned on the opened fd itself (`fchmod`), which also
+/// closes the open-then-chmod path-re-resolution TOCTOU window.  Before any
+/// content is written the opened fd is verified (race-free, via `fstat`) to
+/// be a regular file owned by the current user with a link count of one —
+/// this rejects a symlink (`O_NOFOLLOW`) as well as a hard link planted at
+/// the store path that would otherwise leak clipboard contents into a file
+/// the attacker owns, or overwrite a file we own elsewhere.
+///
+/// Best-effort: failures are swallowed by callers — this is a fallback,
+/// not a primary clipboard mechanism.
+fn write_clipboard_temp(path: &Path, text: &str) -> std::io::Result<()> {
+    ensure_clipboard_store_dir(path)?;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+        // Reject a symlink at the store path so an attacker cannot redirect
+        // our write onto a file we do not own (e.g. via a pre-planted
+        // symlink in a shared temp dir before our 0700 store dir exists).
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut f = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::io::AsRawFd;
+
+        let meta = f.metadata()?;
+        if !meta.is_file() || meta.uid() != unsafe { libc::geteuid() } || meta.nlink() != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "clipboard store: unexpected file ownership, type, or link count",
+            ));
+        }
+        if unsafe { libc::fchmod(f.as_raw_fd(), 0o600) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    f.set_len(0)?;
+    f.write_all(text.as_bytes())?;
+    f.flush()?;
+    Ok(())
+}
+
+/// Read the text previously stored at `path` by the temp-file backing store.
+///
+/// On Unix the file is opened with `O_NOFOLLOW` (rejecting a symlink planted
+/// at the store path) and the opened fd is verified to be a regular file
+/// owned by the current user with owner-only permissions before its contents
+/// are trusted.  A foreign-owned or permissive file could be attacker
+/// content that would be pasted into the terminal (clipboard poisoning).
+fn read_clipboard_temp(path: &Path) -> std::io::Result<String> {
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        options.custom_flags(libc::O_NOFOLLOW);
+        let mut f = options.open(path)?;
+        let meta = f.metadata()?;
+        if !meta.is_file() || meta.uid() != unsafe { libc::geteuid() } || meta.mode() & 0o077 != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "clipboard store: refusing to read non-owner-only file",
+            ));
+        }
+        let mut buf = String::new();
+        f.read_to_string(&mut buf)?;
+        Ok(buf)
+    }
+    #[cfg(not(unix))]
+    std::fs::read_to_string(path)
 }
 
 /// Build the raw bytes of an OSC 52 clipboard sequence.
@@ -58,17 +258,33 @@ pub fn set_via_osc52_with_writer(text: &str, writer: &mut dyn Write) -> Result<(
     Ok(())
 }
 
-/// A persistent clipboard handle backed by `arboard` (optional) and OSC 52.
+/// A persistent clipboard handle backed by `arboard` (optional), OSC 52,
+/// and a temp-file store (optional).
 ///
 /// Holding a long-lived [`arboard::Clipboard`] instance avoids the macOS
 /// problem where a short-lived connection is torn down before the pasteboard
 /// server finishes processing the write.
 ///
 /// When running over SSH the arboard handle will be `None`; `set()` still
-/// works via OSC 52 emitted to stdout, but `get()` returns
-/// `ClipboardError::NotAvailable`.
+/// works via OSC 52 emitted to stdout, and the temp-file store (enabled
+/// only in that headless case) lets `get()` round-trip copy→paste.
 pub struct Clipboard {
     arboard: Option<arboard::Clipboard>,
+    /// Whether the temp-file backing store is active.  Enabled at
+    /// construction when `arboard` is unavailable (headless / SSH), so
+    /// clipboard text is only persisted to disk when there is no real
+    /// system clipboard to write to.  Stored separately (rather than
+    /// recomputed from `arboard`) so tests can exercise both modes without
+    /// a display.
+    temp_store_enabled: bool,
+    /// Resolved path of the temp-file backing store, determined once at
+    /// construction (see [`Clipboard::new`]).  Tests inject an isolated
+    /// path via [`Clipboard::with_temp_path`] to avoid the shared store.
+    temp_path: PathBuf,
+    /// Maximum size of the text emitted over OSC 52, in bytes.  Payloads
+    /// above this cap are truncated at a UTF-8 char boundary; the temp-file
+    /// store and arboard always receive the full text.
+    osc52_limit: usize,
     /// Captured OSC 52 output — only present in test builds so that tests
     /// can verify the OSC 52 path was exercised alongside the arboard path.
     #[cfg(test)]
@@ -86,10 +302,49 @@ impl Clipboard {
     ///
     /// The arboard backend is initialised when a local display is available;
     /// when running remotely (SSH, no display) it is silently absent and
-    /// only the OSC 52 fallback will be available.
+    /// only the OSC 52 fallback will be available.  The temp-file backing
+    /// store path is resolved once here from the environment.
     pub fn new() -> Self {
+        Self::with_options(default_temp_path(), DEFAULT_MAX_OSC52_BYTES)
+    }
+
+    /// Create a clipboard handle using `path` as the temp-file backing
+    /// store and the default OSC 52 cap.  Resolution of the default path is
+    /// skipped; tests use this to inject an isolated path into a throwaway
+    /// temp location.
+    pub fn with_temp_path(path: PathBuf) -> Self {
+        Self::with_options(path, DEFAULT_MAX_OSC52_BYTES)
+    }
+
+    /// Create a clipboard handle using `cache_path` as the temp-file backing
+    /// store and `osc52_limit` as the OSC 52 emission cap (in bytes).
+    ///
+    /// The cap is applied only to OSC 52 emission: payloads larger than
+    /// `osc52_limit` are truncated at a valid UTF-8 char boundary so the
+    /// host terminal still receives output up to the cap.  The temp-file
+    /// store and arboard always receive the full, untruncated text.
+    pub fn with_options(cache_path: PathBuf, osc52_limit: usize) -> Self {
+        let arboard = arboard::Clipboard::new().ok();
+        let temp_store_enabled = arboard.is_none();
+        tracing::debug!(
+            "clipboard: backend arboard={}, temp store={}, store path={}",
+            if arboard.is_some() {
+                "available"
+            } else {
+                "unavailable"
+            },
+            if temp_store_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            cache_path.display()
+        );
         Self {
-            arboard: arboard::Clipboard::new().ok(),
+            arboard,
+            temp_store_enabled,
+            temp_path: cache_path,
+            osc52_limit,
             #[cfg(test)]
             osc52_output: Vec::new(),
         }
@@ -97,51 +352,134 @@ impl Clipboard {
 
     /// Read the clipboard as a `String`.
     ///
-    /// Only works in local environments where `arboard` can reach the
-    /// system clipboard.  Over SSH this returns `ClipboardError::NotAvailable`.
-    /// Does **not** attempt OSC 52 reads because most terminal emulators
-    /// do not support them.
+    /// Prefers `arboard` (the real system clipboard) when available; on
+    /// headless / remote machines it falls back to the temp-file backing
+    /// store written by [`Clipboard::set`], so copy→paste round-trips
+    /// inside term-wm.  Does **not** attempt OSC 52 reads because most
+    /// terminal emulators do not support them.
     pub fn get(&mut self) -> Result<String, ClipboardError> {
-        self.arboard
-            .as_mut()
-            .ok_or(ClipboardError::NotAvailable)?
-            .get_text()
-            .map_err(ClipboardError::from)
+        if let Some(cb) = self.arboard.as_mut() {
+            match cb.get_text() {
+                Ok(text) => {
+                    tracing::debug!("clipboard: get read via arboard ({} bytes)", text.len());
+                    return Ok(text);
+                }
+                Err(e) if !self.temp_store_enabled => {
+                    tracing::debug!("clipboard: get via arboard failed ({e}); temp store inactive");
+                    return Err(e.into());
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "clipboard: get via arboard failed ({e}); falling back to temp store"
+                    );
+                }
+            }
+        } else if !self.temp_store_enabled {
+            tracing::debug!("clipboard: get no backends available");
+            return Err(ClipboardError::NotAvailable);
+        }
+        // arboard absent or errored with the temp store active: fall back to
+        // the temp-file backing store.
+        match read_clipboard_temp(&self.temp_path) {
+            Ok(text) => {
+                tracing::debug!(
+                    "clipboard: get read via temp store {} ({} bytes)",
+                    self.temp_path.display(),
+                    text.len()
+                );
+                // Consume the store: this is a single-use copy→paste round-trip,
+                // so remove the file so sensitive clipboard text does not persist
+                // on disk.  Best-effort.
+                if let Err(e) = std::fs::remove_file(&self.temp_path) {
+                    tracing::debug!(
+                        "clipboard: get temp store cleanup failed at {} ({e})",
+                        self.temp_path.display()
+                    );
+                }
+                Ok(text)
+            }
+            Err(_) => {
+                tracing::debug!(
+                    "clipboard: get temp store unavailable at {}",
+                    self.temp_path.display()
+                );
+                Err(ClipboardError::NotAvailable)
+            }
+        }
     }
 
     /// Set the system clipboard to `text`.
     ///
-    /// Runs **both** back-ends:
+    /// Runs all back-ends; the temp-file store is only written when arboard
+    /// is unavailable (headless / SSH):
     ///
-    /// 1. `arboard` — writes to the local system clipboard directly.
-    /// 2. **OSC 52** — writes to the host terminal's clipboard via the
-    ///    escape sequence.  This ensures copy works when embedded in
-    ///    remote/embedded terminals (Zed, tmux, SSH) where the host
-    ///    terminal intercepts the sequence.
+    /// 1. **Temp file** — when there is no system clipboard (headless /
+    ///    remote), a local copy so `get()` can round-trip copy→paste.
+    ///    Written **first** so an internal paste is guaranteed even if a
+    ///    later backend fails.
+    /// 2. `arboard` — writes to the local system clipboard directly.
+    /// 3. **OSC 52** — writes to the host terminal's clipboard via the
+    ///    escape sequence, and is emitted **last** so the host terminal
+    ///    emulator becomes the final owner of the system clipboard.  This
+    ///    ensures copy works when embedded in remote/embedded terminals
+    ///    (Zed, tmux, SSH), and on X11 it supersedes arboard's in-process
+    ///    selection thread, whose clipboard ownership is known to be
+    ///    unreliable (pastes can silently serve stale data).  The terminal
+    ///    emulator then answers paste requests directly.  Oversized
+    ///    payloads are truncated to [`Clipboard::osc52_limit`] bytes at a
+    ///    valid UTF-8 char boundary, so the host still receives output up to
+    ///    the cap; the temp-file store and arboard always receive the full
+    ///    untruncated text.
     ///
-    /// Errors from either path are silently ignored — at least one of
-    /// the two is expected to fail depending on the environment.
+    /// Errors from any path are silently ignored — at least one of
+    /// the back-ends is expected to fail depending on the environment.
     pub fn set(&mut self, text: &str) -> Result<(), ClipboardError> {
-        // Always write OSC 52 for the host terminal — this is the only
-        // mechanism that reaches the real clipboard when term-wm runs
-        // inside Zed's remote terminal, tmux, or over SSH.
+        // Persist to the temp-file backing store only when there is no real
+        // system clipboard to write to (headless / SSH).  This keeps
+        // clipboard text off disk in normal local sessions.  Best-effort.
+        if self.temp_store_enabled
+            && let Err(e) = write_clipboard_temp(&self.temp_path, text)
+        {
+            tracing::debug!(
+                "clipboard: set temp store write failed at {} ({e})",
+                self.temp_path.display()
+            );
+        }
+
+        // Write via arboard for the local case.  On X11 this claims the
+        // CLIPBOARD selection, but arboard hosts the data in its own
+        // background thread, which can silently drop or serve stale data.
+        // macOS AppKit/NSPasteboard writes debug spam to stderr when
+        // setting the clipboard — suppress it to prevent terminal junk.
+        if let Some(cb) = &mut self.arboard {
+            let _guard = StderrSuppressGuard::new();
+            match cb.set_text(text.to_owned()) {
+                Ok(()) => tracing::debug!("clipboard: set wrote via arboard"),
+                Err(e) => tracing::debug!("clipboard: set via arboard failed ({e})"),
+            }
+        } else {
+            tracing::debug!("clipboard: set arboard unavailable; temp store + OSC 52 only");
+        }
+
+        // Emit OSC 52 for the host terminal LAST.  When the host terminal
+        // emulator supports OSC 52 (VTE, Alacritty, WezTerm, …) it responds
+        // by taking over the system clipboard, making it the final owner —
+        // which on X11 is far more reliable than arboard's in-process
+        // selection thread for answering paste requests.  Truncate at a
+        // valid UTF-8 char boundary so oversized payloads still reach the
+        // host up to the cap without corrupting multibyte characters.
+        let osc52_text = &text[..text.floor_char_boundary(self.osc52_limit)];
         #[cfg(not(test))]
-        let _ = set_via_osc52_with_writer(text, &mut std::io::stdout().lock());
+        if let Err(e) = set_via_osc52_with_writer(osc52_text, &mut std::io::stdout().lock()) {
+            tracing::debug!("clipboard: set OSC 52 to stdout failed ({e})");
+        }
 
         // In tests, capture to osc52_output instead of stdout.
         #[cfg(test)]
         {
             let mut buf = Vec::new();
-            let _ = set_via_osc52_with_writer(text, &mut buf);
+            let _ = set_via_osc52_with_writer(osc52_text, &mut buf);
             self.osc52_output = buf;
-        }
-
-        // Also write via arboard for the local case.
-        // macOS AppKit/NSPasteboard writes debug spam to stderr when
-        // setting the clipboard — suppress it to prevent terminal junk.
-        if let Some(cb) = &mut self.arboard {
-            let _guard = StderrSuppressGuard::new();
-            let _ = cb.set_text(text.to_owned());
         }
 
         Ok(())
@@ -377,9 +715,224 @@ impl Default for Osc52Extractor {
 mod tests {
     use super::*;
 
+    /// Path to the clipboard store inside an isolated, auto-cleaned
+    /// [`tempfile::TempDir`], so tests never touch the shared default store
+    /// or leak files in the OS temp directory.
+    ///
+    /// A nested owner-only (`0700`) subdirectory is used as the store parent
+    /// to mirror production (where the parent is created `0700`), because
+    /// `tempfile::TempDir` roots are group/other-writable by default and
+    /// would be rejected by [`ensure_clipboard_store_dir`].
+    fn store_path(dir: &tempfile::TempDir) -> PathBuf {
+        let sub = dir.path().join("store");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            let mut builder = std::fs::DirBuilder::new();
+            builder.mode(0o700);
+            builder.create(&sub).unwrap();
+        }
+        #[cfg(not(unix))]
+        std::fs::create_dir_all(&sub).unwrap();
+        sub.join(CLIPBOARD_CACHE_FILENAME)
+    }
+
+    #[test]
+    fn temp_store_roundtrip_via_set_get_when_arboard_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = store_path(&dir);
+        let mut cb = Clipboard::with_temp_path(path.clone());
+        // Simulate a headless SSH session where arboard cannot initialise:
+        // the temp-file store is the only round-trip mechanism.
+        cb.arboard = None;
+        cb.temp_store_enabled = true;
+
+        cb.set("clipboard text").unwrap();
+        assert!(path.exists(), "set() must persist to the temp store");
+        assert_eq!(cb.get().unwrap(), "clipboard text");
+        assert!(
+            !path.exists(),
+            "get() must consume the temp store so secrets do not persist on disk"
+        );
+    }
+
+    #[test]
+    fn temp_store_read_helper_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = store_path(&dir);
+        write_clipboard_temp(&path, "helper text").unwrap();
+        assert_eq!(read_clipboard_temp(&path).unwrap(), "helper text");
+    }
+
+    #[test]
+    fn temp_store_read_missing_returns_not_available() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cb = Clipboard::with_temp_path(store_path(&dir));
+        cb.arboard = None;
+        cb.temp_store_enabled = true;
+        assert!(matches!(cb.get(), Err(ClipboardError::NotAvailable)));
+    }
+
+    #[test]
+    fn temp_store_unicode_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cb = Clipboard::with_temp_path(store_path(&dir));
+        cb.arboard = None;
+        cb.temp_store_enabled = true;
+
+        cb.set("héllo 日本語 ✅").unwrap();
+        assert_eq!(cb.get().unwrap(), "héllo 日本語 ✅");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_store_dir_and_file_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Nested path forces `ensure_clipboard_store_dir` to create the
+        // intermediate directory, which must be owner-only (0700).
+        let store_dir = dir.path().join("store");
+        let path = store_dir.join(CLIPBOARD_CACHE_FILENAME);
+        write_clipboard_temp(&path, "secret").unwrap();
+
+        let dir_mode = std::fs::metadata(&store_dir).unwrap().permissions().mode() & 0o777;
+        let file_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700, "store dir must be owner-only");
+        assert_eq!(file_mode, 0o600, "store file must be owner-only");
+    }
+
+    #[test]
+    fn temp_store_not_written_when_clipboard_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = store_path(&dir);
+        let mut cb = Clipboard::with_temp_path(path.clone());
+        // Simulate a local session with a real system clipboard: the
+        // temp-file store is disabled, so `set()` must not persist text
+        // to disk, and `get()` must not read from it.
+        cb.temp_store_enabled = false;
+        cb.arboard = None;
+
+        cb.set("sensitive text").unwrap();
+        assert!(
+            !path.exists(),
+            "temp store must not be written when a system clipboard exists"
+        );
+        assert!(
+            matches!(cb.get(), Err(ClipboardError::NotAvailable)),
+            "get() must not fall back to the temp store when it is disabled"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_store_write_rejects_symlink() {
+        use std::os::unix::fs::{DirBuilderExt, symlink};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        // Owner-only dir so the rejection comes from O_NOFOLLOW, not from
+        // the pre-existing-dir permission check.
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        builder.create(&store_dir).unwrap();
+
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, "precious").unwrap();
+        // Simulate an attacker pre-planting a symlink at the store path.
+        let link = store_dir.join(CLIPBOARD_CACHE_FILENAME);
+        symlink(&target, &link).unwrap();
+
+        // The write must refuse to follow the symlink (O_NOFOLLOW -> ELOOP).
+        assert!(write_clipboard_temp(&link, "evil").is_err());
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "precious",
+            "symlink target must not be truncated"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_store_read_rejects_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        std::fs::create_dir(&store_dir).unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, "precious").unwrap();
+        let link = store_dir.join(CLIPBOARD_CACHE_FILENAME);
+        symlink(&target, &link).unwrap();
+
+        // The read must refuse to follow the symlink so attacker content
+        // cannot be pasted as clipboard text.
+        assert!(read_clipboard_temp(&link).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "precious",
+            "symlink target must be left untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_store_rejects_permissive_preexisting_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        std::fs::create_dir(&store_dir).unwrap();
+        // Simulate a directory pre-created by another user (or left
+        // permissively) that we would otherwise blindly reuse.
+        std::fs::set_permissions(&store_dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+        let path = store_dir.join(CLIPBOARD_CACHE_FILENAME);
+
+        assert!(
+            write_clipboard_temp(&path, "secret").is_err(),
+            "permissive pre-existing store dir must be rejected"
+        );
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_store_write_rejects_hardlink_target() {
+        use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let store_dir = dir.path().join("store");
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        builder.create(&store_dir).unwrap();
+
+        let attacker_file = dir.path().join("attacker-owned.txt");
+        std::fs::write(&attacker_file, "precious").unwrap();
+        // Simulate an attacker hard-linking their own file into the store
+        // path (O_NOFOLLOW does not stop hard links).
+        let store_path = store_dir.join(CLIPBOARD_CACHE_FILENAME);
+        std::fs::hard_link(&attacker_file, &store_path).unwrap();
+        assert_eq!(
+            std::fs::metadata(&store_path).unwrap().nlink(),
+            2,
+            "hard link must be set up for the test"
+        );
+
+        assert!(
+            write_clipboard_temp(&store_path, "secret").is_err(),
+            "a hard-linked store file must be rejected before any write"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&attacker_file).unwrap(),
+            "precious",
+            "hard-link target must not be truncated or overwritten"
+        );
+    }
+
     #[test]
     fn clipboard_set_emits_osc52() {
-        let mut cb = Clipboard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let mut cb = Clipboard::with_temp_path(store_path(&dir));
         cb.set("hello from test").unwrap();
 
         assert!(
@@ -519,6 +1072,56 @@ mod tests {
             Some("hello 日本語".to_string()),
             "writer output should survive extract roundtrip"
         );
+    }
+
+    #[test]
+    fn osc52_emission_truncated_over_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // Force a small OSC 52 cap via with_options.
+        let path = store_path(&dir);
+        let mut cb = Clipboard::with_options(path.clone(), 8);
+        cb.arboard = None;
+        cb.temp_store_enabled = true;
+
+        let oversized = "this text is longer than the 8-byte cap";
+        cb.set(oversized).unwrap();
+
+        // OSC 52 output must be truncated to <= limit bytes at a char boundary.
+        let decoded = extract_osc52_text(&cb.osc52_output).unwrap();
+        assert!(
+            decoded.len() <= 8,
+            "OSC 52 emission must be truncated to the cap, got {} bytes",
+            decoded.len()
+        );
+        assert!(
+            oversized.starts_with(&decoded),
+            "truncated emission must be a prefix of the original text"
+        );
+
+        // The temp store must retain the full, untruncated text.
+        assert_eq!(
+            read_clipboard_temp(&path).unwrap(),
+            oversized,
+            "temp store must keep the full text"
+        );
+    }
+
+    #[test]
+    fn osc52_truncation_respects_utf8_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cb = Clipboard::with_options(store_path(&dir), 5);
+        cb.arboard = None;
+        cb.temp_store_enabled = true;
+
+        // "héllo" — 'é' is 2 bytes.  A byte-5 cut would land inside 'é';
+        // floor_char_boundary must land at index 4 (after 'h' + 'é').
+        let text = "héllo";
+        cb.set(text).unwrap();
+
+        let decoded = extract_osc52_text(&cb.osc52_output).unwrap();
+        assert_eq!(decoded, "héll", "must truncate at a valid UTF-8 boundary");
+        assert!(decoded.len() <= 5);
+        assert!(!cb.osc52_output.is_empty(), "OSC 52 must still be emitted");
     }
 
     /// Verify that `Clipboard::set()` emits OSC 52 to stdout.

--- a/crates/term-wm-pty-engine/src/clipboard.rs
+++ b/crates/term-wm-pty-engine/src/clipboard.rs
@@ -22,6 +22,33 @@
 //! removes the file (single-use round-trip); otherwise the store is cleaned
 //! up by the OS (`$XDG_RUNTIME_DIR` is tmpfs and wiped on logout, and the
 //! fallback temp-dir entries are cleaned by the OS).
+//!
+//! # Design: explicit static orchestration
+//!
+//! The three backends have fundamentally asymmetric capabilities: `arboard`
+//! and the temp-file store can read and write, while OSC 52 is strictly
+//! write-only (terminals do not reliably answer clipboard read queries).
+//! [`Clipboard`] therefore orchestrates them as a **fixed, explicit
+//! pipeline**, not a uniform backend registry:
+//!
+//! - `set()` is an ordered fan-out — temp store, then `arboard`, then
+//!   **OSC 52 last** so the host terminal emulator becomes the final owner of
+//!   the system clipboard (required for reliable X11 ownership).  It is
+//!   infallible: each backend failure is logged and ignored so the remaining
+//!   back-ends still run.
+//! - `get()` is a fallback chain — `arboard`, then the temp store (with
+//!   consume-on-read) — and never consults OSC 52.
+//!
+//! Each step lives in a private helper (`write_temp_store`,
+//! `write_system_clipboard`, `read_temp_store`, `read_system_clipboard`,
+//! `truncate_for_osc52`).  Keeping the ordering structural — rather than
+//! driving it through a loop, iterator, or priority table — makes the
+//! execution invariants impossible to reorder by accident.
+//!
+//! Tests exercise the backends through isolated handles (`with_temp_path`,
+//! `headless_with_temp_path`) and inject the relay target into the PTY reader
+//! loop (`ParserReadLoopArgs.clipboard`), so no test ever touches the real
+//! system clipboard or the user's temp store.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -30,18 +57,6 @@ use base64::Engine;
 use thiserror::Error;
 
 use crate::redirect_stdio::StderrSuppressGuard;
-
-#[derive(Debug, Error)]
-pub enum ClipboardError {
-    #[error("clipboard backend error: {0}")]
-    Backend(#[from] arboard::Error),
-
-    #[error("I/O error writing OSC 52 sequence: {0}")]
-    Io(#[from] std::io::Error),
-
-    #[error("clipboard backend not available (running remotely?)")]
-    NotAvailable,
-}
 
 /// Default cap on OSC 52 emission payload size (1 MB).  Payloads larger than
 /// this are truncated at a valid UTF-8 char boundary so the host terminal
@@ -60,6 +75,367 @@ const CLIPBOARD_CACHE_FILENAME: &str = "term-wm-clipboard.txt";
 /// Prefix for the per-user subdirectory created under the shared temp dir
 /// on Unix when `$XDG_RUNTIME_DIR` is not available.
 const APP_TEMP_DIR_PREFIX: &str = "term-wm";
+
+/// Length of the OSC 52 header `\x1b]52;` (ESC + ] + "52;").
+const OSC52_HEADER_LEN: usize = 5;
+
+/// Length of the Windows ConPTY-transformed header `←]52;` where
+/// the 0x1b ESC byte is rendered as the Unicode left-arrow U+2190
+/// (3-byte UTF-8 sequence: 0xE2 0x86 0x90) followed by `]52;`.
+const OSC52_HEADER_LEN_WIN: usize = 7;
+
+// (OSC52_ESC_OFFSET = 2 is no longer needed; find_osc52_header returns
+//  the position past the full header including the command.)
+
+/// Length of the clipboard-parameter `c;` following the header.
+const CLIPBOARD_PARAM_LEN: usize = 2;
+
+// (ST_TERMINATOR_LEN = 2 is no longer needed; implicit terminator
+//  detection handles the case via extract_osc52_text.)
+
+/// Maximum bytes to buffer for an in-progress OSC 52 sequence before
+/// giving up (safety valve against malformed / non-terminated sequences).
+const MAX_OSC52_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+
+/// Standard ESC-prefixed header bytes: `\x1b]52;`
+const OSC52_HDR_STD: &[u8] = b"\x1b]52;";
+/// Windows ConPTY header bytes: `←]52;` (ESC rendered as left-arrow)
+const OSC52_HDR_WIN: &[u8] = "←]52;".as_bytes();
+
+#[derive(Debug, Error)]
+pub enum ClipboardError {
+    #[error("clipboard backend error: {0}")]
+    Backend(#[from] arboard::Error),
+
+    #[error("I/O error writing OSC 52 sequence: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("clipboard backend not available (running remotely?)")]
+    NotAvailable,
+}
+
+/// Runtime configuration for the clipboard subsystem.
+///
+/// Passed to [`Clipboard::with_config`]; [`Clipboard::new`] uses
+/// [`ClipboardConfig::default`].  `#[non_exhaustive]` so new fields can be
+/// added without breaking external callers (construct with
+/// `..ClipboardConfig::default()`).
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ClipboardConfig {
+    /// Resolved file path for the headless single-use temp-file store
+    /// fallback (see `default_temp_path` for the resolution rules).
+    pub cache_path: PathBuf,
+    /// Maximum payload byte limit for OSC 52 emission; larger payloads are
+    /// truncated at a UTF-8 char boundary.  Default 1 MB
+    /// ([`DEFAULT_MAX_OSC52_BYTES`]).
+    pub osc52_limit: usize,
+}
+
+impl Default for ClipboardConfig {
+    fn default() -> Self {
+        Self {
+            cache_path: default_temp_path(),
+            osc52_limit: DEFAULT_MAX_OSC52_BYTES,
+        }
+    }
+}
+
+/// A persistent clipboard handle backed by `arboard` (optional), OSC 52,
+/// and a temp-file store (optional).
+///
+/// It is a **static orchestrator** over those three backends: `set()` fans
+/// out to each in a fixed order and `get()` follows an explicit fallback
+/// chain, with each step delegated to a private helper.  See the module docs
+/// for the design rationale (and why this deliberately avoids a trait-based
+/// backend registry).
+///
+/// Holding a long-lived [`arboard::Clipboard`] instance avoids the macOS
+/// problem where a short-lived connection is torn down before the pasteboard
+/// server finishes processing the write.
+///
+/// When running over SSH the arboard handle will be `None`; `set()` still
+/// works via OSC 52 emitted to stdout, and the temp-file store (enabled
+/// only in that headless case) lets `get()` round-trip copy→paste.
+pub struct Clipboard {
+    arboard: Option<arboard::Clipboard>,
+    /// Whether the temp-file backing store is active.  Enabled at
+    /// construction when `arboard` is unavailable (headless / SSH), so
+    /// clipboard text is only persisted to disk when there is no real
+    /// system clipboard to write to.  Stored separately (rather than
+    /// recomputed from `arboard`) so tests can exercise both modes without
+    /// a display.
+    temp_store_enabled: bool,
+    /// Resolved path of the temp-file backing store, determined once at
+    /// construction (see [`Clipboard::new`]).  Tests inject an isolated
+    /// path via [`Clipboard::with_temp_path`] to avoid the shared store.
+    temp_path: PathBuf,
+    /// Maximum size of the text emitted over OSC 52, in bytes.  Payloads
+    /// above this cap are truncated at a UTF-8 char boundary; the temp-file
+    /// store and arboard always receive the full text.
+    osc52_limit: usize,
+    /// Captured OSC 52 output — only present in test builds so that tests
+    /// can verify the OSC 52 path was exercised alongside the arboard path.
+    #[cfg(test)]
+    pub osc52_output: Vec<u8>,
+}
+
+impl Default for Clipboard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clipboard {
+    /// Create a new clipboard handle with default configuration.  Always
+    /// succeeds.
+    ///
+    /// The arboard backend is initialised when a local display is available;
+    /// when running remotely (SSH, no display) it is silently absent and
+    /// only the OSC 52 fallback will be available.
+    pub fn new() -> Self {
+        Self::with_config(ClipboardConfig::default())
+    }
+
+    /// Create a clipboard handle using `path` as the temp-file backing
+    /// store and the default OSC 52 cap.  Resolution of the default path is
+    /// skipped; tests use this to inject an isolated path into a throwaway
+    /// temp location.
+    pub fn with_temp_path(path: PathBuf) -> Self {
+        Self::with_config(ClipboardConfig {
+            cache_path: path,
+            ..ClipboardConfig::default()
+        })
+    }
+
+    /// Create a clipboard handle from a [`ClipboardConfig`].
+    ///
+    /// The temp-file backing store is active only when no system clipboard
+    /// (arboard) is available (headless / SSH), so clipboard text is never
+    /// persisted to disk during a normal local session.  The OSC 52 cap is
+    /// applied only to OSC 52 emission: payloads larger than `osc52_limit`
+    /// are truncated at a valid UTF-8 char boundary so the host terminal
+    /// still receives output up to the cap; the temp-file store and arboard
+    /// always receive the full, untruncated text.
+    pub fn with_config(config: ClipboardConfig) -> Self {
+        let arboard = arboard::Clipboard::new().ok();
+        let temp_store_enabled = arboard.is_none();
+        tracing::debug!(
+            "clipboard: backend arboard={}, temp store={}, store path={}",
+            if arboard.is_some() {
+                "available"
+            } else {
+                "unavailable"
+            },
+            if temp_store_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            config.cache_path.display()
+        );
+        Self {
+            arboard,
+            temp_store_enabled,
+            temp_path: config.cache_path,
+            osc52_limit: config.osc52_limit,
+            #[cfg(test)]
+            osc52_output: Vec::new(),
+        }
+    }
+
+    /// Create a clipboard handle that is forced into headless mode (no
+    /// arboard, temp-file store enabled) and uses `path` as the backing store.
+    ///
+    /// Test-only seam: lets sibling modules (e.g. the PTY reader loop tests)
+    /// exercise the headless temp-store and OSC 52 paths deterministically on
+    /// any machine, regardless of whether a display server is present, without
+    /// exposing the internal backend fields.
+    #[cfg(test)]
+    pub(crate) fn headless_with_temp_path(path: PathBuf) -> Self {
+        Self {
+            arboard: None,
+            temp_store_enabled: true,
+            temp_path: path,
+            osc52_limit: DEFAULT_MAX_OSC52_BYTES,
+            osc52_output: Vec::new(),
+        }
+    }
+
+    /// Read the clipboard as a `String`.
+    ///
+    /// Prefers `arboard` (the real system clipboard) when available; on
+    /// headless / remote machines it falls back to the temp-file backing
+    /// store written by [`Clipboard::set`], so copy→paste round-trips
+    /// inside term-wm.  Does **not** attempt OSC 52 reads because most
+    /// terminal emulators do not support them.
+    pub fn get(&mut self) -> Result<String, ClipboardError> {
+        match read_system_clipboard(&mut self.arboard) {
+            Ok(Some(text)) => {
+                return Ok(text);
+            }
+            Ok(None) if !self.temp_store_enabled => {
+                tracing::debug!("clipboard: get no backends available");
+                return Err(ClipboardError::NotAvailable);
+            }
+            Ok(None) => {}
+            Err(e) if !self.temp_store_enabled => {
+                tracing::debug!("clipboard: get via arboard failed ({e}); temp store inactive");
+                return Err(e);
+            }
+            Err(_) => {
+                tracing::debug!("clipboard: get via arboard failed; falling back to temp store");
+            }
+        }
+        // arboard absent or errored with the temp store active: fall back to
+        // the temp-file backing store.
+        read_temp_store(&self.temp_path, self.temp_store_enabled)
+            .ok_or(ClipboardError::NotAvailable)
+    }
+
+    /// Set the system clipboard to `text`.
+    ///
+    /// Best-effort fan-out to every active backend; failures are logged and
+    /// ignored so the remaining back-ends still run.  The temp-file store is
+    /// only written when arboard is unavailable (headless / SSH):
+    ///
+    /// 1. **Temp file** — when there is no system clipboard (headless /
+    ///    remote), a local copy so `get()` can round-trip copy→paste.
+    ///    Written **first** so an internal paste is guaranteed even if a
+    ///    later backend fails.
+    /// 2. `arboard` — writes to the local system clipboard directly.
+    /// 3. **OSC 52** — writes to the host terminal's clipboard via the
+    ///    escape sequence, and is emitted **last** so the host terminal
+    ///    emulator becomes the final owner of the system clipboard.  This
+    ///    ensures copy works when embedded in remote/embedded terminals
+    ///    (Zed, tmux, SSH), and on X11 it supersedes arboard's in-process
+    ///    selection thread, whose clipboard ownership is known to be
+    ///    unreliable (pastes can silently serve stale data).  The terminal
+    ///    emulator then answers paste requests directly.  Oversized
+    ///    payloads are truncated at a valid UTF-8 char boundary to the OSC 52
+    ///    emission cap (default [`DEFAULT_MAX_OSC52_BYTES`], settable via
+    ///    [`Clipboard::with_config`]), so the host still receives output up
+    ///    to the cap; the temp-file store and arboard always receive the full
+    ///    untruncated text.
+    pub fn set(&mut self, text: &str) {
+        write_temp_store(&self.temp_path, self.temp_store_enabled, text);
+        write_system_clipboard(&mut self.arboard, text);
+
+        // Emit OSC 52 for the host terminal LAST.  When the host terminal
+        // emulator supports OSC 52 (VTE, Alacritty, WezTerm, …) it responds
+        // by taking over the system clipboard, making it the final owner —
+        // which on X11 is far more reliable than arboard's in-process
+        // selection thread for answering paste requests.  Truncate at a
+        // valid UTF-8 char boundary so oversized payloads still reach the
+        // host up to the cap without corrupting multibyte characters.
+        let osc52_text = truncate_for_osc52(text, self.osc52_limit);
+        #[cfg(not(test))]
+        if let Err(e) = set_via_osc52_with_writer(osc52_text, &mut std::io::stdout().lock()) {
+            tracing::debug!("clipboard: set OSC 52 to stdout failed ({e})");
+        }
+
+        // In tests, capture to osc52_output instead of stdout.
+        #[cfg(test)]
+        {
+            let mut buf = Vec::new();
+            let _ = set_via_osc52_with_writer(osc52_text, &mut buf);
+            self.osc52_output = buf;
+        }
+    }
+}
+
+/// Best-effort write to the headless temp-file backing store.
+///
+/// Only active when `enabled` (no system clipboard available, e.g. over SSH),
+/// so clipboard text is never persisted to disk during a normal local session.
+fn write_temp_store(path: &Path, enabled: bool, text: &str) {
+    if enabled && let Err(e) = write_clipboard_temp(path, text) {
+        tracing::debug!(
+            "clipboard: set temp store write failed at {} ({e})",
+            path.display()
+        );
+    }
+}
+
+/// Best-effort write to the local system clipboard via `arboard`.
+///
+/// On X11 this claims the CLIPBOARD selection, but arboard hosts the data in
+/// its own background thread, which can silently drop or serve stale data.
+/// macOS AppKit/NSPasteboard writes debug spam to stderr when setting the
+/// clipboard — suppressed by [`StderrSuppressGuard`].
+fn write_system_clipboard(clipboard: &mut Option<arboard::Clipboard>, text: &str) {
+    let Some(cb) = clipboard.as_mut() else {
+        tracing::debug!("clipboard: set arboard unavailable; temp store + OSC 52 only");
+        return;
+    };
+    let _guard = StderrSuppressGuard::new();
+    match cb.set_text(text.to_owned()) {
+        Ok(()) => tracing::debug!("clipboard: set wrote via arboard"),
+        Err(e) => tracing::debug!("clipboard: set via arboard failed ({e})"),
+    }
+}
+
+/// Best-effort read from the local system clipboard via `arboard`.
+///
+/// `Ok(None)` when there is no system clipboard backend (headless / SSH); an
+/// `Err` propagates an arboard read failure so the caller can decide whether
+/// to fall back to the temp store.
+fn read_system_clipboard(
+    clipboard: &mut Option<arboard::Clipboard>,
+) -> Result<Option<String>, ClipboardError> {
+    let Some(cb) = clipboard.as_mut() else {
+        return Ok(None);
+    };
+    match cb.get_text() {
+        Ok(text) => {
+            tracing::debug!("clipboard: get read via arboard ({} bytes)", text.len());
+            Ok(Some(text))
+        }
+        Err(e) => {
+            tracing::debug!("clipboard: get via arboard failed ({e})");
+            Err(e.into())
+        }
+    }
+}
+
+/// Read the headless temp-file backing store, consuming it on success.
+///
+/// This is a single-use copy→paste round-trip: the file is removed so
+/// sensitive clipboard text does not persist on disk.  Best-effort.
+fn read_temp_store(path: &Path, enabled: bool) -> Option<String> {
+    if !enabled {
+        return None;
+    }
+    match read_clipboard_temp(path) {
+        Ok(text) => {
+            tracing::debug!(
+                "clipboard: get read via temp store {} ({} bytes)",
+                path.display(),
+                text.len()
+            );
+            if let Err(e) = std::fs::remove_file(path) {
+                tracing::debug!(
+                    "clipboard: get temp store cleanup failed at {} ({e})",
+                    path.display()
+                );
+            }
+            Some(text)
+        }
+        Err(_) => {
+            tracing::debug!(
+                "clipboard: get temp store unavailable at {}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+/// Truncate `text` to `limit` bytes at a valid UTF-8 char boundary so OSC 52
+/// emission stays within the cap without corrupting multibyte characters.
+fn truncate_for_osc52(text: &str, limit: usize) -> &str {
+    &text[..text.floor_char_boundary(limit)]
+}
 
 /// Resolve the default path of the temp-file clipboard store.
 ///
@@ -257,261 +633,6 @@ pub fn set_via_osc52_with_writer(text: &str, writer: &mut dyn Write) -> Result<(
     writer.flush()?;
     Ok(())
 }
-
-/// A persistent clipboard handle backed by `arboard` (optional), OSC 52,
-/// and a temp-file store (optional).
-///
-/// Holding a long-lived [`arboard::Clipboard`] instance avoids the macOS
-/// problem where a short-lived connection is torn down before the pasteboard
-/// server finishes processing the write.
-///
-/// When running over SSH the arboard handle will be `None`; `set()` still
-/// works via OSC 52 emitted to stdout, and the temp-file store (enabled
-/// only in that headless case) lets `get()` round-trip copy→paste.
-pub struct Clipboard {
-    arboard: Option<arboard::Clipboard>,
-    /// Whether the temp-file backing store is active.  Enabled at
-    /// construction when `arboard` is unavailable (headless / SSH), so
-    /// clipboard text is only persisted to disk when there is no real
-    /// system clipboard to write to.  Stored separately (rather than
-    /// recomputed from `arboard`) so tests can exercise both modes without
-    /// a display.
-    temp_store_enabled: bool,
-    /// Resolved path of the temp-file backing store, determined once at
-    /// construction (see [`Clipboard::new`]).  Tests inject an isolated
-    /// path via [`Clipboard::with_temp_path`] to avoid the shared store.
-    temp_path: PathBuf,
-    /// Maximum size of the text emitted over OSC 52, in bytes.  Payloads
-    /// above this cap are truncated at a UTF-8 char boundary; the temp-file
-    /// store and arboard always receive the full text.
-    osc52_limit: usize,
-    /// Captured OSC 52 output — only present in test builds so that tests
-    /// can verify the OSC 52 path was exercised alongside the arboard path.
-    #[cfg(test)]
-    pub osc52_output: Vec<u8>,
-}
-
-impl Default for Clipboard {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Clipboard {
-    /// Create a new clipboard handle.  Always succeeds.
-    ///
-    /// The arboard backend is initialised when a local display is available;
-    /// when running remotely (SSH, no display) it is silently absent and
-    /// only the OSC 52 fallback will be available.  The temp-file backing
-    /// store path is resolved once here from the environment.
-    pub fn new() -> Self {
-        Self::with_options(default_temp_path(), DEFAULT_MAX_OSC52_BYTES)
-    }
-
-    /// Create a clipboard handle using `path` as the temp-file backing
-    /// store and the default OSC 52 cap.  Resolution of the default path is
-    /// skipped; tests use this to inject an isolated path into a throwaway
-    /// temp location.
-    pub fn with_temp_path(path: PathBuf) -> Self {
-        Self::with_options(path, DEFAULT_MAX_OSC52_BYTES)
-    }
-
-    /// Create a clipboard handle using `cache_path` as the temp-file backing
-    /// store and `osc52_limit` as the OSC 52 emission cap (in bytes).
-    ///
-    /// The cap is applied only to OSC 52 emission: payloads larger than
-    /// `osc52_limit` are truncated at a valid UTF-8 char boundary so the
-    /// host terminal still receives output up to the cap.  The temp-file
-    /// store and arboard always receive the full, untruncated text.
-    pub fn with_options(cache_path: PathBuf, osc52_limit: usize) -> Self {
-        let arboard = arboard::Clipboard::new().ok();
-        let temp_store_enabled = arboard.is_none();
-        tracing::debug!(
-            "clipboard: backend arboard={}, temp store={}, store path={}",
-            if arboard.is_some() {
-                "available"
-            } else {
-                "unavailable"
-            },
-            if temp_store_enabled {
-                "enabled"
-            } else {
-                "disabled"
-            },
-            cache_path.display()
-        );
-        Self {
-            arboard,
-            temp_store_enabled,
-            temp_path: cache_path,
-            osc52_limit,
-            #[cfg(test)]
-            osc52_output: Vec::new(),
-        }
-    }
-
-    /// Read the clipboard as a `String`.
-    ///
-    /// Prefers `arboard` (the real system clipboard) when available; on
-    /// headless / remote machines it falls back to the temp-file backing
-    /// store written by [`Clipboard::set`], so copy→paste round-trips
-    /// inside term-wm.  Does **not** attempt OSC 52 reads because most
-    /// terminal emulators do not support them.
-    pub fn get(&mut self) -> Result<String, ClipboardError> {
-        if let Some(cb) = self.arboard.as_mut() {
-            match cb.get_text() {
-                Ok(text) => {
-                    tracing::debug!("clipboard: get read via arboard ({} bytes)", text.len());
-                    return Ok(text);
-                }
-                Err(e) if !self.temp_store_enabled => {
-                    tracing::debug!("clipboard: get via arboard failed ({e}); temp store inactive");
-                    return Err(e.into());
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        "clipboard: get via arboard failed ({e}); falling back to temp store"
-                    );
-                }
-            }
-        } else if !self.temp_store_enabled {
-            tracing::debug!("clipboard: get no backends available");
-            return Err(ClipboardError::NotAvailable);
-        }
-        // arboard absent or errored with the temp store active: fall back to
-        // the temp-file backing store.
-        match read_clipboard_temp(&self.temp_path) {
-            Ok(text) => {
-                tracing::debug!(
-                    "clipboard: get read via temp store {} ({} bytes)",
-                    self.temp_path.display(),
-                    text.len()
-                );
-                // Consume the store: this is a single-use copy→paste round-trip,
-                // so remove the file so sensitive clipboard text does not persist
-                // on disk.  Best-effort.
-                if let Err(e) = std::fs::remove_file(&self.temp_path) {
-                    tracing::debug!(
-                        "clipboard: get temp store cleanup failed at {} ({e})",
-                        self.temp_path.display()
-                    );
-                }
-                Ok(text)
-            }
-            Err(_) => {
-                tracing::debug!(
-                    "clipboard: get temp store unavailable at {}",
-                    self.temp_path.display()
-                );
-                Err(ClipboardError::NotAvailable)
-            }
-        }
-    }
-
-    /// Set the system clipboard to `text`.
-    ///
-    /// Runs all back-ends; the temp-file store is only written when arboard
-    /// is unavailable (headless / SSH):
-    ///
-    /// 1. **Temp file** — when there is no system clipboard (headless /
-    ///    remote), a local copy so `get()` can round-trip copy→paste.
-    ///    Written **first** so an internal paste is guaranteed even if a
-    ///    later backend fails.
-    /// 2. `arboard` — writes to the local system clipboard directly.
-    /// 3. **OSC 52** — writes to the host terminal's clipboard via the
-    ///    escape sequence, and is emitted **last** so the host terminal
-    ///    emulator becomes the final owner of the system clipboard.  This
-    ///    ensures copy works when embedded in remote/embedded terminals
-    ///    (Zed, tmux, SSH), and on X11 it supersedes arboard's in-process
-    ///    selection thread, whose clipboard ownership is known to be
-    ///    unreliable (pastes can silently serve stale data).  The terminal
-    ///    emulator then answers paste requests directly.  Oversized
-    ///    payloads are truncated at a valid UTF-8 char boundary to the OSC 52
-    ///    emission cap (default [`DEFAULT_MAX_OSC52_BYTES`], settable via
-    ///    [`Clipboard::with_options`]), so the host still receives output up
-    ///    to the cap; the temp-file store and arboard always receive the full
-    ///    untruncated text.
-    ///
-    /// Errors from any path are silently ignored — at least one of
-    /// the back-ends is expected to fail depending on the environment.
-    pub fn set(&mut self, text: &str) -> Result<(), ClipboardError> {
-        // Persist to the temp-file backing store only when there is no real
-        // system clipboard to write to (headless / SSH).  This keeps
-        // clipboard text off disk in normal local sessions.  Best-effort.
-        if self.temp_store_enabled
-            && let Err(e) = write_clipboard_temp(&self.temp_path, text)
-        {
-            tracing::debug!(
-                "clipboard: set temp store write failed at {} ({e})",
-                self.temp_path.display()
-            );
-        }
-
-        // Write via arboard for the local case.  On X11 this claims the
-        // CLIPBOARD selection, but arboard hosts the data in its own
-        // background thread, which can silently drop or serve stale data.
-        // macOS AppKit/NSPasteboard writes debug spam to stderr when
-        // setting the clipboard — suppress it to prevent terminal junk.
-        if let Some(cb) = &mut self.arboard {
-            let _guard = StderrSuppressGuard::new();
-            match cb.set_text(text.to_owned()) {
-                Ok(()) => tracing::debug!("clipboard: set wrote via arboard"),
-                Err(e) => tracing::debug!("clipboard: set via arboard failed ({e})"),
-            }
-        } else {
-            tracing::debug!("clipboard: set arboard unavailable; temp store + OSC 52 only");
-        }
-
-        // Emit OSC 52 for the host terminal LAST.  When the host terminal
-        // emulator supports OSC 52 (VTE, Alacritty, WezTerm, …) it responds
-        // by taking over the system clipboard, making it the final owner —
-        // which on X11 is far more reliable than arboard's in-process
-        // selection thread for answering paste requests.  Truncate at a
-        // valid UTF-8 char boundary so oversized payloads still reach the
-        // host up to the cap without corrupting multibyte characters.
-        let osc52_text = &text[..text.floor_char_boundary(self.osc52_limit)];
-        #[cfg(not(test))]
-        if let Err(e) = set_via_osc52_with_writer(osc52_text, &mut std::io::stdout().lock()) {
-            tracing::debug!("clipboard: set OSC 52 to stdout failed ({e})");
-        }
-
-        // In tests, capture to osc52_output instead of stdout.
-        #[cfg(test)]
-        {
-            let mut buf = Vec::new();
-            let _ = set_via_osc52_with_writer(osc52_text, &mut buf);
-            self.osc52_output = buf;
-        }
-
-        Ok(())
-    }
-}
-
-/// Length of the OSC 52 header `\x1b]52;` (ESC + ] + "52;").
-const OSC52_HEADER_LEN: usize = 5;
-
-/// Length of the Windows ConPTY-transformed header `←]52;` where
-/// the 0x1b ESC byte is rendered as the Unicode left-arrow U+2190
-/// (3-byte UTF-8 sequence: 0xE2 0x86 0x90) followed by `]52;`.
-const OSC52_HEADER_LEN_WIN: usize = 7;
-
-// (OSC52_ESC_OFFSET = 2 is no longer needed; find_osc52_header returns
-//  the position past the full header including the command.)
-
-/// Length of the clipboard-parameter `c;` following the header.
-const CLIPBOARD_PARAM_LEN: usize = 2;
-
-// (ST_TERMINATOR_LEN = 2 is no longer needed; implicit terminator
-//  detection handles the case via extract_osc52_text.)
-
-/// Maximum bytes to buffer for an in-progress OSC 52 sequence before
-/// giving up (safety valve against malformed / non-terminated sequences).
-const MAX_OSC52_BUFFER_BYTES: usize = 4 * 1024 * 1024;
-
-/// Standard ESC-prefixed header bytes: `\x1b]52;`
-const OSC52_HDR_STD: &[u8] = b"\x1b]52;";
-/// Windows ConPTY header bytes: `←]52;` (ESC rendered as left-arrow)
-const OSC52_HDR_WIN: &[u8] = "←]52;".as_bytes();
 
 /// Find the OSC 52 header in `data`, returning the offset past the
 /// header (ready for optional `c;` clipboard-param skip) and a flag
@@ -748,7 +869,7 @@ mod tests {
         cb.arboard = None;
         cb.temp_store_enabled = true;
 
-        cb.set("clipboard text").unwrap();
+        cb.set("clipboard text");
         assert!(path.exists(), "set() must persist to the temp store");
         assert_eq!(cb.get().unwrap(), "clipboard text");
         assert!(
@@ -763,6 +884,36 @@ mod tests {
         let path = store_path(&dir);
         write_clipboard_temp(&path, "helper text").unwrap();
         assert_eq!(read_clipboard_temp(&path).unwrap(), "helper text");
+    }
+
+    #[test]
+    fn clipboard_error_display_messages() {
+        assert_eq!(
+            ClipboardError::NotAvailable.to_string(),
+            "clipboard backend not available (running remotely?)"
+        );
+        let io = ClipboardError::Io(std::io::Error::other("boom"));
+        assert_eq!(io.to_string(), "I/O error writing OSC 52 sequence: boom");
+        let backend = ClipboardError::Backend(arboard::Error::ContentNotAvailable);
+        assert_eq!(
+            backend.to_string(),
+            "clipboard backend error: The clipboard contents were not available in the requested format or the clipboard is empty."
+        );
+    }
+
+    #[test]
+    fn clipboard_error_from_conversions() {
+        let io: ClipboardError = std::io::Error::other("x").into();
+        assert!(matches!(io, ClipboardError::Io(_)));
+        let arboard_err: ClipboardError = arboard::Error::ContentNotAvailable.into();
+        assert!(matches!(arboard_err, ClipboardError::Backend(_)));
+    }
+
+    #[test]
+    fn clipboard_new_uses_default_path_and_default_limit() {
+        let cb = Clipboard::new();
+        assert_eq!(cb.temp_path, default_temp_path());
+        assert_eq!(cb.osc52_limit, DEFAULT_MAX_OSC52_BYTES);
     }
 
     #[test]
@@ -781,7 +932,7 @@ mod tests {
         cb.arboard = None;
         cb.temp_store_enabled = true;
 
-        cb.set("héllo 日本語 ✅").unwrap();
+        cb.set("héllo 日本語 ✅");
         assert_eq!(cb.get().unwrap(), "héllo 日本語 ✅");
     }
 
@@ -814,7 +965,7 @@ mod tests {
         cb.temp_store_enabled = false;
         cb.arboard = None;
 
-        cb.set("sensitive text").unwrap();
+        cb.set("sensitive text");
         assert!(
             !path.exists(),
             "temp store must not be written when a system clipboard exists"
@@ -934,7 +1085,7 @@ mod tests {
     fn clipboard_set_emits_osc52() {
         let dir = tempfile::tempdir().unwrap();
         let mut cb = Clipboard::with_temp_path(store_path(&dir));
-        cb.set("hello from test").unwrap();
+        cb.set("hello from test");
 
         assert!(
             !cb.osc52_output.is_empty(),
@@ -1078,14 +1229,17 @@ mod tests {
     #[test]
     fn osc52_emission_truncated_over_limit() {
         let dir = tempfile::tempdir().unwrap();
-        // Force a small OSC 52 cap via with_options.
+        // Force a small OSC 52 cap via with_config.
         let path = store_path(&dir);
-        let mut cb = Clipboard::with_options(path.clone(), 8);
+        let mut cb = Clipboard::with_config(ClipboardConfig {
+            cache_path: path.clone(),
+            osc52_limit: 8,
+        });
         cb.arboard = None;
         cb.temp_store_enabled = true;
 
         let oversized = "this text is longer than the 8-byte cap";
-        cb.set(oversized).unwrap();
+        cb.set(oversized);
 
         // OSC 52 output must be truncated to <= limit bytes at a char boundary.
         let decoded = extract_osc52_text(&cb.osc52_output).unwrap();
@@ -1110,14 +1264,17 @@ mod tests {
     #[test]
     fn osc52_truncation_respects_utf8_boundary() {
         let dir = tempfile::tempdir().unwrap();
-        let mut cb = Clipboard::with_options(store_path(&dir), 5);
+        let mut cb = Clipboard::with_config(ClipboardConfig {
+            cache_path: store_path(&dir),
+            osc52_limit: 5,
+        });
         cb.arboard = None;
         cb.temp_store_enabled = true;
 
         // "héllo" — 'é' is 2 bytes.  A byte-5 cut would land inside 'é';
         // floor_char_boundary must land at index 4 (after 'h' + 'é').
         let text = "héllo";
-        cb.set(text).unwrap();
+        cb.set(text);
 
         let decoded = extract_osc52_text(&cb.osc52_output).unwrap();
         assert_eq!(decoded, "héll", "must truncate at a valid UTF-8 boundary");
@@ -1238,5 +1395,33 @@ mod tests {
         // Next push with no terminator should hit the safety valve.
         assert!(ex.push(b"", &[]).is_none());
         assert!(!ex.is_active());
+    }
+
+    #[test]
+    fn extractor_new_starts_inactive() {
+        let ex = Osc52Extractor::new();
+        assert!(!ex.is_active());
+    }
+
+    #[test]
+    fn extractor_push_empty_data_no_activation() {
+        let mut ex = Osc52Extractor::new();
+        assert!(ex.push(b"", &[]).is_none());
+        assert!(!ex.is_active());
+    }
+
+    #[test]
+    fn extractor_clear_resets_in_progress() {
+        let seq = format_osc52_bytes("hello");
+        let mid = seq.len() / 2;
+        let mut ex = Osc52Extractor::new();
+        // Header (and partial payload) is buffered without a terminator yet.
+        assert!(ex.push(&seq[..mid], &[]).is_none());
+        assert!(ex.is_active());
+        ex.clear();
+        assert!(!ex.is_active());
+        // A full sequence fed after clear still extracts.
+        let result = ex.push(&seq, &[]);
+        assert_eq!(result.as_deref(), Some("hello"));
     }
 }

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -598,6 +598,11 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
     let mut vte_parser = vte::Parser::new();
     let tracker_for_adapter = std::sync::Arc::clone(&tracker);
     let mut tracker_adapter = PtyPerformAdapter::new(tracker_for_adapter);
+    // One clipboard handle for the whole reader lifetime: re-initialising
+    // arboard per OSC 52 sequence would repeat the display-server handshake
+    // on every copy event.  Each extracted sequence is relayed synchronously
+    // (no debounce) so the final payload of a burst is never dropped.
+    let mut clipboard = Clipboard::new();
     const IO_BURST_BUDGET: usize = 256 * 1024; // 256 KB
     loop {
         match reader.read(&mut buf) {
@@ -667,9 +672,10 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                     *guard = Some(title);
                 }
                 // Intercept OSC 52 clipboard sequences (cross-chunk buffering).
+                // Relay each extracted sequence synchronously via the hoisted
+                // handle — no debounce, so the tail payload is never dropped.
                 if let Some(text) = osc52.push(&buf[..n], &prev_tail) {
-                    let mut cb = Clipboard::new();
-                    let _ = cb.set(&text);
+                    let _ = clipboard.set(&text);
                     if let Some(ref capture) = osc52_text {
                         *capture.lock().unwrap() = Some(text);
                     }

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -188,6 +188,7 @@ impl Pty {
                 status_cb: reader_status_cb,
                 scrollback_len,
                 osc52_text: None,
+                clipboard: None,
                 exited_emitted: reader_exited_emitted,
                 tracker: reader_tracker,
             })
@@ -570,6 +571,11 @@ struct ParserReadLoopArgs {
     /// Test-only hook: when `Some`, the extracted OSC 52 text is written here
     /// in addition to the real clipboard, so tests can assert the value.
     osc52_text: Option<Arc<Mutex<Option<String>>>>,
+    /// Clipboard to relay extracted OSC 52 sequences through. `None` in
+    /// production (the loop constructs a default handle); tests inject an
+    /// isolated, headless [`Clipboard`] so the relay can be exercised without
+    /// touching the real system clipboard or temp store.
+    clipboard: Option<Clipboard>,
     /// Application state tracker — shared via Arc with Pty.
     tracker: std::sync::Arc<crate::PtyStateTracker>,
 }
@@ -588,6 +594,7 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
         status_cb,
         scrollback_len: _scrollback_len,
         osc52_text,
+        clipboard,
         exited_emitted,
         tracker,
     } = args;
@@ -602,7 +609,7 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
     // arboard per OSC 52 sequence would repeat the display-server handshake
     // on every copy event.  Each extracted sequence is relayed synchronously
     // (no debounce) so the final payload of a burst is never dropped.
-    let mut clipboard = Clipboard::new();
+    let mut clipboard = clipboard.unwrap_or_else(Clipboard::new);
     const IO_BURST_BUDGET: usize = 256 * 1024; // 256 KB
     loop {
         match reader.read(&mut buf) {
@@ -675,7 +682,7 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 // Relay each extracted sequence synchronously via the hoisted
                 // handle — no debounce, so the tail payload is never dropped.
                 if let Some(text) = osc52.push(&buf[..n], &prev_tail) {
-                    let _ = clipboard.set(&text);
+                    clipboard.set(&text);
                     if let Some(ref capture) = osc52_text {
                         *capture.lock().unwrap() = Some(text);
                     }
@@ -988,6 +995,7 @@ mod tests {
             scrollback_len: 0,
             exited_emitted: Arc::new(AtomicBool::new(false)),
             osc52_text: None,
+            clipboard: None,
             tracker: std::sync::Arc::new(crate::PtyStateTracker::new(24)),
         }
     }
@@ -1070,6 +1078,52 @@ mod tests {
         assert!(
             dsr_requested.load(Ordering::Relaxed),
             "DSR in combined data must be detected"
+        );
+    }
+
+    #[test]
+    fn parser_read_loop_relays_osc52_to_isolated_clipboard_and_hook() {
+        let dir = tempfile::tempdir().unwrap();
+        // Nested owner-only subdir mirrors production: the tempdir root is
+        // group/other-writable and would be rejected by
+        // ensure_clipboard_store_dir.
+        let store_dir = dir.path().join("store");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            let mut builder = std::fs::DirBuilder::new();
+            builder.mode(0o700);
+            builder.create(&store_dir).unwrap();
+        }
+        #[cfg(not(unix))]
+        std::fs::create_dir_all(&store_dir).unwrap();
+        let path = store_dir.join("clipboard.txt");
+
+        // Inject a headless clipboard so the relay is deterministic and the
+        // real system clipboard / temp store are never touched.
+        let mut args = make_parser_test_args();
+        args.clipboard = Some(Clipboard::headless_with_temp_path(path.clone()));
+        let captured = Arc::new(Mutex::new(None));
+        args.osc52_text = Some(Arc::clone(&captured));
+        args.reader = Box::new(Cursor::new(crate::clipboard::format_osc52_bytes(
+            "clip via pty",
+        )));
+
+        parser_read_loop(args);
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(
+            captured.as_deref(),
+            Some("clip via pty"),
+            "osc52_text hook must capture the relayed payload"
+        );
+        // A fresh headless handle over the same isolated path must read the
+        // relayed text back, proving set() ran without touching the real store.
+        let mut reader = Clipboard::headless_with_temp_path(path);
+        assert_eq!(
+            reader.get().unwrap(),
+            "clip via pty",
+            "relayed set() must have written the isolated temp store"
         );
     }
 

--- a/crates/term-wm-sys-ui-components/assets/help.md
+++ b/crates/term-wm-sys-ui-components/assets/help.md
@@ -3,7 +3,7 @@
 **Package:** `%PACKAGE%` ([https://crates.io/crates/%PACKAGE%](https://crates.io/crates/%PACKAGE%))  
 **Version:** `%VERSION%` (%PLATFORM%)
 
-Submit bug reports: %REPOSITORY%/issues/new
+Submit bug reports to %REPOSITORY%/issues/new
 
 Welcome to `%PACKAGE%`! This page is a quick reference for navigating the UI.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use term_wm::io::RenderTarget;
 use term_wm::runner::WindowManagerHost;
 use term_wm::term_wm_app::TermWmApp;
 use term_wm::unified_event_source::{UnifiedEvent, UnifiedEventSource};
-use term_wm::wm_config::WmConfig;
 use term_wm_console::console_render_target::ConsoleRenderTarget;
 use term_wm_core::components::Component;
 use term_wm_core::events::Event;
@@ -36,9 +35,6 @@ struct Cli {
     /// Command(s) to run.
     #[arg(value_name = "CMD", num_args = 0..)]
     cmds: Vec<String>,
-    /// Run embedded as a library component.
-    #[arg(long)]
-    embedded: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -61,7 +57,7 @@ fn main() -> io::Result<()> {
 
     let mut event_source = UnifiedEventSource::new()?;
     let pty_wakeup_tx = event_source.pty_wakeup_tx();
-    let mut app = App::new_with(cli.cmds, total, cli.embedded, pty_wakeup_tx)?;
+    let mut app = App::new_with(cli.cmds, total, pty_wakeup_tx)?;
 
     let mut output = ConsoleRenderTarget::new()?;
     output.enter()?;
@@ -82,7 +78,6 @@ impl App {
     fn new_with(
         commands: Vec<String>,
         num_windows: usize,
-        embedded: bool,
         pty_wakeup_tx: Sender<UnifiedEvent>,
     ) -> io::Result<Self> {
         let app_ctx = Arc::new(
@@ -97,31 +92,23 @@ impl App {
         let app_name = app_ctx.app_name.clone();
         let app_version = app_ctx.app_version.clone();
 
-        let wm = if embedded {
-            AppBuilder::<LayerComponent>::bare()
-                .config(WmConfig::minimal())
-                .app_ctx(Arc::clone(&app_ctx))
-                .build()
-                .expect("embedded build")
-        } else {
-            AppBuilder::<LayerComponent>::bare()
-                .app_ctx(Arc::clone(&app_ctx))
-                .top_panel(LayerComponent::TopPanel(
-                    term_wm_sys_ui_components::WmTopPanelComponent::new(&app_name),
-                ))
-                .bottom_panel(LayerComponent::BottomPanel(
-                    term_wm_sys_ui_components::WmBottomPanelComponent::new(
-                        &app_name,
-                        &app_version,
-                        hostname,
-                    ),
-                ))
-                .fab(LayerComponent::Fab(
-                    term_wm_sys_ui_components::WmFabComponent::new(),
-                ))
-                .build()
-                .expect("standalone build")
-        };
+        let wm = AppBuilder::<LayerComponent>::bare()
+            .app_ctx(Arc::clone(&app_ctx))
+            .top_panel(LayerComponent::TopPanel(
+                term_wm_sys_ui_components::WmTopPanelComponent::new(&app_name),
+            ))
+            .bottom_panel(LayerComponent::BottomPanel(
+                term_wm_sys_ui_components::WmBottomPanelComponent::new(
+                    &app_name,
+                    &app_version,
+                    hostname,
+                ),
+            ))
+            .fab(LayerComponent::Fab(
+                term_wm_sys_ui_components::WmFabComponent::new(),
+            ))
+            .build()
+            .expect("standalone build");
 
         let inner = TermWmApp::from_wm(wm, pty_wakeup_tx.clone());
         let mut app = Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,13 @@ const PTY_SCROLLBACK_LEN: usize = 2000;
     long_about = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"), ": ", env!("CARGO_PKG_DESCRIPTION")),
 )]
 struct Cli {
+    /// Number of windows to open.
     #[arg(short = 'n', long = "count")]
     count: Option<usize>,
+    /// Command(s) to run.
     #[arg(value_name = "CMD", num_args = 0..)]
     cmds: Vec<String>,
+    /// Run embedded as a library component.
     #[arg(long)]
     embedded: bool,
 }

--- a/tests/common/session.rs
+++ b/tests/common/session.rs
@@ -19,14 +19,10 @@ pub fn test_channel(name: &str) -> ChannelName {
 pub async fn spawn_server_for_channel(
     channel: &ChannelName,
     cmd: Vec<String>,
-    cols: u16,
-    rows: u16,
 ) -> Arc<RpcIpcClient> {
     let config = SessionServerConfig {
         channel: channel.clone(),
         cmd,
-        cols,
-        rows,
     };
     tokio::spawn(async move { run_server(config).await });
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -87,11 +83,6 @@ pub async fn wait_for_output(
     accumulated
 }
 
-pub async fn spawn_session(
-    channel: &ChannelName,
-    cmd: Vec<String>,
-    cols: u16,
-    rows: u16,
-) -> Arc<RpcIpcClient> {
-    spawn_server_for_channel(channel, cmd, cols, rows).await
+pub async fn spawn_session(channel: &ChannelName, cmd: Vec<String>) -> Arc<RpcIpcClient> {
+    spawn_server_for_channel(channel, cmd).await
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -21,8 +21,6 @@ async fn session_spawn_returns_id() {
     let client = spawn_session(
         &test_channel("test/spawn_returns_id"),
         vec![mock, "echo".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
     let (id, _, _) = Spawn::call(&*client, (None, TEST_COLS, TEST_ROWS))
@@ -37,8 +35,6 @@ async fn session_input_output_roundtrip() {
     let client = spawn_session(
         &test_channel("test/input_output"),
         vec![mock, "echo".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -67,8 +63,6 @@ async fn session_mouse_bytes_forwarded() {
     let client = spawn_session(
         &test_channel("test/mouse_forward"),
         vec![mock, "echo".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -113,8 +107,6 @@ async fn session_mouse_bytes_forwarded() {
     let client = spawn_session(
         &test_channel("test/mouse_forward"),
         vec![mock, "capture".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -148,8 +140,6 @@ async fn session_osc52_in_output() {
     let client = spawn_session(
         &test_channel("test/osc52_output"),
         vec![mock, "osc52".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -176,8 +166,6 @@ async fn session_osc52_via_osc52extractor() {
     let client = spawn_session(
         &test_channel("test/osc52_extractor"),
         vec![mock, "osc52".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -234,13 +222,7 @@ async fn session_osc52_via_osc52extractor() {
 #[tokio::test]
 async fn session_resize() {
     let mock = get_mock_bin();
-    let client = spawn_session(
-        &test_channel("test/resize"),
-        vec![mock, "echo".into()],
-        TEST_COLS,
-        TEST_ROWS,
-    )
-    .await;
+    let client = spawn_session(&test_channel("test/resize"), vec![mock, "echo".into()]).await;
 
     let result = ResizePty::call(&*client, (1u64, 120u16, 40u16)).await;
     assert!(result.is_ok(), "Resize should succeed: {:?}", result.err());
@@ -252,8 +234,6 @@ async fn session_list_sessions() {
     let client = spawn_session(
         &test_channel("test/list_sessions"),
         vec![mock, "sleep".into(), "60000".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -268,8 +248,6 @@ async fn session_close_session() {
     let client = spawn_session(
         &test_channel("test/close_session"),
         vec![mock, "sleep".into(), "60000".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -287,8 +265,6 @@ async fn session_child_exit() {
     let client = spawn_session(
         &test_channel("test/child_exit"),
         vec![mock, "exit".into(), "0".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -320,8 +296,6 @@ async fn session_child_exit_before_subscribe() {
     let client = spawn_session(
         &test_channel("test/child_exit_early"),
         vec![mock, "exit".into(), "0".into()],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -358,8 +332,6 @@ async fn session_reconnect() {
     let config = term_session_server::SessionServerConfig {
         channel: channel.clone(),
         cmd: vec![mock, "echo".into()],
-        cols: TEST_COLS,
-        rows: TEST_ROWS,
     };
     tokio::spawn(async move { term_session_server::run_server(config).await });
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -409,8 +381,6 @@ async fn term_bench_runs_to_completion() {
             "-f".into(),
             "10".into(),
         ],
-        TEST_COLS,
-        TEST_ROWS,
     )
     .await;
 
@@ -453,8 +423,6 @@ async fn session_multi_client_pty_constrained_to_smallest() {
     let config = term_session_server::SessionServerConfig {
         channel: channel.clone(),
         cmd: vec![mock, "echo".into()],
-        cols: 120,
-        rows: 40,
     };
     tokio::spawn(async move { term_session_server::run_server(config).await });
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -514,8 +482,6 @@ async fn session_multi_client_disconnect_expands_pty() {
     let config = term_session_server::SessionServerConfig {
         channel: channel.clone(),
         cmd: vec![mock, "echo".into()],
-        cols: 120,
-        rows: 40,
     };
     tokio::spawn(async move { term_session_server::run_server(config).await });
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -581,8 +547,6 @@ async fn session_server_start_stop_cleanly() {
     let config = term_session_server::SessionServerConfig {
         channel: channel.clone(),
         cmd: vec![mock, "echo".into()],
-        cols: 80,
-        rows: 24,
     };
     tokio::spawn(async move { term_session_server::run_server(config).await });
     tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
Clipboard temp-store + OSC 52 relay hardening (term-wm-pty-engine):
- Add Clipboard::with_options(cache_path, osc52_limit) with a 1 MiB DEFAULT_MAX_OSC52_BYTES cap; new() and with_temp_path() delegate to it.
- Reorder set() to temp store -> arboard -> OSC 52 last, and truncate the OSC 52 emission to the cap at a valid UTF-8 char boundary via str::floor_char_boundary. The file cache and arboard always receive the full, untruncated text.
- Remove unlink-on-Drop coupling: the store is session-scoped, not handle-scoped. Cleanup happens via consume-on-read in get() and OS-level temp cleanup (XDG_RUNTIME_DIR tmpfs, OS temp reaping); documented in the module docs.
- Hoist a single Clipboard above the PTY reader loop and relay every extracted OSC 52 sequence synchronously (no debounce), so the final payload of a burst is never dropped and arboard is not re-initialised on every copy event.
- Tests bind explicit isolated tempfile::tempdir() paths; add osc52_emission_truncated_over_limit and osc52_truncation_respects_utf8_boundary. Add tempfile as a pty-engine dev-dependency.

Session server PTY sizing (term-session):
- Drop manual cols/rows from SessionServerConfig, the term-session CLI, ServerSpawnConfig, and the E2E test helpers. The server spawns the PTY at a fallback size and resizes it on demand to the smallest geometry across attached clients; README updated.

Polish:
- Source CLI metadata (name/about/version) from CARGO_PKG_* in term-wm, term-session, and term-bench; add --help doc comments for count/cmds/ embedded; tidy help.md wording and Cargo.toml categories formatting.