### PR TITLE
feat(term-session): Windows Win32 Job Object process-tree containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.5-alpha] - 2026-08-03
+
+### Added
+
+- **Windows Win32 Job Object process-tree containment:** the PTY engine now contains each Windows PTY child in a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` job, so killing a session also kills the background processes it spawned — not just the session's own process. This makes the v0.9.4-alpha containment claim true for processes spawned after startup (see Errata). A known limitation: a process spawned in the brief moment during startup can escape the job; the full fix needs a portable-pty change and is tracked in the code. Windows-gated unit test `spawn_assigns_job_object_containing_child` verifies the behavior.
+- **Behavioral whole-tree-kill proof:** `term-session-mock` gained a `spawn_child <ms>` subcommand that spawns a real grandchild process and reports its PID; integration tests assert that both `KillChannel` and `CloseSession` terminate the grandchild too (nothing re-parents to init), backed by a cross-platform `check_pid` liveness probe.
+- **`term-session-mock` promoted to a workspace crate:** a single canonical `get_mock_bin()` resolver (honors `CARGO_BIN_EXE_term-session-mock`, falls back to the workspace `target/` build locations, and **builds the binary on demand** so tests never silently skip) now serves every test suite, with a dedicated README.
+
+### Changed
+
+- Docs: `term-session` README (session sharing, session nesting, upgrade ordering, scrolling & text selection), `term-session-server` README, `term-session-mock` README, and `docs/COMPATIBILITY.md` refreshed to match the shipped CLI and daemon behavior.
+- Package metadata (description/keywords/categories) updated.
+
+## Errata / Corrections for v0.9.4-alpha
+
+- **Windows process-tree containment (correction):** the v0.9.4-alpha changelog entry "Gateway process supervision" stated that kill paths terminate the whole process tree on Windows via "Win32 Job Object containment". That was inaccurate for the shipped binary: at release time the Windows kill path (`Pty::kill_child`) delegated to portable-pty's `WinChild`, which performs a bare `TerminateProcess` on the **single session leader** — grandchildren were not contained and could be orphaned. Only the Unix process-group path (SIGTERM → exited-checked SIGKILL escalation) actually matched the description.
+  - **Resolution:** the Job Object containment described in that entry is now genuinely implemented: killing a Windows session also kills the processes it spawned, not just its own process. There is a known startup race (see the 0.9.5-alpha entry) where a process spawned in the brief startup moment can escape; the full fix needs a portable-pty change and is tracked in the code. Covered by the Windows-gated test `spawn_assigns_job_object_containing_child`.
+- **`term-session` admin CLI (`--json` / `--socket`):** the v0.9.4-alpha "term-session admin CLI" entry described a `--json` list mode and a `kill <channel> [--socket CONN_ID]` flag. Neither exists in the shipped binary: `list` is plain-text only, and socket detachment is performed by the top-level `kill-client <channel> <CLIENT_ID>` subcommand (the `--socket` form was removed during development in favor of the explicit `kill-client`).
+
 ## [0.9.4-alpha] - 2026-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,13 +3028,14 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "clap",
  "hostname",
  "libc",
  "muxio-tokio-rpc-ipc-client",
  "term-session-client",
+ "term-session-mock",
  "term-session-muxio-service-definitions",
  "term-session-server",
  "tokio",
@@ -3044,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3071,11 +3072,15 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.0.0"
+version = "0.9.5-alpha"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3085,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3104,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3122,6 +3127,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "term-session-client",
+ "term-session-mock",
  "term-session-muxio-service-definitions",
  "term-session-server",
  "term-wm-console",
@@ -3141,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3159,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3181,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3190,41 +3196,43 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
  "ctrlc",
  "libc",
  "portable-pty",
+ "term-session-mock",
  "term-wm-events",
  "thiserror 2.0.19",
  "tracing",
  "vt100",
  "vte",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3240,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3265,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.4-alpha"
+version = "0.9.5-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,21 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.4-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.4-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.4-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.4-alpha" }
-term-wm = { path = ".", version = "0.9.4-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.4-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.4-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.4-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.4-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.4-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.4-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.4-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.4-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.4-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.4-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.5-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.5-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.5-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.5-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.5-alpha" }
+term-wm = { path = ".", version = "0.9.5-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.5-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.5-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.5-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.5-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.5-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.5-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.5-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.5-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.5-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.5-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
@@ -117,6 +118,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_System_IO",
+    "Win32_System_JobObjects",
     "Win32_System_Pipes",
     "Win32_System_Threading",
 ] }
@@ -162,6 +164,7 @@ proptest = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 term-session-client = { path = "crates/term-session-client" }
+term-session-mock = { workspace = true }
 term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions" }
 term-session-server = { path = "crates/term-session-server" }
 term-wm-render = { workspace = true }

--- a/crates/term-session-mock/Cargo.toml
+++ b/crates/term-session-mock/Cargo.toml
@@ -1,9 +1,21 @@
 [package]
 name = "term-session-mock"
-description = "Isolated workspace binary for simulating cross-platform raw virtual terminal streams and ConPTY byte sequences in integration tests."
-keywords = ["terminal", "conpty", "windows", "testing", "simulation"]
-categories = ["emulators", "development-tools", "simulation"]
-version = "0.0.0"
-edition = "2024"
-# Never publish this; only used for testing
-publish = false
+description = "Internal test tooling for term-wm: a mock PTY binary and shared test helpers for cross-platform terminal stream simulation, including Windows ConPTY byte-sequence handling."
+keywords = ["terminal", "pty", "testing", "simulation", "cross-platform"]
+categories = ["development-tools", "emulators", "simulation"]
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lib]
+name = "term_session_mock"
+path = "src/lib.rs"
+
+[dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }

--- a/crates/term-session-mock/README.md
+++ b/crates/term-session-mock/README.md
@@ -1,0 +1,40 @@
+# term-session-mock
+
+Internal test tooling for the [term-wm](https://crates.io/crates/term-wm) workspace. Not intended for direct use.
+
+## What this is
+
+A **deterministic PTY-resident test fixture** — a small, real binary that the session daemon spawns inside a PTY so tests can drive a child process with full determinism. It replaces a real shell/command in tests, removing dependency on shell availability, shell startup timing, and platform-specific command behavior.
+
+It is **not** a "posix mocker". It runs on Linux, macOS, and Windows, and includes explicit Windows ConPTY console-mode handling (raw VT input, VT-processing toggling) so ANSI sequences pass through ConPTY intact.
+
+Every subcommand performs **real** OS behavior — real process spawning, real exit codes, real sleeping, real PIDs, real liveness probing. Nothing is hardcoded to fabricate a passing assertion; the only fixed output is the `osc52` payload, which is the exact byte sequence the OSC 52 encoder is expected to emit.
+
+## Subcommands
+
+| Subcommand | Behavior | Used to verify |
+|---|---|---|
+| `echo` | Unbuffered stdin→stdout passthrough (like `cat`) | PTY I/O round-trip, cross-client output broadcast |
+| `osc52` | Writes a fixed OSC 52 clipboard sequence to stdout, then exits | OSC 52 interception → clipboard relay |
+| `sleep <ms>` | Sleeps for `ms` (default 1000), then exits | Session persistence across clients; timed exits |
+| `exit <code>` | Exits with the given status code (default 0) | Exit-code propagation, session-exit handling |
+| `spawn_child <ms>` | Spawns a **real grandchild** (`sleep <ms>`), prints `GRANDCHILD_PID:<pid>`, then echoes stdin until EOF | Tree-kill containment: the whole process tree dies (process group / Job Object), nothing orphans |
+| `check_pid <pid>` | Exits 0 if the process is alive, non-zero otherwise | Post-kill liveness assertions (tree teardown proof) |
+| `capture` | Echoes stdin back prefixed with `MOUSE_OK:` until it sees `ping` | Mouse/input event forwarding through the session |
+
+## Why a dedicated mock
+
+- **Determinism:** a real shell's startup, prompts, and timing vary; the mock's behavior is fixed and simple.
+- **Cross-platform:** one binary behaves identically (modulo ConPTY console-mode setup) on Unix and Windows.
+- **Tree-kill verification:** `spawn_child` creates an actual second process so tests can assert that killing a session terminates the grandchild — impossible to fake, and the crux of the Unix process-group / Windows Job Object containment guarantees.
+- **No production footprint:** this crate is test-only; nothing in the shipped binaries depends on it.
+
+## Finding the binary
+
+Test suites locate the compiled binary through [`get_mock_bin`](src/lib.rs), which:
+
+1. honors `CARGO_BIN_EXE_term-session-mock` when Cargo provides it (this crate's own integration tests);
+2. otherwise finds the workspace build in `target/debug` or the hashed `target/debug/deps` location;
+3. if neither exists, **runs `cargo build` for this crate on demand** and re-resolves.
+
+The helper never returns a missing path, so tests can never silently skip. If the binary still cannot be located after an on-demand build, it panics — a broken build fails loudly instead of quietly dropping coverage.

--- a/crates/term-session-mock/src/lib.rs
+++ b/crates/term-session-mock/src/lib.rs
@@ -1,0 +1,133 @@
+//! Shared test helpers for the `term-session-mock` binary.
+//!
+//! Every test suite that needs the mock binary (the session server integration
+//! tests, the daemon tests, the PTY engine unit tests) resolves it through the
+//! single canonical [`get_mock_bin`] helper instead of re-implementing
+//! `current_exe()` path-walking in each crate. Keeping the resolution logic in
+//! the mock's own library means there is exactly one place that knows where the
+//! binary lives and how to find it on every platform.
+
+use std::path::PathBuf;
+
+/// Locate (building on demand if necessary) the compiled `term-session-mock`
+/// binary.
+///
+/// Resolution order:
+/// 1. `CARGO_BIN_EXE_term-session-mock`, which Cargo sets when this crate's
+///    *binary* is a dependency (e.g. for this crate's own integration tests).
+/// 2. The plain workspace build location: `target/debug/term-session-mock`
+///    (walking up from the test executable, skipping the `deps` directory).
+/// 3. The hashed dependency build location: `target/debug/deps/term-session-mock-*`.
+/// 4. If none exist, run `cargo build` to produce the binary, then resolve
+///    again.
+///
+/// Never returns a missing path: the binary is built on demand so tests can
+/// never silently skip. Panics if the build fails.
+pub fn get_mock_bin() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_term-session-mock") {
+        return PathBuf::from(path);
+    }
+
+    let resolved = resolve_mock_bin();
+    if let Some(path) = resolved {
+        return path;
+    }
+
+    build_mock_bin();
+
+    match resolve_mock_bin() {
+        Some(path) => path,
+        None => panic!(
+            "term-session-mock binary still missing after `cargo build`; \
+             searched {:?} and {:?}",
+            mock_bin_candidates().0,
+            mock_bin_candidates().1,
+        ),
+    }
+}
+
+/// The two conventional locations for the compiled mock binary.
+fn mock_bin_candidates() -> (PathBuf, PathBuf) {
+    let mut path = std::env::current_exe().expect("test exe path");
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    let plain = path.join(format!("term-session-mock{}", std::env::consts::EXE_SUFFIX));
+    let deps_dir = path.join("deps");
+    (plain, deps_dir)
+}
+
+fn resolve_mock_bin() -> Option<PathBuf> {
+    let (plain, deps_dir) = mock_bin_candidates();
+    if plain.exists() {
+        return Some(plain);
+    }
+
+    let suffix = std::env::consts::EXE_SUFFIX;
+    if let Ok(entries) = std::fs::read_dir(&deps_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with("term-session-mock-") && name.ends_with(suffix) {
+                return Some(entry.path());
+            }
+        }
+    }
+
+    None
+}
+
+/// Invoke `cargo build` for this crate so the binary exists in the target
+/// directory. Uses the crate's own `Cargo.toml` so it works regardless of
+/// which workspace directory the test process happens to run from.
+fn build_mock_bin() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let status = std::process::Command::new(env!("CARGO"))
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .status()
+        .expect("failed to spawn `cargo build` for term-session-mock");
+    if !status.success() {
+        panic!(
+            "`cargo build --manifest-path {}` failed with {status}",
+            manifest.display()
+        );
+    }
+}
+
+// TODO: The following `process_is_alive` utils could be migrated somewhere else.
+// Here's an issue/comment with ideas: https://github.com/jzombie/term-wm/issues/204#issuecomment-5170285844
+
+/// Exit code for `check_pid` when the process is alive.
+pub const CHECK_PID_ALIVE: i32 = 0;
+/// Exit code for `check_pid` when the process is not running.
+pub const CHECK_PID_DEAD: i32 = 1;
+
+/// Whether a process with the given OS PID is currently running.
+#[cfg(windows)]
+pub fn process_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        let mut code: u32 = 0;
+        let ok = GetExitCodeProcess(handle, &mut code);
+        let _ = CloseHandle(handle);
+        ok != 0 && code == STILL_ACTIVE as u32
+    }
+}
+
+/// Whether a process with the given OS PID is currently running.
+#[cfg(not(windows))]
+pub fn process_is_alive(pid: u32) -> bool {
+    // kill(pid, 0) probes existence without signalling.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}

--- a/crates/term-session-mock/src/main.rs
+++ b/crates/term-session-mock/src/main.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Read, Write};
 use std::time::Duration;
 
+use term_session_mock::{CHECK_PID_ALIVE, CHECK_PID_DEAD, process_is_alive};
+
 /// Deterministic mock binary for session server E2E tests.
 ///
 /// Subcommands:
@@ -12,6 +14,12 @@ use std::time::Duration;
 ///   byte isn't intercepted by ConPTY.
 /// - `sleep <ms>` — sleeps for N milliseconds, then exits.
 /// - `exit <code>` — exits with the given status code.
+/// - `spawn_child <ms>` — spawns a grandchild (`sleep <ms>`), prints
+///   `GRANDCHILD_PID:<pid>` to stdout, then echoes stdin until EOF.
+///   Used to prove that kill paths tear down the whole tree (grandchildren
+///   included), not just the session leader.
+/// - `check_pid <pid>` — exits 0 if the process is alive, non-zero otherwise.
+///   Cross-platform liveness probe for tree-kill assertions.
 pub const OSC52_TEST_PAYLOAD: &[u8] = b"c;dGVzdA==";
 
 #[cfg(windows)]
@@ -61,7 +69,7 @@ mod win_console {
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: term_session_mock <echo|osc52|sleep|exit> [args]");
+        eprintln!("Usage: term_session_mock <echo|osc52|sleep|exit|spawn_child|check_pid> [args]");
         std::process::exit(1);
     }
 
@@ -125,6 +133,57 @@ fn main() {
         "sleep" => {
             let ms: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1000);
             std::thread::sleep(Duration::from_millis(ms));
+        }
+        "spawn_child" => {
+            #[cfg(windows)]
+            win_console::enable_raw_vt();
+
+            let ms: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(60000);
+            // Spawn a grandchild process that outlives this one unless the
+            // whole tree is torn down. `sleep` keeps the process alive without
+            // producing output.
+            let exe = std::env::current_exe().expect("current exe");
+            let mut grandchild = std::process::Command::new(exe)
+                .arg("sleep")
+                .arg(ms.to_string())
+                .spawn()
+                .expect("spawn grandchild");
+            let pid = grandchild.id();
+
+            let mut stdout = io::stdout();
+            let _ = stdout.write_all(format!("GRANDCHILD_PID:{pid}\n").as_bytes());
+            let _ = stdout.flush();
+
+            // Keep this process alive (like `echo`) so the session stays up.
+            let mut buffer = [0u8; 4096];
+            let mut stdin = io::stdin();
+            loop {
+                match stdin.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if stdout.write_all(&buffer[..n]).is_err() {
+                            break;
+                        }
+                        if stdout.flush().is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            // The session kill path tears the whole tree down via the Job
+            // Object / process group, but if we exit normally (stdin EOF)
+            // the grandchild would otherwise be orphaned — reap it.
+            let _ = grandchild.kill();
+            let _ = grandchild.wait();
+        }
+        "check_pid" => {
+            let pid: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+            if process_is_alive(pid) {
+                std::process::exit(CHECK_PID_ALIVE);
+            }
+            std::process::exit(CHECK_PID_DEAD);
         }
         "exit" => {
             let code: i32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);

--- a/crates/term-session-mock/tests/mock_bin_tests.rs
+++ b/crates/term-session-mock/tests/mock_bin_tests.rs
@@ -2,13 +2,9 @@ use std::process::Command;
 use std::time::Duration;
 
 fn mock_bin() -> String {
-    let mut path = std::env::current_exe().expect("test exe path");
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.push(format!("term-session-mock{}", std::env::consts::EXE_SUFFIX));
-    path.to_string_lossy().to_string()
+    term_session_mock::get_mock_bin()
+        .to_string_lossy()
+        .to_string()
 }
 
 fn find_osc52_payload(stream: &[u8]) -> Option<&[u8]> {

--- a/crates/term-session/Cargo.toml
+++ b/crates/term-session/Cargo.toml
@@ -30,4 +30,5 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 muxio-tokio-rpc-ipc-client = { workspace = true }
+term-session-mock = { workspace = true }
 tokio = { workspace = true }

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -20,15 +20,10 @@ fn bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_term-session"))
 }
 
-/// Path to the mock PTY binary used as a session child.
+/// Path to the mock PTY binary used as a session child. Delegates to the
+/// shared helper in the mock crate's library.
 fn mock_bin() -> PathBuf {
-    let mut path = std::env::current_exe().expect("test exe path");
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.push(format!("term-session-mock{}", std::env::consts::EXE_SUFFIX));
-    path
+    term_session_mock::get_mock_bin()
 }
 
 /// A unique per-test gateway name.

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "term-wm-pty-engine"
-description = "PTY engine for term-wm."
+description = "Cross-platform PTY engine for term-wm (Unix PTY and Windows ConPTY), with vt100 emulation and OSC/clipboard handling."
 keywords = ["pty", "terminal", "vt100", "conpty", "cross-platform"]
 categories = ["emulators", "os", "external-ffi-bindings", "concurrency"]
 version.workspace = true
@@ -20,4 +20,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 vt100 = { workspace = true }
 vte = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
+[dev-dependencies]
+term-session-mock = { workspace = true }
 

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -24,6 +24,11 @@ vte = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }
 
-[dev-dependencies]
+[target.'cfg(windows)'.dev-dependencies]
+# Only the `#[cfg(windows)]` Job Object test (`spawn_assigns_job_object_containing_child`
+# in src/pty.rs) consumes the mock binary (`get_mock_bin` / `process_is_alive`). On
+# Unix/Linux all of those references compile out, so an unconditional dev-dependency
+# is dead there — cargo-udeps reports it as unused. Gating it to Windows keeps the
+# binary built exactly where the test needs it and keeps the Linux/Unix build clean.
 term-session-mock = { workspace = true }
 

