### PR TITLE
feat(term-session): Require `--force stop` when exiting sessions; improve cmd interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.6-alpha] - 2026-08-03
+
+### Added
+
+- **`term-session` CLI hardening — bare run shows help:** running `term-session` with no subcommand and no arguments prints the help menu and exits (code 2) instead of auto-connecting; the redundant `attach` subcommand was removed. A channel (`--channel <name>`) and/or a command still attach implicitly and auto-start the gateway.
+- **Idiomatic command passing via `--`:** the command is now trailing positional args after the POSIX end-of-options delimiter (like `sudo --` / `cargo run --`), so `term-session --channel work -- git log --oneline` passes flags through untouched, and a token before `--` that matches a subcommand name is always the subcommand. The argv comes straight from the outer shell (no re-parsing). `--channel` is long-only — the ambiguous `-c` short flag was removed.
+- **`stop --force` (server-enforced):** `ShutdownGateway` now carries a `force` flag; the gateway **refuses to shut down while any live session is running** unless `--force` is given (`RPC_ERROR_LIVE_SESSIONS`), and a refused stop leaves the daemon fully operational.
+- **Client identity in `list`:** each connected socket now reports its OS user, client binary version, and (for SSH attaches) the remote peer IP (`ssh ip from:` — read from the `SSH_CLIENT` / `SSH_CONNECTION` env vars `sshd` sets, omitted for local attaches).
+- **Creation-order listing:** `list` now returns channels and their clients in **creation order (newest last)** via a monotonic per-channel sequence and connection-ordered conn ids.
+- **Readable CLI errors:** errors print as plain `error: …` messages instead of Rust's `Debug` dump (previously `Custom { kind: …, … }`).
+
+### Changed
+
+- `Attach` RPC input is now the structured `AttachRequest` (channel, hostname, pid, user, version, ssh_ip) rather than a bare tuple; `ClientInfo` gains the identity fields. Windows user resolution falls back to `GetUserNameW` when `%USERNAME%` is unset.
+- Docs: `term-session` README updated for the bare-run help, `--` command passing, `stop --force`, creation-order listing, and per-client identity.
+
 ## [0.9.5-alpha] - 2026-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3196,21 +3196,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3228,11 +3228,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.5-alpha"
+version = "0.9.6-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,22 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.5-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.5-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.5-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.5-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.5-alpha" }
-term-wm = { path = ".", version = "0.9.5-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.5-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.5-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.5-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.5-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.5-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.5-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.5-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.5-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.5-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.5-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.6-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.6-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.6-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.6-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.6-alpha" }
+term-wm = { path = ".", version = "0.9.6-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.6-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.6-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.6-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.6-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.6-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.6-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.6-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.6-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.6-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.6-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
@@ -121,6 +121,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_JobObjects",
     "Win32_System_Pipes",
     "Win32_System_Threading",
+    "Win32_System_WindowsProgramming",
 ] }
 
 [[bin]]

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -145,6 +145,12 @@ const RENDER_BUF_CELL_MULTIPLIER: usize = 3;
 const MIN_TERM_COLS: u16 = 2;
 const MIN_TERM_ROWS: u16 = 2;
 
+/// Heuristic seed geometry when the terminal size cannot be queried (headless
+/// CI, redirected/`/dev/null` stdio). Overridden by the real attached geometry
+/// at render time; the server clamps to the smallest size across clients.
+const FALLBACK_TERM_COLS: u16 = 80;
+const FALLBACK_TERM_ROWS: u16 = 24;
+
 /// Initialize terminal for TUI mode: write startup escape sequences
 /// (alternate screen, hide cursor, bracketed paste, mouse capture) to
 /// the given writer, enable raw mode on stdin, and return a guard that
@@ -368,9 +374,12 @@ pub fn run_session(socket_path: &str, channel: &str, cmd: &[String]) -> io::Resu
     // Terminal geometry comes from the real terminal (no cols/rows are threaded
     // through the API). The vt100 parser computes `rows - 1` at construction, so
     // clamp a degenerate 0x0 report up to a non-zero grid rather than panicking.
-    let (term_cols, term_rows) = {
-        let (c, r) = crossterm::terminal::size()?;
-        (c.max(MIN_TERM_COLS), r.max(MIN_TERM_ROWS))
+    // On Unix with redirected stdio (e.g. `>/dev/null` under CI or tests) the
+    // TIOCGWINSZ ioctl fails and `COLUMNS`/`LINES` are unset, so `size()` errors
+    // — fall back to a seed rather than aborting before Attach/Spawn.
+    let (term_cols, term_rows) = match crossterm::terminal::size() {
+        Ok((c, r)) => (c.max(MIN_TERM_COLS), r.max(MIN_TERM_ROWS)),
+        Err(_) => (FALLBACK_TERM_COLS, FALLBACK_TERM_ROWS),
     };
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().into_owned())

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -20,8 +20,8 @@ use muxio_tokio_mpsc_adapter::ChannelCallerExt;
 use muxio_tokio_rpc_ipc_client::{RpcCallPrebuffered, RpcIpcClient, RpcServiceCallerInterface};
 use portable_pty::PtySize;
 use term_session_muxio_service_definitions::{
-    Attach, OnPtyResized, RpcMethodPrebuffered, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID,
-    Spawn,
+    Attach, AttachRequest, OnPtyResized, RpcMethodPrebuffered, STREAM_INPUT_METHOD_ID,
+    SUBSCRIBE_OUTPUT_METHOD_ID, Spawn,
 };
 use term_wm_events::{Event, KeyKind, KeyModifiers, MouseEventKind};
 use term_wm_pty_engine::Pane;
@@ -213,6 +213,80 @@ fn is_coalescable_mouse(
     }
 }
 