--- a/crates/term-wm-pty-engine/src/job_object.rs
+++ b/crates/term-wm-pty-engine/src/job_object.rs
@@ -1,0 +1,103 @@
+//! Win32 Job Object containment for PTY process trees (Windows only).
+//!
+//! A spawned PTY child is assigned to a Job Object configured with
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Every descendant process inherits
+//! membership in the job, so terminating the job (`TerminateJobObject`) or
+//! closing the last job handle kills the **entire tree** — including
+//! grandchildren — rather than only the session leader. This is the Windows
+//! analogue of Unix `kill(-pgid, signal)` and keeps background jobs from being
+//! orphaned when a session is killed.
+
+use std::io;
+
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject,
+};
+
+/// Owned handle to a Win32 Job Object configured to terminate its process
+/// tree when the last handle is closed.
+pub struct JobObject {
+    handle: HANDLE,
+}
+
+impl JobObject {
+    /// Create an anonymous job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+    ///
+    /// The kill-on-close flag is set **before** any process is assigned, so
+    /// the containment guarantee holds even if this `JobObject` is dropped
+    /// without an explicit `terminate()`.
+    pub fn new() -> io::Result<Self> {
+        unsafe {
+            let handle = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if handle.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let ok = SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if ok == 0 {
+                let err = io::Error::last_os_error();
+                CloseHandle(handle);
+                return Err(err);
+            }
+            Ok(Self { handle })
+        }
+    }
+
+    /// Assign an already-running process (by its handle) to the job.
+    ///
+    /// `process` must be a valid, open handle to the process (e.g. the PTY
+    /// child's handle from `Child::as_raw_handle`). Since Windows 8 processes
+    /// may belong to multiple (nested) jobs, this succeeds even when the
+    /// process was spawned from a parent that is itself inside a job. A
+    /// failure means containment could not be established; the caller falls
+    /// back to single-process termination.
+    ///
+    /// # Safety
+    /// `process` must reference a live process handle for the duration of the
+    /// call.
+    pub unsafe fn assign(&self, process: HANDLE) -> io::Result<()> {
+        let ok = unsafe { AssignProcessToJobObject(self.handle, process) };
+        if ok == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Terminate every process currently in the job (the whole tree).
+    pub fn terminate(&self, exit_code: u32) -> io::Result<()> {
+        let ok = unsafe { TerminateJobObject(self.handle, exit_code) };
+        if ok == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// Job Object handles are thread-safe: `TerminateJobObject` and
+// `AssignProcessToJobObject` may be called from any thread, and the OS owns
+// the underlying object's lifetime. `HANDLE` is a pointer-sized value with no
+// thread-affinity semantics, so moving/cloning it across threads is sound.
+unsafe impl Send for JobObject {}
+unsafe impl Sync for JobObject {}
+
+impl Drop for JobObject {
+    fn drop(&mut self) {
+        // Closing the last job handle fires `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`,
+        // terminating any processes still in the job. Best-effort: a failure
+        // only means the tree was already gone.
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}

--- a/crates/term-wm-pty-engine/src/lib.rs
+++ b/crates/term-wm-pty-engine/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod clipboard;
 pub mod input_encoding;
+#[cfg(windows)]
+pub mod job_object;
 pub mod pane;
 pub mod pty;
 pub mod pty_state_tracker;

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -9,6 +9,8 @@ use std::time::Instant;
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
 use crate::clipboard::{Clipboard, Osc52Extractor};
+#[cfg(windows)]
+use crate::job_object::JobObject;
 use crate::pty_state_tracker::PtyPerformAdapter;
 
 /// Size of the PTY master read buffer (single `read()` call).
@@ -94,6 +96,12 @@ pub struct Pty {
     pty_size: PtySize,
     scrollback_len: usize,
     child: Option<Box<dyn Child + Send + Sync>>,
+    /// Win32 Job Object containing the child's process tree (Windows only).
+    /// Dropping it with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` terminates any
+    /// processes still in the job, so an un-killed `Pty` never orphans
+    /// descendants. The Windows analogue of the Unix process group.
+    #[cfg(windows)]
+    job: Option<JobObject>,
     exited: bool,
     exit_status: Option<portable_pty::ExitStatus>,
     /// Guards against double-fire of the Exited callback from both
@@ -139,6 +147,38 @@ impl Pty {
             .slave
             .spawn_command(command)
             .map_err(|err| wrap_err("spawn_command", err))?;
+        #[cfg(windows)]
+        let job = {
+            // Contain the child's process tree in a Job Object so kill paths
+            // tear down grandchildren too (the Windows analogue of
+            // `kill(-pgid, sig)`). Assignment happens immediately after spawn:
+            // Win32 allows nested jobs, so membership in any parent job does
+            // not block this. Once the child is assigned, every descendant it
+            // subsequently spawns inherits job membership and dies with the
+            // job (or on job-handle close).
+            //
+            // TODO(windows): assignment is post-spawn, so a descendant spawned
+            // in the window between portable-pty's `CreateProcessW` returning
+            // and our `AssignProcessToJobObject` call escapes the job and
+            // would be orphaned by a kill. The formal zero-escape guarantee
+            // requires spawning the child with `CREATE_SUSPENDED`, assigning
+            // the suspended process to the job, then `ResumeThread`. portable-pty
+            // 0.9.0 hardcodes the creation flags (`psuedocon.rs`:
+            // `EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT`) and
+            // `CommandBuilder` exposes no creation-flags hook, so the suspended
+            // spawn must be added upstream (or the crate forked). Until then
+            // the guarantee is: descendants spawned after assignment are
+            // contained; descendants spawned during the startup race are not.
+            let job = JobObject::new().ok();
+            if let (Some(job), Some(proc)) = (&job, child.as_raw_handle())
+                && let Err(err) = unsafe { job.assign(proc) }
+            {
+                tracing::warn!(
+                    "AssignProcessToJobObject failed: {err}; falling back to single-process kill"
+                );
+            }
+            job
+        };
         let reader = pair
             .master
             .try_clone_reader()
@@ -212,6 +252,8 @@ impl Pty {
             pty_size: size,
             scrollback_len,
             child: Some(child),
+            #[cfg(windows)]
+            job,
             exited: false,
             exit_status: None,
             reader: Some(reader_handle),
@@ -445,7 +487,16 @@ impl Pty {
     }
 
     /// Kill the child process if present.
+    ///
+    /// On Windows the whole contained tree is terminated via the Job Object
+    /// (grandchildren included), falling back to single-process termination
+    /// when containment was not established. The job handle is taken so its
+    /// `Drop` (KILL_ON_JOB_CLOSE) is the last line of defense for stragglers.
     pub fn kill_child(&mut self) -> PtyResult<()> {
+        #[cfg(windows)]
+        if let Some(job) = self.job.take() {
+            let _ = job.terminate(1);
+        }
         if let Some(mut child) = self.child.take() {
             child.kill().map_err(|err| wrap_err("kill", err))?;
             self.exited = true;
@@ -970,6 +1021,16 @@ mod tests {
         }
     }
 
+    /// Locate the `term-session-mock` binary so the Job Object test can spawn
+    /// a child that itself forks a grandchild. Resolution is delegated to the
+    /// shared helper in the mock crate's library (see
+    /// `term_session_mock::get_mock_bin`), which is a dev-dependency of this
+    /// crate so the binary is always built for tests.
+    #[cfg(windows)]
+    fn get_mock_bin() -> std::path::PathBuf {
+        term_session_mock::get_mock_bin()
+    }
+
     // ── bytes_to_debug_text ──────────────────────────────────────────
 
     #[test]
@@ -1204,6 +1265,88 @@ mod tests {
             woke.load(Ordering::Relaxed),
             "status callback must fire on Wakeup when PTY outputs data"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn spawn_assigns_job_object_containing_child() {
+        // The Windows child must be contained in a Job Object so kill paths
+        // terminate the whole tree (grandchildren included), not just the
+        // session leader. We spawn the mock in `spawn_child` mode: it forks a
+        // grandchild (another mock instance in `sleep` mode) and prints
+        // `GRANDCHILD_PID:<n>` to stdout. We read that PID, confirm the
+        // grandchild is alive, kill the child via `kill_child` (which calls
+        // `TerminateJobObject`), and confirm the grandchild died too — the
+        // whole-tree guarantee.
+        let mock = get_mock_bin();
+        let mut cmd = CommandBuilder::new(mock);
+        cmd.arg("spawn_child");
+        cmd.arg("60000");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
+
+        assert!(
+            pty.job.is_some(),
+            "spawned child must be contained in a Job Object on Windows"
+        );
+
+        // Poll `screen()` — which answers the child's startup DSR
+        // cursor-position request — while accumulating output until the
+        // `GRANDCHILD_PID:` marker appears.
+        let mut accumulated = Vec::new();
+        let start = std::time::Instant::now();
+        let grandchild = loop {
+            pty.screen();
+            accumulated.extend_from_slice(&pty.drain_pending());
+            if let Some(idx) = accumulated
+                .windows(b"GRANDCHILD_PID:".len())
+                .position(|w| w == b"GRANDCHILD_PID:")
+            {
+                let rest = &accumulated[idx + b"GRANDCHILD_PID:".len()..];
+                let pid_str: String = rest
+                    .iter()
+                    .take_while(|b| b.is_ascii_digit())
+                    .map(|b| *b as char)
+                    .collect();
+                break pid_str
+                    .parse()
+                    .unwrap_or_else(|_| panic!("invalid grandchild PID in {rest:?}"));
+            }
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(5),
+                "mock spawn_child should print a grandchild PID; got {accumulated:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        };
+
+        // The grandchild must be alive before the kill.
+        assert!(
+            term_session_mock::process_is_alive(grandchild),
+            "grandchild {grandchild} should be alive before kill_child"
+        );
+
+        // kill_child must consume the job (its Drop then fires
+        // KILL_ON_JOB_CLOSE for any stragglers) and reap the child.
+        pty.kill_child().expect("kill_child");
+        assert!(pty.job.is_none(), "job must be taken on kill_child");
+        assert!(pty.child.is_none(), "child must be reaped on kill_child");
+        assert!(pty.exited, "pty must be marked exited after kill_child");
+
+        // The grandchild must die with the tree — the whole point of the
+        // Job Object containment. Poll briefly since termination is async.
+        let start = std::time::Instant::now();
+        while term_session_mock::process_is_alive(grandchild) {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(5),
+                "grandchild {grandchild} should be dead after kill_child"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
     }
 
     #[test]

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -2,14 +2,24 @@
 
 pub const EXPECTED_OSC52_PAYLOAD: &[u8] = b"c;dGVzdA==";
 
+/// Locate the `term-session-mock` binary. Delegates to the shared helper in
+/// the mock crate's library so every test suite resolves it the same way.
 pub fn get_mock_bin() -> String {
-    let mut path = std::env::current_exe().expect("test exe path");
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.push(format!("term-session-mock{}", std::env::consts::EXE_SUFFIX));
-    path.to_string_lossy().to_string()
+    term_session_mock::get_mock_bin()
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Probe whether a process with the given OS PID is alive by asking the mock
+/// binary's `check_pid` subcommand. Cross-platform (uses `OpenProcess` on
+/// Windows, `kill(pid, 0)` elsewhere), so tests can assert tree-kill behavior
+/// without platform-specific APIs in the harness.
+pub fn mock_pid_alive(mock_bin: &str, pid: u32) -> bool {
+    std::process::Command::new(mock_bin)
+        .args(["check_pid", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Scan for a complete SGR 1006 mouse sequence: `\x1b[<...M` or `\x1b[<...m`.

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -1,6 +1,7 @@
 use muxio_tokio_mpsc_adapter::ChannelCallerExt;
-use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
+use muxio_tokio_rpc_ipc_client::{RpcCallPrebuffered, RpcIpcClient};
 use serial_test::serial;
+use std::sync::Arc;
 use std::time::Duration;
 use term_session_muxio_service_definitions::{
     CloseSession, KillChannel, KillClient, ResizePty, STREAM_INPUT_METHOD_ID,
@@ -8,7 +9,7 @@ use term_session_muxio_service_definitions::{
 };
 
 mod common;
-use common::mock::{find_osc52_payload, find_sgr_mouse_token, get_mock_bin};
+use common::mock::{find_osc52_payload, find_sgr_mouse_token, get_mock_bin, mock_pid_alive};
 use common::session::{
     TEST_COLS, TEST_ROWS, attach_client, connect_client_with_retry, get_bench_bin, list_channels,
     spawn_gateway, spawn_session, test_channel, wait_for_output,
@@ -592,6 +593,112 @@ async fn list_channels_reports_clients_and_geometry() {
     // Process visibility: the response identifies the daemon PID + socket.
     assert!(resp.gateway_pid > 0, "gateway pid reported");
     assert!(!resp.socket.is_empty(), "socket name reported");
+    guard.shutdown().await;
+}
+
+/// Spawn a session running the mock in `spawn_child` mode on the client's
+/// bound channel, read the grandchild PID it reports, and return it.
+/// Panics if the marker never appears.
+async fn spawn_session_with_grandchild(client: &Arc<RpcIpcClient>, mock: &str) -> u32 {
+    Spawn::call(
+        &**client,
+        (
+            Some(vec![mock.to_string(), "spawn_child".into(), "60000".into()]),
+            TEST_COLS,
+            TEST_ROWS,
+        ),
+    )
+    .await
+    .expect("spawn with grandchild");
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .expect("subscribe output");
+
+    const MARKER: &[u8] = b"GRANDCHILD_PID:";
+    let output = wait_for_output(&mut reader, MARKER, Duration::from_secs(5)).await;
+    let idx = output
+        .windows(MARKER.len())
+        .position(|w| w == MARKER)
+        .unwrap_or_else(|| panic!("grandchild PID marker not found; got {output:?}"));
+    let rest = &output[idx + MARKER.len()..];
+    let pid_str: String = rest
+        .iter()
+        .take_while(|b| b.is_ascii_digit())
+        .map(|b| *b as char)
+        .collect();
+    pid_str
+        .parse()
+        .unwrap_or_else(|_| panic!("invalid grandchild PID in {rest:?}"))
+}
+
+/// Assert that after a kill RPC completes, the grandchild process dies too
+/// (whole-tree containment, nothing orphaned). Polls briefly since
+/// termination is asynchronous.
+async fn assert_grandchild_dies(mock: &str, grandchild_pid: u32, via: &str) {
+    let start = std::time::Instant::now();
+    loop {
+        if !mock_pid_alive(mock, grandchild_pid) {
+            return;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "grandchild {grandchild_pid} should be dead after {via}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// KillChannel must terminate the *entire* process tree — grandchildren
+/// included, not just the PTY session leader. The mock's `spawn_child` mode
+/// forks a grandchild and reports its PID on stdout; this test reads that
+/// PID, confirms the grandchild is alive, kills the channel, then confirms
+/// the grandchild died.
+///
+/// On Windows this exercises the Win32 Job Object containment
+/// (`TerminateJobObject` on a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` job); on
+/// Unix it exercises the process-group SIGTERM→SIGKILL escalation.
+#[tokio::test]
+#[serial]
+async fn kill_channel_terminates_process_tree() {
+    let mock = get_mock_bin();
+    let (client, _conn_id, guard) = spawn_session(&test_channel("test/kill_tree")).await;
+    let grandchild_pid = spawn_session_with_grandchild(&client, &mock).await;
+
+    assert!(
+        mock_pid_alive(&mock, grandchild_pid),
+        "grandchild {grandchild_pid} should be alive before KillChannel"
+    );
+
+    KillChannel::call(&*client, "test/kill_tree".to_string())
+        .await
+        .unwrap();
+
+    assert_grandchild_dies(&mock, grandchild_pid, "KillChannel").await;
+    guard.shutdown().await;
+}
+
+/// CloseSession must terminate the *entire* process tree — grandchildren
+/// included, not just the PTY session leader. Same containment guarantee as
+/// KillChannel (both route through `request_session_kill` → `kill_child` →
+/// `TerminateJobObject` on Windows / process-group kill on Unix), so the
+/// grandchild must die here too.
+#[tokio::test]
+#[serial]
+async fn close_session_terminates_process_tree() {
+    let mock = get_mock_bin();
+    let (client, _conn_id, guard) = spawn_session(&test_channel("test/close_tree")).await;
+    let grandchild_pid = spawn_session_with_grandchild(&client, &mock).await;
+
+    assert!(
+        mock_pid_alive(&mock, grandchild_pid),
+        "grandchild {grandchild_pid} should be alive before CloseSession"
+    );
+
+    CloseSession::call(&*client, 1u64).await.unwrap();
+
+    assert_grandchild_dies(&mock, grandchild_pid, "CloseSession").await;
     guard.shutdown().await;
 }
 


### PR DESCRIPTION
- **Windows Win32 Job Object process-tree containment:** the PTY engine now contains each Windows PTY child in a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` job, so killing a session also kills the background processes it spawned — not just the session's own process. This makes the v0.9.4-alpha containment claim true for processes spawned after startup (see Errata). A known limitation: a process spawned in the brief moment during startup can escape the job; the full fix needs a portable-pty change and is tracked in the code. Windows-gated unit test `spawn_assigns_job_object_containing_child` verifies the behavior.
- **Behavioral whole-tree-kill proof:** `term-session-mock` gained a `spawn_child <ms>` subcommand that spawns a real grandchild process and reports its PID; integration tests assert that both `KillChannel` and `CloseSession` terminate the grandchild too (nothing re-parents to init), backed by a cross-platform `check_pid` liveness probe.
- **`term-session-mock` promoted to a workspace crate:** a single canonical `get_mock_bin()` resolver (honors `CARGO_BIN_EXE_term-session-mock`, falls back to the workspace `target/` build locations, and **builds the binary on demand** so tests never silently skip) now serves every test suite, with a dedicated README.

- Docs: `term-session` README (session sharing, session nesting, upgrade ordering, scrolling & text selection), `term-session-server` README, `term-session-mock` README, and `docs/COMPATIBILITY.md` refreshed to match the shipped CLI and daemon behavior.
- Package metadata (description/keywords/categories) updated.

- **Windows process-tree containment (correction):** the v0.9.4-alpha changelog entry "Gateway process supervision" stated that kill paths terminate the whole process tree on Windows via "Win32 Job Object containment". That was inaccurate for the shipped binary: at release time the Windows kill path (`Pty::kill_child`) delegated to portable-pty's `WinChild`, which performs a bare `TerminateProcess` on the **single session leader** — grandchildren were not contained and could be orphaned. Only the Unix process-group path (SIGTERM → exited-checked SIGKILL escalation) actually matched the description.
  - **Resolution:** the Job Object containment described in that entry is now genuinely implemented: killing a Windows session also kills the processes it spawned, not just its own process. There is a known startup race (see the 0.9.5-alpha entry) where a process spawned in the brief startup moment can escape; the full fix needs a portable-pty change and is tracked in the code. Covered by the Windows-gated test `spawn_assigns_job_object_containing_child`.
- **`term-session` admin CLI (`--json` / `--socket`):** the v0.9.4-alpha "term-session admin CLI" entry described a `--json` list mode and a `kill <channel> [--socket CONN_ID]` flag. Neither exists in the shipped binary: `list` is plain-text only, and socket detachment is performed by the top-level `kill-client <channel> <CLIENT_ID>` subcommand (the `--socket` form was removed during development in favor of the explicit `kill-client`).