+/// OS user running the client process, reported at `Attach` so `list` can show
+/// who each socket belongs to. On Unix the passwd entry is authoritative, with
+/// `$USER` as a fallback; on Windows `%USERNAME%` is used, with `GetUserNameW`
+/// as a fallback for contexts where the env var is unset.
+fn client_user() -> String {
+    #[cfg(unix)]
+    {
+        unsafe {
+            let pw = libc::getpwuid(libc::getuid());
+            if !pw.is_null() {
+                let name = std::ffi::CStr::from_ptr((*pw).pw_name);
+                if let Ok(s) = name.to_str()
+                    && !s.is_empty()
+                {
+                    return s.to_string();
+                }
+            }
+        }
+        std::env::var("USER").unwrap_or_default()
+    }
+    #[cfg(windows)]
+    {
+        if let Ok(u) = std::env::var("USERNAME")
+            && !u.is_empty()
+        {
+            return u;
+        }
+        windows_username().unwrap_or_default()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        String::new()
+    }
+}
+
+/// Windows fallback: resolve the account via `GetUserNameW` when `%USERNAME%`
+/// is not set (e.g. service or non-interactive contexts).
+#[cfg(windows)]
+fn windows_username() -> Option<String> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::System::WindowsProgramming::GetUserNameW;
+    let mut buf = [0u16; 256];
+    let mut len = buf.len() as u32;
+    let ok = unsafe { GetUserNameW(buf.as_mut_ptr(), &mut len) };
+    if ok == 0 {
+        return None;
+    }
+    let s = std::ffi::OsString::from_wide(&buf[..len as usize])
+        .to_string_lossy()
+        .into_owned();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Client binary version (`CARGO_PKG_VERSION`), reported at `Attach` so `list`
+/// can surface mixed-version clients against the same daemon.
+fn client_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Remote peer IP for SSH attaches: `sshd` sets `SSH_CLIENT` (client ip/port
+/// server-port) or `SSH_CONNECTION` (client ip/port server ip/port); the first
+/// whitespace token is the peer address. Returns `None` for local attaches.
+fn client_ssh_ip() -> Option<String> {
+    for var in ["SSH_CLIENT", "SSH_CONNECTION"] {
+        if let Ok(v) = std::env::var(var) {
+            let ip = v.split_whitespace().next()?;
+            if !ip.is_empty() {
+                return Some(ip.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Connect to a term-session gateway and run the TUI viewer for `channel`.
 ///
 /// This function is synchronous. It creates a background tokio runtime for
@@ -307,7 +381,14 @@ pub fn run_session(socket_path: &str, channel: &str, cmd: &[String]) -> io::Resu
         // conn_id); report our OS PID so `list` can show which client is which.
         let conn_id = Attach::call(
             &*client,
-            (channel.to_string(), hostname, std::process::id() as u64),
+            AttachRequest {
+                channel: channel.to_string(),
+                hostname,
+                pid: std::process::id() as u64,
+                user: client_user(),
+                version: client_version(),
+                ssh_ip: client_ssh_ip(),
+            },
         )
         .await
         .map_err(|e| abi_fault(&e))?;
@@ -814,6 +895,104 @@ mod tests {
             bytes
                 .windows(b"\x1b[?2004h".len())
                 .any(|w| w == b"\x1b[?2004h")
+        );
+    }
+
+    // ── client identity helpers ─────────────────────────────────────
+    //
+    // These mutate `SSH_CLIENT`/`SSH_CONNECTION`, which is process-global;
+    // a static mutex serializes them against other tests (and each other).
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn client_ssh_ip_from_ssh_client() {
+        let _guard = env_lock();
+        unsafe {
+            std::env::set_var("SSH_CLIENT", "192.168.1.50 54321 22");
+            std::env::remove_var("SSH_CONNECTION");
+        }
+        assert_eq!(client_ssh_ip().as_deref(), Some("192.168.1.50"));
+        unsafe {
+            std::env::remove_var("SSH_CLIENT");
+        }
+    }
+
+    #[test]
+    fn client_ssh_ip_from_ssh_connection_fallback() {
+        let _guard = env_lock();
+        unsafe {
+            std::env::remove_var("SSH_CLIENT");
+            std::env::set_var("SSH_CONNECTION", "10.0.0.7 48000 10.0.0.1 22");
+        }
+        assert_eq!(client_ssh_ip().as_deref(), Some("10.0.0.7"));
+        unsafe {
+            std::env::remove_var("SSH_CONNECTION");
+        }
+    }
+
+    #[test]
+    fn client_ssh_ip_ssh_client_wins_over_connection() {
+        let _guard = env_lock();
+        unsafe {
+            std::env::set_var("SSH_CLIENT", "1.2.3.4 1000 22");
+            std::env::set_var("SSH_CONNECTION", "9.9.9.9 2000 1.1.1.1 22");
+        }
+        assert_eq!(client_ssh_ip().as_deref(), Some("1.2.3.4"));
+        unsafe {
+            std::env::remove_var("SSH_CLIENT");
+            std::env::remove_var("SSH_CONNECTION");
+        }
+    }
+
+    #[test]
+    fn client_ssh_ip_none_when_local() {
+        let _guard = env_lock();
+        unsafe {
+            std::env::remove_var("SSH_CLIENT");
+            std::env::remove_var("SSH_CONNECTION");
+        }
+        assert_eq!(client_ssh_ip(), None);
+    }
+
+    #[test]
+    fn client_version_matches_package() {
+        assert_eq!(client_version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn client_user_non_empty() {
+        assert!(!client_user().is_empty(), "client user must resolve");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn client_user_prefers_username_env_when_set() {
+        let _guard = env_lock();
+        unsafe {
+            std::env::set_var("USERNAME", "win-test-user");
+        }
+        assert_eq!(client_user(), "win-test-user");
+        unsafe {
+            std::env::remove_var("USERNAME");
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn client_user_falls_back_to_getusername_when_env_absent() {
+        let _guard = env_lock();
+        unsafe {
+            std::env::remove_var("USERNAME");
+        }
+        // `USERNAME` is normally always set on Windows; with it removed, the
+        // `GetUserNameW` fallback must still resolve the real account.
+        assert!(
+            !client_user().is_empty(),
+            "GetUserNameW fallback must resolve a user"
         );
     }
 

--- a/crates/term-session-mock/README.md
+++ b/crates/term-session-mock/README.md
@@ -6,7 +6,7 @@ Internal test tooling for the [term-wm](https://crates.io/crates/term-wm) worksp
 
 A **deterministic PTY-resident test fixture** — a small, real binary that the session daemon spawns inside a PTY so tests can drive a child process with full determinism. It replaces a real shell/command in tests, removing dependency on shell availability, shell startup timing, and platform-specific command behavior.
 
-It is **not** a "posix mocker". It runs on Linux, macOS, and Windows, and includes explicit Windows ConPTY console-mode handling (raw VT input, VT-processing toggling) so ANSI sequences pass through ConPTY intact.
+It runs on Linux, macOS, and Windows, and includes explicit Windows ConPTY console-mode handling (raw VT input, VT-processing toggling) so ANSI sequences pass through ConPTY intact.
 
 Every subcommand performs **real** OS behavior — real process spawning, real exit codes, real sleeping, real PIDs, real liveness probing. Nothing is hardcoded to fabricate a passing assertion; the only fixed output is the `osc52` payload, which is the exact byte sequence the OSC 52 encoder is expected to emit.
 

--- a/crates/term-session-muxio-service-definitions/src/lib.rs
+++ b/crates/term-session-muxio-service-definitions/src/lib.rs
@@ -3,9 +3,9 @@ pub mod methods;
 
 pub use channel::{ChannelName, GATEWAY_CHANNEL_ENV_VAR, gateway_channel_name, probe_ipc_endpoint};
 pub use methods::{
-    Attach, ChannelInfo, ClientInfo, CloseSession, KillChannel, KillClient, ListChannels,
-    ListChannelsResponse, OnPtyResized, PushOutput, RPC_ERROR_SHUTTING_DOWN, RPC_ERROR_UNATTACHED,
-    ResizePty, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway,
-    Spawn, WriteInput,
+    Attach, AttachRequest, ChannelInfo, ClientInfo, CloseSession, KillChannel, KillClient,
+    ListChannels, ListChannelsResponse, OnPtyResized, PushOutput, RPC_ERROR_LIVE_SESSIONS,
+    RPC_ERROR_SHUTTING_DOWN, RPC_ERROR_UNATTACHED, ResizePty, STREAM_INPUT_METHOD_ID,
+    SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway, Spawn, WriteInput,
 };
 pub use muxio_rpc_service::prebuffered::RpcMethodPrebuffered;

--- a/crates/term-session-muxio-service-definitions/src/methods.rs
+++ b/crates/term-session-muxio-service-definitions/src/methods.rs
@@ -10,15 +10,25 @@ use muxio_rpc_service::{prebuffered::RpcMethodPrebuffered, rpc_method_id};
 pub const RPC_ERROR_UNATTACHED: &str =
     "gateway: connection is not attached to a channel; call Attach first";
 pub const RPC_ERROR_SHUTTING_DOWN: &str = "gateway: shutting down";
+pub const RPC_ERROR_LIVE_SESSIONS: &str =
+    "gateway: live session(s) running; use `term-session stop --force` to stop anyway";
 
 // ── Attach ──────────────────────────────────────────────────────────
 
-#[derive(Encode, Decode)]
-struct AttachRequest {
+/// Client-provided identity reported at `Attach` so `list` can show who each
+/// socket belongs to and where it came from.
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct AttachRequest {
     pub channel: String,
     pub hostname: String,
     /// The client process's OS PID, so `list` can show which PID is attached.
     pub pid: u64,
+    /// OS user running the client process (e.g. `jzombie`).
+    pub user: String,
+    /// Client binary version (`CARGO_PKG_VERSION`).
+    pub version: String,
+    /// Remote peer IP for SSH attaches; `None` for local attaches.
+    pub ssh_ip: Option<String>,
 }
 
 #[derive(Encode, Decode)]
@@ -31,22 +41,16 @@ pub struct Attach;
 impl RpcMethodPrebuffered for Attach {
     const METHOD_ID: u64 = rpc_method_id!("session.attach");
 
-    // TODO: Use type aliases to simplify this
-    type Input = (String, String, u64);
+    type Input = AttachRequest;
     type Output = usize;
 
     fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
-        Ok(bitcode::encode(&AttachRequest {
-            channel: input.0,
-            hostname: input.1,
-            pid: input.2,
-        }))
+        Ok(bitcode::encode(&input))
     }
 
     fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
-        let r = bitcode::decode::<AttachRequest>(bytes)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok((r.channel, r.hostname, r.pid))
+        bitcode::decode::<AttachRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
     fn encode_response(output: Self::Output) -> Result<Vec<u8>, io::Error> {
@@ -292,6 +296,12 @@ pub struct ClientInfo {
     pub connected_at_unix: u64,
     pub cols: u16,
     pub rows: u16,
+    /// OS user running the client process (reported at Attach).
+    pub user: String,
+    /// Client binary version (reported at Attach).
+    pub version: String,
+    /// Remote peer IP for SSH attaches; `None` for local attaches.
+    pub ssh_ip: Option<String>,
 }
 
 /// Public wire info for one channel on the gateway.
@@ -429,20 +439,27 @@ impl RpcMethodPrebuffered for KillClient {
 
 // ── ShutdownGateway ──────────────────────────────────────────────────
 
+#[derive(Encode, Decode)]
+struct ShutdownGatewayRequest {
+    pub force: bool,
+}
+
 pub struct ShutdownGateway;
 
 impl RpcMethodPrebuffered for ShutdownGateway {
     const METHOD_ID: u64 = rpc_method_id!("session.shutdown_gateway");
 
-    type Input = ();
+    type Input = bool;
     type Output = ();
 
-    fn encode_request(_input: Self::Input) -> Result<Vec<u8>, io::Error> {
-        Ok(Vec::new())
+    fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
+        Ok(bitcode::encode(&ShutdownGatewayRequest { force: input }))
     }
 
-    fn decode_request(_bytes: &[u8]) -> Result<Self::Input, io::Error> {
-        Ok(())
+    fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
+        let r = bitcode::decode::<ShutdownGatewayRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(r.force)
     }
 
     fn encode_response(_output: Self::Output) -> Result<Vec<u8>, io::Error> {

--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use muxio_core::rpc::rpc_internals::RpcStreamEvent;
 use muxio_rpc_service::prebuffered::RpcMethodPrebuffered;
@@ -12,9 +12,9 @@ use tokio::sync::{Mutex, Notify, RwLock, mpsc, oneshot};
 
 use term_session_muxio_service_definitions::{
     Attach, ChannelInfo, ChannelName, ClientInfo, CloseSession, KillChannel, KillClient,
-    ListChannels, ListChannelsResponse, OnPtyResized, RPC_ERROR_SHUTTING_DOWN,
-    RPC_ERROR_UNATTACHED, ResizePty, STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID,
-    SessionInfo, ShutdownGateway, Spawn, WriteInput,
+    ListChannels, ListChannelsResponse, OnPtyResized, RPC_ERROR_LIVE_SESSIONS,
+    RPC_ERROR_SHUTTING_DOWN, RPC_ERROR_UNATTACHED, ResizePty, STREAM_INPUT_METHOD_ID,
+    SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway, Spawn, WriteInput,
 };
 use term_wm_pty_engine::PtyStatus;
 
@@ -72,6 +72,12 @@ struct ConnEntry {
     connected_at_unix: u64,
     /// Client process OS PID (reported at Attach).
     pid: u64,
+    /// OS user running the client process (reported at Attach).
+    user: String,
+    /// Client binary version (reported at Attach).
+    version: String,
+    /// Remote peer IP for SSH attaches; `None` for local (reported at Attach).
+    ssh_ip: Option<String>,
 }
 
 #[derive(Clone)]
@@ -80,6 +86,9 @@ struct ClientEntry {
     hostname: String,
     connected_at_unix: u64,
     pid: u64,
+    user: String,
+    version: String,
+    ssh_ip: Option<String>,
     cols: u16,
     rows: u16,
 }
@@ -98,6 +107,11 @@ struct ChannelState {
     notify: Arc<Notify>,
     /// Unix seconds when the channel was first created on the gateway.
     created_at_unix: u64,
+    /// Monotonic creation sequence (across the whole gateway process). Sort key
+    /// for `ListChannels`: creation order, newest last. `created_at_unix` is
+    /// only second-resolution wall clock and cannot disambiguate same-second
+    /// creations, so this monotonic counter is authoritative.
+    created_seq: u64,
     /// Command template used to respawn the session after it exits.
     cmd: Vec<String>,
     input_tx: mpsc::Sender<Vec<u8>>,
@@ -118,6 +132,8 @@ struct ServerState {
     conns: RwLock<HashMap<usize, ConnEntry>>,
     channels: RwLock<HashMap<ChannelName, Arc<Mutex<ChannelState>>>>,
     is_shutting_down: AtomicBool,
+    /// Monotonic source of `ChannelState::created_seq` (creation order).
+    next_channel_seq: AtomicU64,
 }
 
 type SharedState = Arc<ServerState>;
@@ -140,13 +156,19 @@ fn now_unix() -> u64 {
 }
 
 impl ChannelState {
-    fn new(cmd: Vec<String>, input_tx: mpsc::Sender<Vec<u8>>, notify: Arc<Notify>) -> Self {
+    fn new(
+        cmd: Vec<String>,
+        input_tx: mpsc::Sender<Vec<u8>>,
+        notify: Arc<Notify>,
+        created_seq: u64,
+    ) -> Self {
         Self {
             session: None,
             clients: HashMap::new(),
             subscribers: Vec::new(),
             notify,
             created_at_unix: now_unix(),
+            created_seq,
             cmd,
             input_tx,
             kill_pending: false,
@@ -266,7 +288,9 @@ impl ChannelState {
             exit_code: s.exit_code,
             title: s.title.clone().unwrap_or_default(),
         });
-        let clients = self
+        // Sort by `conn_id`, which muxio assigns monotonically at connection
+        // accept — ascending order = connection order, newest client last.
+        let mut clients: Vec<ClientInfo> = self
             .clients
             .iter()
             .map(|(conn_id, c)| ClientInfo {
@@ -276,8 +300,12 @@ impl ChannelState {
                 connected_at_unix: c.connected_at_unix,
                 cols: c.cols,
                 rows: c.rows,
+                user: c.user.clone(),
+                version: c.version.clone(),
+                ssh_ip: c.ssh_ip.clone(),
             })
             .collect();
+        clients.sort_by_key(|c| c.conn_id);
         ChannelInfo {
             name: name.to_string(),
             created_at_unix: self.created_at_unix,
@@ -338,7 +366,13 @@ async fn get_or_create_channel(
     }
     let (input_tx, input_rx) = mpsc::channel::<Vec<u8>>(INPUT_CHANNEL_CAPACITY);
     let notify = Arc::new(Notify::new());
-    let channel = Arc::new(Mutex::new(ChannelState::new(Vec::new(), input_tx, notify)));
+    let created_seq = state.next_channel_seq.fetch_add(1, Ordering::Relaxed);
+    let channel = Arc::new(Mutex::new(ChannelState::new(
+        Vec::new(),
+        input_tx,
+        notify,
+        created_seq,
+    )));
     let ch = Arc::clone(&channel);
     tokio::spawn(async move {
         let mut input_rx = input_rx;
@@ -534,6 +568,7 @@ pub async fn run_gateway(
         conns: RwLock::new(HashMap::new()),
         channels: RwLock::new(HashMap::new()),
         is_shutting_down: AtomicBool::new(false),
+        next_channel_seq: AtomicU64::new(0),
     });
 
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
@@ -549,8 +584,8 @@ pub async fn run_gateway(
                 if state.is_shutting_down.load(Ordering::SeqCst) {
                     return Err(rpc_err(RPC_ERROR_SHUTTING_DOWN));
                 }
-                let (channel_str, hostname, pid) = Attach::decode_request(&payload)?;
-                let name = ChannelName::parse(&channel_str).map_err(|e| rpc_err(&e))?;
+                let req = Attach::decode_request(&payload)?;
+                let name = ChannelName::parse(&req.channel).map_err(|e| rpc_err(&e))?;
                 let _channel = get_or_create_channel(&state, &name).await;
                 let conn_id = ctx.conn_id;
                 let mut conns = state.conns.write().await;
@@ -563,11 +598,17 @@ pub async fn run_gateway(
                     hostname: String::new(),
                     connected_at_unix: now_unix(),
                     pid: 0,
+                    user: String::new(),
+                    version: String::new(),
+                    ssh_ip: None,
                 });
                 entry.state = ConnState::Attached(name);
-                entry.hostname = hostname;
+                entry.hostname = req.hostname;
                 entry.connected_at_unix = now_unix();
-                entry.pid = pid;
+                entry.pid = req.pid;
+                entry.user = req.user;
+                entry.version = req.version;
+                entry.ssh_ip = req.ssh_ip;
                 Attach::encode_response(conn_id).map_err(boxed_io)
             }
         })
@@ -589,31 +630,36 @@ pub async fn run_gateway(
                     return Err(rpc_err(RPC_ERROR_UNATTACHED));
                 };
                 let ch = get_or_create_channel(&state, &channel).await;
-                // Fetch the connection's caller handle, hostname, and connect
-                // time before locking the channel (never hold two locks).
+                // Fetch the connection's entry (caller handle, hostname,
+                // identity) before locking the channel (never hold two locks).
                 let conn_meta = {
                     let conns = state.conns.read().await;
-                    conns.get(&ctx.conn_id).map(|c| {
-                        (
-                            c.handle.clone(),
-                            c.hostname.clone(),
-                            c.connected_at_unix,
-                            c.pid,
-                        )
-                    })
+                    conns.get(&ctx.conn_id).cloned()
                 };
                 let mut guard = ch.lock().await;
                 let entry = guard
                     .clients
                     .entry(ctx.conn_id)
                     .or_insert_with(|| ClientEntry {
-                        caller: conn_meta.as_ref().map(|(h, _, _, _)| h.clone()),
+                        caller: conn_meta.as_ref().map(|c| c.handle.clone()),
                         hostname: conn_meta
                             .as_ref()
-                            .map(|(_, n, _, _)| n.clone())
+                            .map(|c| c.hostname.clone())
                             .unwrap_or_default(),
-                        connected_at_unix: conn_meta.as_ref().map(|(_, _, t, _)| *t).unwrap_or(0),
-                        pid: conn_meta.as_ref().map(|(_, _, _, p)| *p).unwrap_or(0),
+                        connected_at_unix: conn_meta
+                            .as_ref()
+                            .map(|c| c.connected_at_unix)
+                            .unwrap_or(0),
+                        pid: conn_meta.as_ref().map(|c| c.pid).unwrap_or(0),
+                        user: conn_meta
+                            .as_ref()
+                            .map(|c| c.user.clone())
+                            .unwrap_or_default(),
+                        version: conn_meta
+                            .as_ref()
+                            .map(|c| c.version.clone())
+                            .unwrap_or_default(),
+                        ssh_ip: conn_meta.as_ref().and_then(|c| c.ssh_ip.clone()),
                         cols,
                         rows,
                     });
@@ -863,17 +909,21 @@ pub async fn run_gateway(
             async move {
                 let channels = {
                     let chans = state.channels.read().await;
-                    let mut v: Vec<(ChannelName, Arc<Mutex<ChannelState>>)> =
-                        chans.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                    drop(chans);
-                    v.sort_by_key(|a| a.0.to_string());
-                    v
+                    chans
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect::<Vec<_>>()
                 };
-                let mut out = Vec::with_capacity(channels.len());
+                // Creation order, newest last (monotonic `created_seq`, not
+                // second-resolution wall clock). The seq is read under the same
+                // per-channel lock used to build `ChannelInfo` below.
+                let mut out: Vec<(u64, ChannelInfo)> = Vec::with_capacity(channels.len());
                 for (name, ch) in channels {
                     let guard = ch.lock().await;
-                    out.push(guard.to_info(&name));
+                    out.push((guard.created_seq, guard.to_info(&name)));
                 }
+                out.sort_by_key(|(seq, _)| *seq);
+                let out: Vec<ChannelInfo> = out.into_iter().map(|(_, info)| info).collect();
                 ListChannels::encode_response(ListChannelsResponse {
                     gateway_pid: std::process::id() as u64,
                     socket,
@@ -997,10 +1047,33 @@ pub async fn run_gateway(
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
     let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
     endpoint
-        .register_prebuffered(ShutdownGateway::METHOD_ID, move |_payload, _ctx| {
+        .register_prebuffered(ShutdownGateway::METHOD_ID, move |payload, _ctx| {
             let state = Arc::clone(&st);
             let shutdown_tx = Arc::clone(&shutdown_tx);
             async move {
+                // Refuse an accidental shutdown while live sessions are running
+                // unless the caller explicitly forced it. Checked BEFORE the
+                // `is_shutting_down` seal so a refused stop leaves the gateway
+                // fully operational (no half-sealed state, no orphaned teardown).
+                let force = ShutdownGateway::decode_request(&payload).map_err(boxed_io)?;
+                if !force {
+                    let live = {
+                        let chans = state.channels.read().await;
+                        let mut n = 0usize;
+                        for ch in chans.values() {
+                            let guard = ch.lock().await;
+                            if guard.session.as_ref().is_some_and(|s| !s.exited) {
+                                n += 1;
+                            }
+                        }
+                        n
+                    };
+                    if live > 0 {
+                        return Err(rpc_err(&format!(
+                            "{RPC_ERROR_LIVE_SESSIONS} ({live} live session(s))"
+                        )));
+                    }
+                }
                 // Atomic seal: reject all further RPCs before teardown starts.
                 state.is_shutting_down.store(true, Ordering::SeqCst);
                 // Snapshot the channels, then release the map lock.
@@ -1061,6 +1134,9 @@ pub async fn run_gateway(
                         hostname: String::new(),
                         connected_at_unix: now_unix(),
                         pid: 0,
+                        user: String::new(),
+                        version: String::new(),
+                        ssh_ip: None,
                     });
                 }
                 RpcIpcServerEvent::ClientDisconnected(conn_id) => {

--- a/crates/term-session/README.md
+++ b/crates/term-session/README.md
@@ -11,13 +11,21 @@ Its clients render in **alternate-screen mode** (a full-screen TUI): the attache
 Build and run from source (Rust 1.85+, edition 2024; no extra toolchain needed):
 
 ```sh
-cargo run --release --bin term-session -- attach                          # attach to default/main, auto-spawning the gateway
-cargo run --release --bin term-session -- attach --channel work -- vim    # attach to (or spawn) the "work" channel
-cargo run --release --bin term-session -- list                            # list channels, sessions, and connected sockets
-cargo run --release --bin term-session -- kill-client work 4              # detach client conn 4 from the "work" channel
-cargo run --release --bin term-session -- kill work                       # kill the "work" channel's session + sockets
-cargo run --release --bin term-session -- stop                            # stop the gateway daemon
+cargo run --release --bin term-session -- --channel work -- vim -l           # attach to (or spawn) the "work" channel, running vim -l
+cargo run --release --bin term-session -- --channel work                    # attach to (or spawn) the "work" channel (default shell)
+cargo run --release --bin term-session -- -- git log --oneline              # attach to the default channel, running git log --oneline
+cargo run --release --bin term-session -- list                              # list channels, sessions, and connected sockets
+cargo run --release --bin term-session -- kill-client work 4                # detach client conn 4 from the "work" channel
+cargo run --release --bin term-session -- kill work                         # kill the "work" channel's session + sockets
+cargo run --release --bin term-session -- stop                              # stop the gateway daemon
+cargo run --release --bin term-session -- stop --force                      # stop even while live sessions are running
 ```
+
+Running `term-session` with **no subcommand and no arguments** prints the help menu and exits (code 2) — it never auto-connects on its own. Giving a channel (`--channel <name>`) and/or a command attaches implicitly: the channel and command are the session to join or spawn, and the gateway daemon is auto-started if none is running.
+
+The command is passed as trailing arguments after `--` (the POSIX end-of-options delimiter), exactly like `sudo --` or `cargo run --`: anything after `--` is handed to the spawned process as its `argv` without extra shell parsing, so flags and spaces need no quoting. Anything before `--` is `term-session`'s own option; a token before `--` that matches a subcommand name (e.g. `list`, `kill`, `stop`) is always the subcommand — use `--` to run a program with that name instead.
+
+**A command is honored only when the channel has no live session** (or its session has exited) — it then becomes the command the channel spawns/respawns. Attaching to a channel with a **running** session ignores the command entirely: you join the existing process, sharing its live viewport with every other attached client (like `tmux`/`screen`).
 
 Multiple terminals can attach to the same channel to share one session.
 
@@ -27,7 +35,8 @@ Multiple terminals can attach to the same channel to share one session.
 
 * **One process, many channels:** a single daemon supervises all PTY sessions; no per-channel server process.
 * **Server-assigned identity:** a client's `conn_id` is assigned by the gateway at connect time; channel binding is server-side and authoritative — a client can only reach the channel it attached to.
-* **Admin CLI:** `list` dumps every channel's session status (PTY cols×rows, exited state) and each connected socket (`conn_id`, hostname, connect time, physical terminal size). `kill` terminates a channel's session/process tree; `kill-client <channel> <CLIENT_ID>` detaches a single socket by its `conn_id` (from `list`). `stop` performs an orderly daemon shutdown.
+* **Admin CLI:** `list` dumps every channel's session status (PTY cols×rows, exited state) and each connected socket (`conn_id`, hostname, OS user, client binary version, connect time, physical terminal size). Channels and their clients are listed in **creation order (newest last)**. `kill` terminates a channel's session/process tree; `kill-client <channel> <CLIENT_ID>` detaches a single socket by its `conn_id` (from `list`). `stop` performs an orderly daemon shutdown — it **refuses while any live session is running** unless `--force` is given.
+  - The OS user and binary version are reported by each client at `Attach`. The **remote SSH IP** (`ssh ip from:` in the per-client output) is the client's peer address, read from the `SSH_CLIENT` / `SSH_CONNECTION` environment variables that `sshd` sets — it is omitted for local (non-SSH) attaches.
 * **Muxio IPC:** PTY state and RPCs travel over the Muxio IPC framework with Bitcode serialization over OS-native transports (Linux abstract sockets, macOS `/tmp`, Windows named pipes). The gateway socket name is deterministic (`term-wm/<user>/gateway`) and can be overridden at runtime via `TERM_WM_GATEWAY`.
 * **Shared Mechanics:** Reuses a large part of `term-wm`'s internals — the PTY engine (`term-wm-pty-engine`: spawning, scrollback tracking, `vt100` parsing), the input event types (`term-wm-events`), and the crossterm input adapter (`term-wm-crossterm-adapter`). `term-session` does **not** produce the window manager: there is no layout engine, no tiling, and no window chrome — only the persistence and multiplexing layer.
 
@@ -47,7 +56,7 @@ Always stop the running daemon using the **currently installed** binary before r
 ```sh
 term-session stop       # 1. Stop the running v_old daemon
 cargo install --path .  # 2. Install the v_new binary on PATH
-term-session attach     # 3. Auto-spawn the v_new daemon
+term-session --channel work   # 3. Auto-spawn the v_new daemon and attach
 ```
 
 ### Recovery if Binary is Replaced First
@@ -68,7 +77,7 @@ To deploy a persistent, tiling terminal workspace, run `term-wm` as a child proc
 
 ## Session Nesting
 
-Invoking `term-session attach` inside a shell that is already running within an active `term-session` client (session inception) is discouraged due to operational tradeoffs:
+Invoking a `term-session` client (e.g. `term-session --channel work`) inside a shell that is already running within an active `term-session` client (session inception) is discouraged due to operational tradeoffs:
 
 - **TUI Buffer Conflicts:** Both the inner and outer clients manipulate terminal raw mode and the alternate screen buffer (`smcup`/`rmcup`). An unhandled exit or panic in the nested client can leave the outer viewport in a corrupted terminal state, requiring a manual reset or clear.
 - **Daemon Scope Ambiguity:** Unless overridden via `TERM_WM_GATEWAY`, both the outer session and inner nested client communicate with the same gateway daemon. Running `term-session stop` from inside a nested session will shut down the gateway hosting both the inner and outer sessions.
@@ -76,7 +85,7 @@ Invoking `term-session attach` inside a shell that is already running within an 
 
 ## Scrolling and Text Selection
 
-The standalone `term-session attach` client runs the terminal in **alternate-screen mode** (`smcup`), the standard full-screen TUI convention. On most terminal emulators the alternate screen carries **no native scrollback**, so the host terminal's built-in scroll wheel/scrollbar does not capture the session's output. This is deliberate: a full-screen TUI owns its viewport and must not be conflated with the terminal's main-screen history, so `term-session` does **not** implement scrollback for its remote clients — `term-session attach` renders only the current viewport of the shared PTY.
+The standalone `term-session` client (e.g. `term-session --channel work`) runs the terminal in **alternate-screen mode** (`smcup`), the standard full-screen TUI convention. On most terminal emulators the alternate screen carries **no native scrollback**, so the host terminal's built-in scroll wheel/scrollbar does not capture the session's output. This is deliberate: a full-screen TUI owns its viewport and must not be conflated with the terminal's main-screen history, so `term-session` does **not** implement scrollback for its remote clients — the client renders only the current viewport of the shared PTY.
 
 Scrollback is the host integration's responsibility. `term-session` is designed to work alongside [term-wm](https://crates.io/crates/term-wm), which provides its own scrollback handling for its windows. If you run `term-wm` inside a `term-session` session (the recommended integration above), scrolling is handled by the window manager rather than the session layer. Standalone `term-session` clients that need in-terminal scrollback are not supported.
 

--- a/crates/term-session/src/lib.rs
+++ b/crates/term-session/src/lib.rs
@@ -62,7 +62,7 @@ where
                 io::Error::new(
                     io::ErrorKind::ConnectionRefused,
                     format!(
-                        "No gateway daemon is running on '{gateway}'. Start one with `term-session attach` or `term-session --daemon` first.\n  cause: {e}"
+                        "No gateway daemon is running on '{gateway}'. Start one with `term-session --channel <name>` or `term-session --daemon` first.\n  cause: {e}"
                     ),
                 )
             })?;
@@ -91,8 +91,11 @@ pub fn kill_client(channel: &str, conn_id: usize) -> io::Result<()> {
 }
 
 /// Stop the gateway daemon.
-pub fn stop_gateway() -> io::Result<()> {
-    with_gateway(|client| async move { ShutdownGateway::call(&*client, ()).await })?
+///
+/// The daemon refuses to shut down while any live session is running unless
+/// `force` is true (see `RPC_ERROR_LIVE_SESSIONS`).
+pub fn stop_gateway(force: bool) -> io::Result<()> {
+    with_gateway(|client| async move { ShutdownGateway::call(&*client, force).await })?
         .map_err(|e| io::Error::other(format!("shutdown: {e}")))
 }
 

--- a/crates/term-session/src/main.rs
+++ b/crates/term-session/src/main.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use term_session::auto_spawn::connect_or_spawn_server;
 use term_session_client::run_session;
 use term_session_muxio_service_definitions::ChannelName;
@@ -22,34 +22,32 @@ struct Cli {
     #[arg(long, hide = true)]
     daemon: bool,
 
-    /// Override the gateway channel name (env TERM_WM_GATEWAY also works).
-    #[arg(long)]
-    gateway: Option<String>,
-
     /// Test-only: write a marker file with the platform's detachment proof
     /// once the daemon has bound, then exit.
     #[arg(long, hide = true)]
     daemon_selfcheck: Option<std::path::PathBuf>,
 
     /// Channel name (namespace/name); falls back to TERM_WM_CHANNEL env, then "default/main".
-    #[arg(short, long)]
+    /// Implicitly attaches when given without a subcommand.
+    #[arg(long)]
     channel: Option<String>,
 
     /// Command to run (and its arguments); if omitted, launches the default shell.
+    /// Anything after `--` is passed straight through as the spawned argv
+    /// (e.g. `--channel work -- git log --oneline`). Only used when the channel
+    /// has no live session; attaching to a running session ignores the command
+    /// and joins the existing process. Implicitly attaches when given without
+    /// a subcommand.
     #[arg(value_name = "CMD", num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
     cmd: Vec<String>,
+
+    /// Override the gateway channel name (env TERM_WM_GATEWAY also works).
+    #[arg(long)]
+    gateway: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Attach to a channel (default when no subcommand given).
-    #[command(name = "attach")]
-    Attach {
-        #[arg(short, long)]
-        channel: Option<String>,
-        #[arg(value_name = "CMD", num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
-        cmd: Vec<String>,
-    },
     /// List channels and their sessions/clients.
     #[command(name = "ls", alias = "list")]
     List,
@@ -71,10 +69,24 @@ enum Command {
     },
     /// Stop the gateway daemon.
     #[command(name = "stop")]
-    Stop,
+    Stop {
+        /// Stop even if live sessions are running (otherwise the gateway
+        /// refuses while any session is active).
+        #[arg(long)]
+        force: bool,
+    },
 }
 
-fn main() -> io::Result<()> {
+fn main() {
+    // Print errors as readable messages (Display), not Rust's Debug dump that
+    // `main() -> Result` emits by default (e.g. `Custom { kind: ..., ... }`).
+    if let Err(e) = run() {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> io::Result<()> {
     let cli = Cli::parse();
 
     // Gateway name resolution: explicit --gateway wins; else TERM_WM_GATEWAY
@@ -90,7 +102,6 @@ fn main() -> io::Result<()> {
     }
 
     match cli.command {
-        Some(Command::Attach { channel, cmd }) => attach(channel, &cmd),
         Some(Command::List) => list(),
         Some(Command::Kill {
             channel,
@@ -101,8 +112,22 @@ fn main() -> io::Result<()> {
             println!("Detached client {client_id} from channel {channel}");
             Ok(())
         }
-        Some(Command::Stop) => stop(),
-        None => attach(cli.channel, &cli.cmd),
+        Some(Command::Stop { force }) => stop(force),
+        None => {
+            if cli.channel.is_some() || !cli.cmd.is_empty() {
+                // A channel and/or command was given without a subcommand:
+                // implicit attach.
+                attach(cli.channel, &cli.cmd)
+            } else {
+                // No subcommand and nothing to attach: show help instead of
+                // auto-connecting (exit code 2, the clap missing-argument
+                // convention). `--daemon` is handled above. Long help so it
+                // matches `--help` exactly (version + long_about).
+                let mut stderr = io::stderr();
+                let _ = Cli::command().write_long_help(&mut stderr);
+                std::process::exit(2);
+            }
+        }
     }
 }
 
@@ -111,6 +136,8 @@ fn attach(channel: Option<String>, cmd: &[String]) -> io::Result<()> {
     let channel = ChannelName::parse(&channel_str).map_err(|e| {
         io::Error::new(io::ErrorKind::InvalidInput, format!("Invalid channel: {e}"))
     })?;
+    // The argv comes straight from the outer shell (split exactly once);
+    // the server spawns it directly, no shell involved there.
     let socket_name = connect_or_spawn_server(None)?;
     run_session(&socket_name, &channel.to_string(), cmd)
 }
@@ -152,6 +179,11 @@ fn list() -> io::Result<()> {
         );
         for c in &ch.clients {
             println!("    - conn: {}  (pid {})", c.conn_id, c.pid);
+            println!("      user: {}", c.user);
+            println!("      version: {}", c.version);
+            if let Some(ip) = &c.ssh_ip {
+                println!("      ssh ip from: {}", ip);
+            }
             println!("      host: {}", c.hostname);
             println!("      size: {}x{}", c.cols, c.rows);
             println!(
@@ -169,8 +201,8 @@ fn kill(channel: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn stop() -> io::Result<()> {
-    term_session::stop_gateway()?;
-    println!("Gateway shutdown initiated");
+fn stop(force: bool) -> io::Result<()> {
+    term_session::stop_gateway(force)?;
+    println!("Gateway shutdown initiated.");
     Ok(())
 }

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
-use term_session_muxio_service_definitions::{Attach, ListChannels, ShutdownGateway, Spawn};
+use term_session_muxio_service_definitions::{
+    Attach, AttachRequest, ChannelName, ListChannels, ShutdownGateway, Spawn, probe_ipc_endpoint,
+};
 
 /// The compiled `term-session` binary under test.
 fn bin() -> PathBuf {
@@ -58,6 +60,28 @@ fn spawn_daemon(gateway: &str, selfcheck: bool) -> (Child, Option<PathBuf>) {
     (child, marker)
 }
 
+/// Attach a client to a channel and return its server-assigned conn id,
+/// using the mock identity fields the other helpers expect.
+async fn attach_to(
+    client: &muxio_tokio_rpc_ipc_client::RpcIpcClient,
+    channel: &str,
+    hostname: &str,
+) -> usize {
+    Attach::call(
+        client,
+        AttachRequest {
+            channel: channel.to_string(),
+            hostname: hostname.to_string(),
+            pid: std::process::id() as u64,
+            user: "test-user".to_string(),
+            version: "test-version".to_string(),
+            ssh_ip: None,
+        },
+    )
+    .await
+    .expect("attach")
+}
+
 /// Poll until a client can connect to the gateway, or panic after a timeout.
 async fn wait_connectable(gateway: &str) -> Arc<muxio_tokio_rpc_ipc_client::RpcIpcClient> {
     let start = Instant::now();
@@ -99,7 +123,7 @@ async fn daemon_detaches_and_reports_proof() {
 
     // Clean up.
     let client = wait_connectable(&gateway).await;
-    ShutdownGateway::call(&*client, ()).await.unwrap();
+    ShutdownGateway::call(&*client, true).await.unwrap();
     let _ = child.wait();
 }
 
@@ -110,16 +134,7 @@ async fn daemon_survives_all_clients_disconnecting() {
 
     let client = wait_connectable(&gateway).await;
     let channel = "test/daemon_survive";
-    Attach::call(
-        &*client,
-        (
-            channel.to_string(),
-            "t".to_string(),
-            std::process::id() as u64,
-        ),
-    )
-    .await
-    .unwrap();
+    attach_to(&client, channel, "t").await;
     Spawn::call(
         &*client,
         (
@@ -139,19 +154,10 @@ async fn daemon_survives_all_clients_disconnecting() {
     // After ALL clients disconnect, the daemon must still be reachable and a
     // fresh attach/spawn must succeed (session respawns / persists).
     let client2 = wait_connectable(&gateway).await;
-    Attach::call(
-        &*client2,
-        (
-            channel.to_string(),
-            "t".to_string(),
-            std::process::id() as u64,
-        ),
-    )
-    .await
-    .unwrap();
+    attach_to(&client2, channel, "t").await;
     Spawn::call(&*client2, (None, 80u16, 24u16)).await.unwrap();
 
-    ShutdownGateway::call(&*client2, ()).await.unwrap();
+    ShutdownGateway::call(&*client2, true).await.unwrap();
     let _ = child.wait();
 }
 
@@ -161,48 +167,31 @@ async fn daemon_survives_parent_death() {
     let channel = "test/daemon_parent_death";
     let mock = mock_bin().to_string_lossy().to_string();
 
-    // Spawn an `attach` subprocess that auto-spawns the daemon, running a
-    // LONG-LIVED session so its process survives the parent dying.
-    let mut attach = Command::new(bin())
+    // Spawn a client that auto-spawns the daemon, running a LONG-LIVED
+    // session so its process survives the parent dying.
+    let mut client = Command::new(bin())
         .env("TERM_WM_GATEWAY", &gateway)
-        .args([
-            "attach",
-            "--channel",
-            channel,
-            "--",
-            &mock,
-            "sleep",
-            "60000",
-        ])
+        .args(["--channel", channel, "--", &mock, "sleep", "60000"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn attach");
+        .expect("spawn auto-attach client");
 
     // Give it time to auto-spawn the daemon and attach.
     tokio::time::sleep(Duration::from_millis(2000)).await;
-    let _ = attach.kill();
-    let _ = attach.wait();
+    let _ = client.kill();
+    let _ = client.wait();
 
     // The daemon it spawned must still be reachable and the session alive
     // (the `sleep` process is still running, so the daemon must not have
     // exited — sessions are torn down only when their process ends).
     let client = wait_connectable(&gateway).await;
-    Attach::call(
-        &*client,
-        (
-            channel.to_string(),
-            "t".to_string(),
-            std::process::id() as u64,
-        ),
-    )
-    .await
-    .unwrap();
+    attach_to(&client, channel, "t").await;
     let (id, _, _) = Spawn::call(&*client, (None, 80u16, 24u16)).await.unwrap();
     assert_eq!(id, 1, "session from the orphaned daemon must persist");
 
-    ShutdownGateway::call(&*client, ()).await.unwrap();
+    ShutdownGateway::call(&*client, true).await.unwrap();
     // Give the daemon time to run its teardown and exit.
     tokio::time::sleep(Duration::from_millis(1000)).await;
 }
@@ -250,7 +239,7 @@ async fn daemon_does_not_inherit_parent_handles() {
 
     // Clean up the daemon.
     let client = wait_connectable(&gateway).await;
-    ShutdownGateway::call(&*client, ()).await.unwrap();
+    ShutdownGateway::call(&*client, true).await.unwrap();
 }
 
 /// Create an inheritable named pipe whose read end we keep. Both ends are
@@ -414,26 +403,8 @@ async fn cli_kill_client_detaches_one_client() {
     // Two attached clients on the same channel.
     let c1 = wait_connectable(&gateway).await;
     let c2 = wait_connectable(&gateway).await;
-    Attach::call(
-        &*c1,
-        (
-            channel.to_string(),
-            "one".to_string(),
-            std::process::id() as u64,
-        ),
-    )
-    .await
-    .unwrap();
-    Attach::call(
-        &*c2,
-        (
-            channel.to_string(),
-            "two".to_string(),
-            std::process::id() as u64,
-        ),
-    )
-    .await
-    .unwrap();
+    attach_to(&c1, channel, "one").await;
+    attach_to(&c2, channel, "two").await;
     Spawn::call(
         &*c1,
         (
@@ -485,6 +456,232 @@ async fn cli_kill_client_detaches_one_client() {
         "one client should remain after kill-client"
     );
 
-    ShutdownGateway::call(&*c1, ()).await.unwrap();
+    ShutdownGateway::call(&*c1, true).await.unwrap();
+    let _ = child.wait();
+}
+
+#[test]
+fn bare_term_session_shows_help_and_does_not_connect() {
+    let gateway = unique_gateway("bare");
+    let out = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .output()
+        .expect("run bare term-session");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "bare run must exit 2 (help, not auto-connect), got: {:?}",
+        out.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--channel"),
+        "help should mention --channel, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("list"),
+        "help should list list, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("stop"),
+        "help should list stop, got: {stderr}"
+    );
+    // A bare run must NOT have auto-spawned a daemon on the gateway.
+    let gw = ChannelName::parse(&gateway).expect("gateway name");
+    assert!(
+        !probe_ipc_endpoint(&gw),
+        "bare run must not auto-spawn a daemon"
+    );
+}
+
+#[tokio::test]
+async fn top_level_channel_auto_attaches() {
+    let gateway = unique_gateway("autoattach");
+    let channel = "test/autoattach";
+    let mock = mock_bin().to_string_lossy().to_string();
+    // `term-session --channel <ch> -- <mock> sleep 60000` (no subcommand):
+    // giving a channel must still auto-attach and auto-spawn the daemon.
+    let mut client = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .args(["--channel", channel, "--", &mock, "sleep", "60000"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn auto-attach client");
+
+    // The auto-spawned daemon becomes reachable and hosts a live session.
+    let rpc = wait_connectable(&gateway).await;
+    let start = Instant::now();
+    loop {
+        let resp = ListChannels::call(&*rpc, ()).await.unwrap();
+        let live = resp
+            .channels
+            .iter()
+            .any(|c| c.name == channel && c.session.as_ref().is_some_and(|s| !s.exited));
+        if live {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(20),
+            "session never appeared on the auto-attached channel"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Cleanup: kill the client process; the daemon (and its live session)
+    // survives, so stop it explicitly with force.
+    let _ = client.kill();
+    let _ = client.wait();
+    ShutdownGateway::call(&*rpc, true).await.unwrap();
+}
+
+#[tokio::test]
+async fn dash_dash_disambiguates_command_from_subcommand() {
+    let gateway = unique_gateway("disambig");
+    let gw = ChannelName::parse(&gateway).expect("gateway name");
+
+    // `term-session list` (no `--`) parses `list` as the admin SUBCOMMAND: it
+    // connects to a gateway and never auto-spawns one.
+    let out = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .arg("list")
+        .output()
+        .expect("run list");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("No gateway"),
+        "`list` must parse as the admin subcommand, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !probe_ipc_endpoint(&gw),
+        "admin subcommand must not auto-spawn"
+    );
+
+    // `term-session -- list` (after `--`) parses `list` as a COMMAND to run:
+    // the implicit attach path auto-spawns a gateway.
+    let mut client = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .args(["--", "list"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("run -- list");
+
+    // The auto-spawned gateway becomes reachable (the `list` command itself
+    // does not exist, so the session spawn fails — but the daemon persists).
+    let rpc = wait_connectable(&gateway).await;
+    ShutdownGateway::call(&*rpc, true).await.unwrap();
+    let _ = client.kill();
+    let _ = client.wait();
+}
+
+#[tokio::test]
+async fn cli_list_renders_client_identity() {
+    let gateway = unique_gateway("list_identity");
+    let channel = "test/list_identity";
+    let (mut daemon, _marker) = spawn_daemon(&gateway, false);
+
+    // A client that stays connected, with explicit identity fields.
+    let client = wait_connectable(&gateway).await;
+    Attach::call(
+        &*client,
+        AttachRequest {
+            channel: channel.to_string(),
+            hostname: "render-host".to_string(),
+            pid: 4242,
+            user: "bob".to_string(),
+            version: "v7".to_string(),
+            ssh_ip: Some("203.0.113.9".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    Spawn::call(&*client, (None, 80u16, 24u16)).await.unwrap();
+
+    let out = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .arg("list")
+        .output()
+        .expect("run list");
+    assert!(
+        out.status.success(),
+        "list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("user: bob"),
+        "list must render the client user, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("version: v7"),
+        "list must render the client version, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("ssh ip from: 203.0.113.9"),
+        "list must render the remote ssh ip, got: {stdout}"
+    );
+
+    ShutdownGateway::call(&*client, true).await.unwrap();
+    let _ = daemon.wait();
+}
+
+#[tokio::test]
+async fn cli_stop_requires_force_when_live_sessions() {
+    let gateway = unique_gateway("stop_force");
+    let channel = "test/stop_force";
+    let (mut child, _marker) = spawn_daemon(&gateway, false);
+
+    let client = wait_connectable(&gateway).await;
+    attach_to(&client, channel, "cli").await;
+    Spawn::call(
+        &*client,
+        (
+            Some(vec![
+                mock_bin().to_string_lossy().to_string(),
+                "sleep".into(),
+                "60000".into(),
+            ]),
+            80u16,
+            24u16,
+        ),
+    )
+    .await
+    .unwrap();
+
+    // `stop` without --force: refused, non-zero exit, daemon keeps running.
+    let out = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .arg("stop")
+        .output()
+        .expect("run stop");
+    assert!(
+        !out.status.success(),
+        "stop must refuse while a live session runs"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("live session"),
+        "refusal message should mention live sessions, got: {stderr}"
+    );
+
+    // Gateway still reachable after the refusal.
+    ListChannels::call(&*client, ())
+        .await
+        .expect("gateway alive");
+
+    // `stop --force` succeeds and the daemon process exits on its own.
+    let out = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .args(["stop", "--force"])
+        .output()
+        .expect("run stop --force");
+    assert!(
+        out.status.success(),
+        "stop --force failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let _ = child.wait();
 }

--- a/tests/common/session.rs
+++ b/tests/common/session.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use muxio_tokio_rpc_ipc_client::{RpcCallPrebuffered, RpcIpcClient};
-use term_session_muxio_service_definitions::{Attach, ChannelName, ListChannels, ShutdownGateway};
+use term_session_muxio_service_definitions::{
+    Attach, AttachRequest, ChannelName, ListChannels, ShutdownGateway,
+};
 use term_session_server::run_gateway;
 
 pub const TEST_COLS: u16 = 80;
@@ -106,11 +108,14 @@ pub async fn connect_client_with_retry(socket_path: &str) -> Arc<RpcIpcClient> {
 pub async fn attach_client(client: &RpcIpcClient, channel: &ChannelName) -> usize {
     Attach::call(
         client,
-        (
-            channel.to_string(),
-            "test-host".to_string(),
-            std::process::id() as u64,
-        ),
+        AttachRequest {
+            channel: channel.to_string(),
+            hostname: "test-host".to_string(),
+            pid: std::process::id() as u64,
+            user: "test-user".to_string(),
+            version: "test-version".to_string(),
+            ssh_ip: None,
+        },
     )
     .await
     .expect("attach")
@@ -165,7 +170,7 @@ pub async fn list_channels(
 
 /// Stop the gateway daemon.
 pub async fn shutdown_gateway(client: &Arc<RpcIpcClient>) {
-    ShutdownGateway::call(&**client, ())
+    ShutdownGateway::call(&**client, true)
         .await
         .expect("shutdown");
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -4,8 +4,8 @@ use serial_test::serial;
 use std::sync::Arc;
 use std::time::Duration;
 use term_session_muxio_service_definitions::{
-    CloseSession, KillChannel, KillClient, ResizePty, STREAM_INPUT_METHOD_ID,
-    SUBSCRIBE_OUTPUT_METHOD_ID, Spawn,
+    Attach, AttachRequest, CloseSession, KillChannel, KillClient, ResizePty,
+    STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, ShutdownGateway, Spawn,
 };
 
 mod common;
@@ -963,6 +963,55 @@ async fn spawn_idempotent_on_live_session() {
 
 #[tokio::test]
 #[serial]
+async fn spawn_cmd_ignored_on_live_session() {
+    let mock = get_mock_bin();
+    let (client, _conn_id, guard) = spawn_session(&test_channel("test/cmd_ignored")).await;
+    Spawn::call(
+        &*client,
+        (
+            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            TEST_COLS,
+            TEST_ROWS,
+        ),
+    )
+    .await
+    .unwrap();
+
+    // A second client joins the live session with a DIFFERENT cmd (`exit 0`).
+    // If honored, the session would terminate immediately; instead it must be
+    // ignored and the original `sleep` process kept running.
+    let c2 = connect_client_with_retry(guard.socket()).await;
+    attach_client(&c2, &test_channel("test/cmd_ignored")).await;
+    let (id2, _, _) = Spawn::call(
+        &*c2,
+        (
+            Some(vec![mock, "exit".into(), "0".into()]),
+            TEST_COLS,
+            TEST_ROWS,
+        ),
+    )
+    .await
+    .unwrap();
+
+    // Give a would-be `exit` time to take effect: the session must still be
+    // live, proving the command was ignored and the original process survived.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let resp = list_channels(&client).await;
+    let ch = resp
+        .channels
+        .iter()
+        .find(|c| c.name == "test/cmd_ignored")
+        .expect("channel listed");
+    assert!(
+        ch.session.as_ref().is_some_and(|s| !s.exited),
+        "session must stay alive when a different cmd is supplied"
+    );
+    assert_eq!(id2, 1, "reused session id");
+    guard.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn session_multi_client_pty_constrained_to_smallest() {
     let mock = get_mock_bin();
     let guard = spawn_gateway().await;
@@ -1088,5 +1137,166 @@ async fn shutdown_gateway_stops_daemon() {
     // assert the ShutdownGateway call returned cleanly (the RPC response was
     // flushed before the daemon exited).
     // Give the daemon a moment to actually terminate.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn list_channels_orders_channels_and_clients_by_creation() {
+    let mock = get_mock_bin();
+    let guard = spawn_gateway().await;
+    let socket = guard.socket().to_string();
+
+    // Channel A is created before B; channel order must be [A, B], newest last.
+    let ca = connect_client_with_retry(&socket).await;
+    let cb = connect_client_with_retry(&socket).await;
+    attach_client(&ca, &test_channel("test/order_a")).await;
+    attach_client(&cb, &test_channel("test/order_b")).await;
+    Spawn::call(
+        &*ca,
+        (
+            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            TEST_COLS,
+            TEST_ROWS,
+        ),
+    )
+    .await
+    .unwrap();
+    Spawn::call(
+        &*cb,
+        (
+            Some(vec![mock, "sleep".into(), "60000".into()]),
+            TEST_COLS,
+            TEST_ROWS,
+        ),
+    )
+    .await
+    .unwrap();
+
+    // A second client attaches to channel A AFTER B was created. Its conn_id
+    // is higher, so it must sort after A's first client. (A client only shows
+    // up in `list` once it has Spawned, so spawn it too.)
+    let ca2 = connect_client_with_retry(&socket).await;
+    attach_client(&ca2, &test_channel("test/order_a")).await;
+    Spawn::call(&*ca2, (None, TEST_COLS, TEST_ROWS))
+        .await
+        .unwrap();
+
+    let resp = list_channels(&ca).await;
+    let names: Vec<&str> = resp.channels.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["test/order_a", "test/order_b"],
+        "channels must be in creation order, newest last: {names:?}"
+    );
+
+    let ch_a = resp
+        .channels
+        .iter()
+        .find(|c| c.name == "test/order_a")
+        .expect("channel a listed");
+    assert_eq!(ch_a.clients.len(), 2, "two clients on channel a");
+    assert!(
+        ch_a.clients[0].conn_id < ch_a.clients[1].conn_id,
+        "clients must be in connection order, newest last"
+    );
+
+    guard.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn list_channels_reports_client_identity() {
+    let guard = spawn_gateway().await;
+    let channel = test_channel("test/client_identity");
+    let client = connect_client_with_retry(guard.socket()).await;
+    Attach::call(
+        &*client,
+        AttachRequest {
+            channel: channel.to_string(),
+            hostname: "host-a".to_string(),
+            pid: 1234,
+            user: "alice".to_string(),
+            version: "9.9.9".to_string(),
+            ssh_ip: Some("192.168.1.50".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    Spawn::call(&*client, (None, TEST_COLS, TEST_ROWS))
+        .await
+        .unwrap();
+
+    let resp = list_channels(&client).await;
+    let ch = resp
+        .channels
+        .iter()
+        .find(|c| c.name == "test/client_identity")
+        .expect("channel listed");
+    assert_eq!(ch.clients.len(), 1);
+    let c = &ch.clients[0];
+    assert_eq!(
+        c.user, "alice",
+        "user reported at Attach must surface in list"
+    );
+    assert_eq!(
+        c.version, "9.9.9",
+        "version reported at Attach must surface in list"
+    );
+    assert_eq!(
+        c.ssh_ip.as_deref(),
+        Some("192.168.1.50"),
+        "ssh_ip reported at Attach must surface in list"
+    );
+    guard.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn shutdown_refuses_without_force_when_live_sessions() {
+    let mock = get_mock_bin();
+    let guard = spawn_gateway().await;
+    let client = connect_client_with_retry(guard.socket()).await;
+    attach_client(&client, &test_channel("test/force")).await;
+    Spawn::call(
+        &*client,
+        (
+            Some(vec![mock, "sleep".into(), "60000".into()]),
+            TEST_COLS,
+            TEST_ROWS,
+        ),
+    )
+    .await
+    .unwrap();
+
+    // Without force: refused, and the gateway must stay fully operational.
+    let err = ShutdownGateway::call(&*client, false)
+        .await
+        .expect_err("stop without force while a live session runs must fail");
+    assert!(
+        err.to_string().contains("live session"),
+        "refusal message should mention live sessions, got: {err}"
+    );
+
+    // Still reachable after the refusal.
+    let resp = list_channels(&client).await;
+    assert_eq!(
+        resp.channels.len(),
+        1,
+        "gateway still serving after refusal"
+    );
+
+    // With force: clean shutdown.
+    ShutdownGateway::call(&*client, true).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn shutdown_without_force_succeeds_when_no_live_sessions() {
+    let guard = spawn_gateway().await;
+    let client = connect_client_with_retry(guard.socket()).await;
+    // No sessions were ever spawned: stop must succeed without --force.
+    ShutdownGateway::call(&*client, false).await.unwrap();
     tokio::time::sleep(Duration::from_millis(200)).await;
 }


### PR DESCRIPTION
### Added

- **`term-session` CLI hardening — bare run shows help:** running `term-session` with no subcommand and no arguments prints the help menu and exits (code 2) instead of auto-connecting; the redundant `attach` subcommand was removed. A channel (`--channel <name>`) and/or a command still attach implicitly and auto-start the gateway.
- **Idiomatic command passing via `--`:** the command is now trailing positional args after the POSIX end-of-options delimiter (like `sudo --` / `cargo run --`), so `term-session --channel work -- git log --oneline` passes flags through untouched, and a token before `--` that matches a subcommand name is always the subcommand. The argv comes straight from the outer shell (no re-parsing). `--channel` is long-only — the ambiguous `-c` short flag was removed.
- **`stop --force` (server-enforced):** `ShutdownGateway` now carries a `force` flag; the gateway **refuses to shut down while any live session is running** unless `--force` is given (`RPC_ERROR_LIVE_SESSIONS`), and a refused stop leaves the daemon fully operational.
- **Client identity in `list`:** each connected socket now reports its OS user, client binary version, and (for SSH attaches) the remote peer IP (`ssh ip from:` — read from the `SSH_CLIENT` / `SSH_CONNECTION` env vars `sshd` sets, omitted for local attaches).
- **Creation-order listing:** `list` now returns channels and their clients in **creation order (newest last)** via a monotonic per-channel sequence and connection-ordered conn ids.
- **Readable CLI errors:** errors print as plain `error: …` messages instead of Rust's `Debug` dump (previously `Custom { kind: …, … }`).

### Changed

- `Attach` RPC input is now the structured `AttachRequest` (channel, hostname, pid, user, version, ssh_ip) rather than a bare tuple; `ClientInfo` gains the identity fields. Windows user resolution falls back to `GetUserNameW` when `%USERNAME%` is unset.
- Docs: `term-session` README updated for the bare-run help, `--` command passing, `stop --force`, creation-order listing, and per-client identity.