### PR TITLE
fix: Multi-window run commands and tile balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.7-alpha] - 2026-08-03
+
+### Added
+
+- **`term-wm` multi-window commands:** a repeatable `-r, --run <CMD>` flag opens one window per command, and the trailing `-- CMD...` runs a single command (the whole argv joined) in a window after the `--run` windows; `-n, --count` sets the total window count. Fixes `-n 3 -- ls -la` previously spawning one window per token (`ls`, `-la`).
+- **`term-wm` balanced tiling:** the tiling layout now reweights every split to its descendant leaf count on each window insert and remove, so all windows share equal area regardless of tree depth — fixing the uneven startup layout (one ½ window + two ¼ windows) and keeping tiles balanced as windows are opened or closed interactively. Startup windows are no longer tiled against an uninitialized 0×0 area: `tile_window` defers layout construction until the first render frame, and the tree is then built from the mapped, non-floating windows against the measured viewport — so multi-window launch orients to the real terminal aspect ratio instead of being baked early against a landscape fallback. Horizontal splits are biased so a tile must be at least 1.5× as wide as it is tall (in visual cell units) to split side-by-side — inserting windows into a half-screen column stacks them instead of spawning narrow full-height strips.
+
+### Fixed
+
+- **`term-wm` startup window orientation:** two windows launched in a tall/narrow terminal previously split side-by-side into thin vertical strips because the tiling tree was built before the real viewport was known (against a fixed landscape fallback size). Tiling is now deferred until the first render frame and built from the mapped windows against the measured terminal size, so startup orientation matches the actual aspect ratio (stacked when tall/narrow, side-by-side when wide).
+- **`term-wm` trailing-command example:** the README's `-n 3 -- ls -la` (documented as running `ls -la` in the first window) didn't work — it spawned one window per token (`ls`, then `-la`). The `--` argv is now treated as a single command, and the README Usage section was updated to match (plus the new `-r, --run` multi-window syntax).
+
 ## [0.9.6-alpha] - 2026-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3196,21 +3196,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3228,11 +3228,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,22 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.6-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.6-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.6-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.6-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.6-alpha" }
-term-wm = { path = ".", version = "0.9.6-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.6-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.6-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.6-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.6-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.6-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.6-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.6-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.6-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.6-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.6-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.7-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.7-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.7-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.7-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.7-alpha" }
+term-wm = { path = ".", version = "0.9.7-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.7-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.7-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.7-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.7-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.7-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.7-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.7-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.7-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.7-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.7-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ This opens a new workspace with two terminal windows by default. Pass programs a
 cargo run --release -- vim
 cargo run --release -- -n 4              # open 4 windows
 cargo run --release -- -n 3 -- ls -la    # 3 windows; the first runs `ls -la`
+cargo run --release -- -r "vim -l" -r "htop"                            # 2 windows, one command each
+cargo run --release -- -n 4 -r "vim -l" -r "htop" -- git log --oneline  # 4 windows: 3 commands + 1 default shell
 ```
 
 Options (`term-wm -h`):
 
 - `-n, --count <N>` — number of windows to open (default 2; min 1)
+- `-r, --run <CMD>` — command to run in a window; repeatable, one window per `--run`. A trailing `-- CMD...` runs one command in a window after the `--run` windows. Remaining windows launch default shells.
 - `-h, --help`, `-V, --version`
 
 New windows launch the shell from `$SHELL` (Unix) or `%COMSPEC%` (Windows).

--- a/crates/term-wm-core/src/constants.rs
+++ b/crates/term-wm-core/src/constants.rs
@@ -73,6 +73,12 @@ pub const MIN_TILE_HEIGHT: u16 = 6;
 /// Terminal cell aspect ratio (height ~2x width) for visual split direction.
 pub const CELL_ASPECT_RATIO: u32 = 2;
 
+/// Horizontal-split bias for `insert_window_balanced`: visual width must be at
+/// least 1.5x (3/2) visual height before a tile splits side-by-side, so a
+/// horizontal split never produces tall, narrow vertical child strips.
+pub const TILING_HORIZONTAL_BIAS_NUMERATOR: u32 = 3;
+pub const TILING_HORIZONTAL_BIAS_DENOMINATOR: u32 = 2;
+
 /// Width threshold (in columns) below which auto-monocle mode activates.
 pub const MONOCLE_WIDTH_THRESHOLD: u16 = 80;
 

--- a/crates/term-wm-core/src/layout/tiling.rs
+++ b/crates/term-wm-core/src/layout/tiling.rs
@@ -122,8 +122,24 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
     }
 
     pub fn insert_window_balanced(&mut self, insert: Id, area: Rect) {
+        // Startup inserts can run before the first render pass, when
+        // `managed_area` is still `Rect { 0, 0, 0, 0 }`; a degenerate area would
+        // force every split to `InsertPosition::Bottom` (a vertical strip stack).
+        // Fall back to a standard terminal size so the tree is a real 2D grid.
+        let area = if area.width == 0 || area.height == 0 {
+            Rect {
+                x: 0,
+                y: 0,
+                width: crate::constants::DEFAULT_FLOAT_WIDTH,
+                height: crate::constants::DEFAULT_FLOAT_HEIGHT,
+            }
+        } else {
+            area
+        };
+
         // 1. Unified topological fallback — fill voids before splitting
         if self.consume_first_void(insert, area) {
+            self.root.reweight_by_leaf_count();
             return;
         }
 
@@ -131,6 +147,7 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
         let regions = self.regions(area);
         if regions.is_empty() {
             self.split_root(insert, InsertPosition::Right);
+            self.root.reweight_by_leaf_count();
             return;
         }
 
@@ -140,23 +157,35 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
             .copied()
             .unwrap();
 
-        let pos = if largest_rect.width / 2 < crate::constants::MIN_TILE_WIDTH {
-            InsertPosition::Bottom
-        } else if largest_rect.height / 2 < crate::constants::MIN_TILE_HEIGHT {
-            InsertPosition::Right
-        } else {
-            let visual_h = (largest_rect.height as u32) * crate::constants::CELL_ASPECT_RATIO;
-            let visual_w = largest_rect.width as u32;
-            if visual_w >= visual_h {
-                InsertPosition::Right
-            } else {
-                InsertPosition::Bottom
+        // Split direction: only one axis fits → that axis; both fit (or neither)
+        // → decide by visual aspect ratio. Checking each axis independently avoids
+        // the old `width/2` first bias that forced vertical stacking on small areas.
+        let can_split_h = largest_rect.width / 2 >= crate::constants::MIN_TILE_WIDTH;
+        let can_split_v = largest_rect.height / 2 >= crate::constants::MIN_TILE_HEIGHT;
+        let pos = match (can_split_h, can_split_v) {
+            (true, false) => InsertPosition::Right,
+            (false, true) => InsertPosition::Bottom,
+            _ => {
+                let visual_h = (largest_rect.height as u32) * crate::constants::CELL_ASPECT_RATIO;
+                let visual_w = largest_rect.width as u32;
+                // Horizontal splits halve the tile's width; bias them to only
+                // fire when the region is clearly wider than tall (>= 1.5x
+                // visual height), so they never create narrow vertical strips.
+                if visual_w * crate::constants::TILING_HORIZONTAL_BIAS_DENOMINATOR
+                    >= visual_h * crate::constants::TILING_HORIZONTAL_BIAS_NUMERATOR
+                {
+                    InsertPosition::Right
+                } else {
+                    InsertPosition::Bottom
+                }
             }
         };
 
         if !self.root.insert_leaf(largest_id, insert, pos) {
             self.split_root(insert, pos);
         }
+        // Equal-area rebalancing: every leaf gets 1/N regardless of tree depth.
+        self.root.reweight_by_leaf_count();
     }
 
     pub fn project_insert_void(&self, insert: Id, void_id: usize, area: Rect) -> Option<Rect> {
@@ -249,6 +278,8 @@ impl<Id: Copy + Eq + Ord> TilingLayout<Id> {
         self.root.remove_leaf(key);
         self.root.cleanup_after_removal();
         self.root.clear_leaf(key);
+        // Rebalance the remaining leaves; the pre-removal weights are stale.
+        self.root.reweight_by_leaf_count();
     }
 
     pub fn is_empty(&self) -> bool {
@@ -333,6 +364,164 @@ mod tests {
         } else {
             panic!("Root must remain a Split");
         }
+    }
+
+    /// Assert every tiled leaf region occupies near-equal area (within a few
+    /// percent; integer rounding and split gaps cause small deviations, but a
+    /// real imbalance such as ½ vs ¼ must fail).
+    fn assert_equal_tiled_areas(layout: &TilingLayout<usize>, area: Rect) {
+        let regions = layout.regions(area);
+        assert!(!regions.is_empty(), "expected at least one tiled leaf");
+        let areas: Vec<u32> = regions
+            .iter()
+            .map(|(_, r)| (r.width as u32) * (r.height as u32))
+            .collect();
+        let min_a = *areas.iter().min().unwrap();
+        let max_a = *areas.iter().max().unwrap();
+        assert!(
+            (max_a as u64) * 100 <= (min_a as u64) * 115,
+            "tiled leaves must be near equal-area, got {areas:?}"
+        );
+    }
+
+    #[test]
+    fn insert_window_balanced_yields_equal_areas() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        // First window becomes a single leaf (as the window manager does).
+        let mut layout = TilingLayout::new(LayoutNode::leaf(1));
+        for id in 2..=4 {
+            layout.insert_window_balanced(id, area);
+        }
+        assert_eq!(layout.regions(area).len(), 4);
+        assert_equal_tiled_areas(&layout, area);
+    }
+
+    #[test]
+    fn insert_window_balanced_avoids_narrow_vertical_strips() {
+        // A half-screen column (60 cols x 24 rows, e.g. in a 120x24 terminal)
+        // must split vertically: a horizontal split would leave two 30-wide
+        // full-height strips (the "narrow column" bug).
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 24,
+        };
+        let mut layout = TilingLayout::new(LayoutNode::leaf(1));
+        layout.insert_window_balanced(2, area);
+        let regions = layout.regions(area);
+        assert_eq!(regions.len(), 2);
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        let r2 = regions.iter().find(|(id, _)| *id == 2).unwrap().1;
+        assert_eq!(r1.x, 0, "window 1 starts at column 0");
+        assert_eq!(r2.x, 0, "window 2 starts at column 0");
+        assert_eq!(r1.width, 60, "window 1 spans full width");
+        assert_eq!(r2.width, 60, "window 2 spans full width");
+        assert!(r1.y < r2.y, "windows must stack, not form narrow columns");
+    }
+
+    #[test]
+    fn insert_window_balanced_splits_square_panes_horizontally() {
+        // A genuinely wide tile (96 cols x 24 rows) still splits side-by-side
+        // into two ~48-wide square panes (a 1-col resize gap is subtracted).
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 96,
+            height: 24,
+        };
+        let mut layout = TilingLayout::new(LayoutNode::leaf(1));
+        layout.insert_window_balanced(2, area);
+        let regions = layout.regions(area);
+        assert_eq!(regions.len(), 2);
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        let r2 = regions.iter().find(|(id, _)| *id == 2).unwrap().1;
+        assert!(r1.x < r2.x, "windows must be side by side on a wide tile");
+        assert!(
+            r1.width >= 47 && r2.width >= 47,
+            "each pane must be ~half the tile, got {} and {}",
+            r1.width,
+            r2.width
+        );
+    }
+
+    #[test]
+    fn insert_window_balanced_two_up_landscape_stays_side_by_side() {
+        // Regression guard: the standard 80x24 two-window layout must remain a
+        // side-by-side split, not regress to stacked.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        let mut layout = TilingLayout::new(LayoutNode::leaf(1));
+        layout.insert_window_balanced(2, area);
+        let regions = layout.regions(area);
+        assert_eq!(regions.len(), 2);
+        let r1 = regions.iter().find(|(id, _)| *id == 1).unwrap().1;
+        let r2 = regions.iter().find(|(id, _)| *id == 2).unwrap().1;
+        assert!(r1.x < r2.x, "80x24 two-up must stay side by side");
+    }
+
+    #[test]
+    fn remove_window_rebalances_remaining_leaves() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        let mut layout = TilingLayout::new(LayoutNode::leaf(1));
+        for id in 2..=4 {
+            layout.insert_window_balanced(id, area);
+        }
+        assert_equal_tiled_areas(&layout, area);
+
+        // Removing one of four windows must rebalance the remaining three.
+        layout.remove_window(1);
+        assert_eq!(layout.regions(area).len(), 3);
+        assert_equal_tiled_areas(&layout, area);
+    }
+
+    #[test]
+    fn insert_four_windows_uninitialized_area_forms_balanced_2d_grid() {
+        // Startup inserts happen before the first render pass when the managed
+        // area is still 0x0; they must still form a balanced 2D grid, not a
+        // vertical strip stack (the SEV-1 degenerate-area failure).
+        let uninitialized = Rect {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        };
+        let viewport = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+
+        let mut layout = TilingLayout::new_void();
+        for id in 1..=4 {
+            layout.insert_window_balanced(id, uninitialized);
+        }
+
+        let regions = layout.regions(viewport);
+        assert_eq!(regions.len(), 4);
+        // Equal-area rebalance, and horizontally partitioned (not a full-width
+        // vertical strip stack where every window has the same x).
+        assert_equal_tiled_areas(&layout, viewport);
+        let x_coords: std::collections::BTreeSet<_> = regions.iter().map(|(_, r)| r.x).collect();
+        assert!(
+            x_coords.len() > 1,
+            "must have horizontal division, not vertical strips"
+        );
     }
 
     #[test]

--- a/crates/term-wm-core/src/window/window_manager/drag.rs
+++ b/crates/term-wm-core/src/window/window_manager/drag.rs
@@ -438,6 +438,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
 
         self.clear_floating_rect(key);
 
+        if self.managed_area.width == 0 || self.managed_area.height == 0 {
+            // Viewport not measured yet (pre-first-render startup): defer layout
+            // construction. register_managed_layout builds the tree on frame 1
+            // from the mapped windows against the real area.
+            self.focus_window_key(key);
+            return true;
+        }
+
         if self.layout_contains(key)
             && let Some(layout) = &mut self.managed_layout
         {

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -390,6 +390,29 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         self.bottom_claimed = bottom_rect;
         let prev_managed = self.managed_area;
         self.managed_area = managed_area;
+        // First real frame: the true viewport is now known. If no tiling layout
+        // was built yet (startup windows were tiled lazily, not at 0x0), build
+        // the tree now from the mapped, non-floating windows in creation order
+        // so orientation matches the actual aspect ratio.
+        if self.managed_layout.is_none()
+            && self.managed_area.width > 0
+            && self.managed_area.height > 0
+        {
+            let mut tiled: Vec<WindowKey> = self
+                .windows
+                .iter()
+                .filter(|(_, w)| w.state() == WindowState::Mapped && !w.is_floating())
+                .map(|(k, _)| k)
+                .collect();
+            tiled.sort_by_key(|k| self.windows.get(*k).map_or(0, Window::creation_order));
+            if let Some(first) = tiled.first().copied() {
+                let mut layout = TilingLayout::new(LayoutNode::leaf(first));
+                for key in tiled.iter().skip(1) {
+                    layout.insert_window_balanced(*key, self.managed_area);
+                }
+                self.managed_layout = Some(layout);
+            }
+        }
         if prev_managed.width > 0 && prev_managed.height > 0 {
             let prev_full = FloatRectSpec::Absolute(crate::window::FloatRect {
                 x: prev_managed.x,
@@ -906,13 +929,119 @@ mod tests {
     use std::sync::Arc;
 
     fn make_wm() -> WindowManager<NoopComponent> {
-        WindowManager::<NoopComponent>::with_config(
+        let mut wm = WindowManager::<NoopComponent>::with_config(
             WmConfig::standalone(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
             std::collections::HashMap::new(),
-        )
+        );
+        wm.managed_area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        wm
+    }
+
+    #[test]
+    fn startup_two_windows_stack_vertically_on_tall_area() {
+        // Unseeded WM: managed_area is 0x0 until the first frame registers it.
+        let mut config = WmConfig::standalone();
+        config.chrome_enabled = false;
+        let mut wm = WindowManager::<NoopComponent>::with_config(
+            config,
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        wm.set_panel_visible(false);
+
+        let k0 = wm.create_window(NoopComponent);
+        let k1 = wm.create_window(NoopComponent);
+        wm.transition_window(k0, WindowState::Mapped);
+        wm.transition_window(k1, WindowState::Mapped);
+
+        // Startup tiling must be deferred while the viewport is unmeasured,
+        // otherwise the tree is baked against the 80x24 fallback (horizontal).
+        assert!(wm.managed_layout.is_none());
+        assert!(wm.tile_window(k0));
+        assert!(
+            wm.managed_layout.is_none(),
+            "layout must stay deferred while managed_area is 0x0"
+        );
+        assert!(wm.tile_window(k1));
+        assert!(wm.managed_layout.is_none());
+
+        // First real frame: tall, narrow viewport (35x100).
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 35,
+            height: 100,
+        });
+
+        assert!(wm.managed_layout.is_some(), "layout built on first frame");
+        assert!(wm.layout_contains(k0));
+        assert!(wm.layout_contains(k1));
+
+        let r0 = wm.region(k0);
+        let r1 = wm.region(k1);
+        assert_eq!(r0.x, 0, "left window starts at column 0");
+        assert_eq!(r1.x, 0, "right window starts at column 0");
+        assert_eq!(r0.width, 35, "left window spans full width");
+        assert_eq!(r1.width, 35, "right window spans full width");
+        assert!(
+            r0.y < r1.y,
+            "windows must stack vertically on a tall viewport"
+        );
+    }
+
+    #[test]
+    fn three_windows_on_wide_area_do_not_form_narrow_columns() {
+        // Regression: on a wide 120x24 viewport, the third window lands in a
+        // half-screen column (60x24). It must stack there rather than split
+        // side-by-side into narrow full-height strips.
+        let mut config = WmConfig::standalone();
+        config.chrome_enabled = false;
+        let mut wm = WindowManager::<NoopComponent>::with_config(
+            config,
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        wm.set_panel_visible(false);
+
+        let k0 = wm.create_window(NoopComponent);
+        let k1 = wm.create_window(NoopComponent);
+        let k2 = wm.create_window(NoopComponent);
+        wm.transition_window(k0, WindowState::Mapped);
+        wm.transition_window(k1, WindowState::Mapped);
+        wm.transition_window(k2, WindowState::Mapped);
+
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 24,
+        });
+
+        let regions = [wm.region(k0), wm.region(k1), wm.region(k2)];
+        for r in &regions {
+            assert!(
+                r.width >= 38,
+                "no window may be a narrow strip, got width {}",
+                r.width
+            );
+        }
+        let xs: std::collections::HashSet<i32> = regions.iter().map(|r| r.x).collect();
+        assert!(
+            xs.len() < 3,
+            "windows must share a column rather than all sit side-by-side"
+        );
     }
 
     #[test]
@@ -1260,13 +1389,20 @@ mod window_mode_tests {
     use std::sync::Arc;
 
     fn make_wm() -> WindowManager<NoopComponent> {
-        WindowManager::<NoopComponent>::with_config(
+        let mut wm = WindowManager::<NoopComponent>::with_config(
             WmConfig::standalone(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
             std::collections::HashMap::new(),
-        )
+        );
+        wm.managed_area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        };
+        wm
     }
 
     fn window(key_idx: usize) -> Window {

--- a/crates/term-wm-layout-engine/src/tiling.rs
+++ b/crates/term-wm-layout-engine/src/tiling.rs
@@ -620,6 +620,27 @@ impl<Id: Copy + Eq + Ord> LayoutNode<Id> {
         }
     }
 
+    /// Reweight every `Split` to its children's descendant leaf counts, so all
+    /// leaves occupy an equal share of the parent area regardless of tree depth
+    /// (a leaf in a shallow branch gets the same area as a leaf in a deep one).
+    /// Returns this subtree's leaf count.
+    pub fn reweight_by_leaf_count(&mut self) -> u16 {
+        match self {
+            LayoutNode::Leaf(_) | LayoutNode::Void(_) => 1,
+            LayoutNode::Split {
+                children, weights, ..
+            } => {
+                let counts: Vec<u16> = children
+                    .iter_mut()
+                    .map(|c| c.reweight_by_leaf_count())
+                    .collect();
+                let total = counts.iter().fold(0u16, |acc, &x| acc.saturating_add(x));
+                *weights = counts;
+                total
+            }
+        }
+    }
+
     pub fn replace_void_by_id(&mut self, void_id: usize, new_leaf: LayoutNode<Id>) -> bool {
         match self {
             LayoutNode::Void(id) if *id == void_id => {
@@ -1634,6 +1655,101 @@ mod tests {
         node.normalize_weights();
         if let LayoutNode::Split { weights, .. } = &node {
             assert!(weights.iter().all(|w| *w == 1u16));
+        } else {
+            panic!("expected split");
+        }
+    }
+
+    /// Assert every leaf region in a tree occupies near-equal area (within a
+    /// few percent; integer rounding and split gaps cause small deviations, but
+    /// a real imbalance such as ½ vs ¼ must fail).
+    fn assert_equal_leaf_areas(node: &LayoutNode<usize>, area: LayoutRect) {
+        let rects = node.layout_rects(area);
+        assert!(!rects.is_empty(), "expected at least one leaf");
+        let areas: Vec<u32> = rects
+            .iter()
+            .map(|(_, r)| (r.width as u32) * (r.height as u32))
+            .collect();
+        let min_a = *areas.iter().min().unwrap();
+        let max_a = *areas.iter().max().unwrap();
+        assert!(
+            (max_a as u64) * 100 <= (min_a as u64) * 115,
+            "leaves must be near equal-area, got {areas:?}"
+        );
+    }
+
+    #[test]
+    fn reweight_by_leaf_count_equalizes_depth_weighted_tree() {
+        // ½ + ¼ + ¼ tree: [leaf(1) | Split[leaf(2), leaf(3)]] all weights [1,1].
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1),
+                LayoutNode::Split {
+                    direction: Direction::Horizontal,
+                    children: vec![LayoutNode::leaf(2), LayoutNode::leaf(3)],
+                    weights: vec![1u16, 1u16],
+                    resizable: true,
+                },
+            ],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        node.reweight_by_leaf_count();
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 90,
+            height: 30,
+        };
+        assert_equal_leaf_areas(&node, area);
+    }
+
+    #[test]
+    fn reweight_by_leaf_count_four_leaves_all_equal() {
+        // ½ + ¼ + ⅛ + ⅛ tree; after reweight every leaf must be ¼.
+        let mut node = LayoutNode::Split {
+            direction: Direction::Horizontal,
+            children: vec![
+                LayoutNode::leaf(1),
+                LayoutNode::Split {
+                    direction: Direction::Horizontal,
+                    children: vec![
+                        LayoutNode::leaf(2),
+                        LayoutNode::Split {
+                            direction: Direction::Horizontal,
+                            children: vec![LayoutNode::leaf(3), LayoutNode::leaf(4)],
+                            weights: vec![1u16, 1u16],
+                            resizable: true,
+                        },
+                    ],
+                    weights: vec![1u16, 1u16],
+                    resizable: true,
+                },
+            ],
+            weights: vec![1u16, 1u16],
+            resizable: true,
+        };
+        node.reweight_by_leaf_count();
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 40,
+        };
+        assert_equal_leaf_areas(&node, area);
+    }
+
+    #[test]
+    fn reweight_by_leaf_count_populates_empty_weights() {
+        // `LayoutNode::split` initializes weights empty; reweight must fill them.
+        let mut node = LayoutNode::split(
+            Direction::Horizontal,
+            vec![LayoutNode::leaf(1), LayoutNode::leaf(2)],
+        );
+        node.reweight_by_leaf_count();
+        if let LayoutNode::Split { weights, .. } = &node {
+            assert_eq!(weights, &vec![1u16, 1u16]);
         } else {
             panic!("expected split");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,35 +29,49 @@ const PTY_SCROLLBACK_LEN: usize = 2000;
     long_about = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"), ": ", env!("CARGO_PKG_DESCRIPTION")),
 )]
 struct Cli {
-    /// Number of windows to open.
+    /// Total number of windows to open (default 2; min 1).
     #[arg(short = 'n', long = "count")]
     count: Option<usize>,
-    /// Command(s) to run.
-    #[arg(value_name = "CMD", num_args = 0..)]
+
+    /// Command to run in a window; repeatable, one window per `--run`.
+    #[arg(short = 'r', long = "run", value_name = "CMD", action = clap::ArgAction::Append)]
+    run_cmds: Vec<String>,
+
+    /// One command for a window (the whole argv after `--`); it follows any
+    /// `--run` windows. Remaining `--count` windows are default shells.
+    #[arg(value_name = "CMD", num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
     cmds: Vec<String>,
+}
+
+/// Combine repeatable `--run` commands with the single trailing `--` command
+/// (joined into one command line). `--run` windows come first.
+fn build_commands(run_cmds: Vec<String>, positional: Vec<String>) -> Vec<String> {
+    let mut commands = run_cmds;
+    if !positional.is_empty() {
+        commands.push(positional.join(" "));
+    }
+    commands
+}
+
+/// Total number of windows: explicit commands take precedence over a smaller
+/// `-n`; without commands, default to 2 (min 1).
+fn total_windows(count: Option<usize>, commands: &[String]) -> usize {
+    if commands.is_empty() {
+        count.unwrap_or(2).max(1)
+    } else {
+        commands.len().max(count.unwrap_or(0))
+    }
 }
 
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
-    // Determine total number of windows to open by default.
-    //
-    // Behavior:
-    // - If no commands provided: open `--count` shells (default 2 if not given).
-    // - If commands provided: if `--count` given use it, otherwise default to
-    //   the number of commands.
-    let total = if cli.cmds.is_empty() {
-        cli.count.unwrap_or(2).max(1)
-    } else {
-        // default to number of commands when count not given
-        cli.count
-            .map(|c| c.max(1))
-            .unwrap_or_else(|| cli.cmds.len().max(1))
-    };
+    let commands = build_commands(cli.run_cmds, cli.cmds);
+    let total = total_windows(cli.count, &commands);
 
     let mut event_source = UnifiedEventSource::new()?;
     let pty_wakeup_tx = event_source.pty_wakeup_tx();
-    let mut app = App::new_with(cli.cmds, total, pty_wakeup_tx)?;
+    let mut app = App::new_with(commands, total, pty_wakeup_tx)?;
 
     let mut output = ConsoleRenderTarget::new()?;
     output.enter()?;
@@ -119,27 +133,19 @@ impl App {
         // Initialize debug log and system panel windows.
         app.inner.init_system_windows();
 
-        // If commands provided, open one per command; otherwise open `num_windows`
-        // shells using the default shell.
-        if !commands.is_empty() {
-            let mut it = commands.into_iter();
-            for _ in 0..num_windows {
-                if let Some(cmd) = it.next() {
-                    // Spawn an interactive shell and send the command as input so
-                    // that when the command exits the shell remains.
-                    let cb = default_shell_command();
-                    if let Err(e) = app.spawn_terminal_with_command(cb, Some(cmd)) {
-                        tracing::error!("Window spawn error: {}", e);
-                    }
-                } else if let Err(e) = app.wm_new_window() {
-                    tracing::error!("Window spawn error: {}", e);
-                }
+        // One window per command (shell + the command as input), then default
+        // shells to fill `num_windows`. `commands` is owned and consumed here.
+        let mut used = 0;
+        for cmd in commands {
+            let cb = default_shell_command();
+            if let Err(e) = app.spawn_terminal_with_command(cb, Some(cmd)) {
+                tracing::error!("Window spawn error: {}", e);
             }
-        } else {
-            for _ in 0..num_windows {
-                if let Err(e) = app.wm_new_window() {
-                    tracing::error!("Window spawn error: {}", e);
-                }
+            used += 1;
+        }
+        for _ in used..num_windows {
+            if let Err(e) = app.wm_new_window() {
+                tracing::error!("Window spawn error: {}", e);
             }
         }
 
@@ -230,5 +236,65 @@ impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for A
 
     fn render(&mut self, backend: &mut dyn term_wm_render::RenderBackend) {
         self.inner.render_app(backend);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_commands_appends_joined_positional_after_run() {
+        let commands = build_commands(
+            vec!["vim -l".into(), "htop".into()],
+            vec!["git".into(), "log".into(), "--oneline".into()],
+        );
+        assert_eq!(commands, vec!["vim -l", "htop", "git log --oneline"]);
+    }
+
+    #[test]
+    fn build_commands_positional_only_is_single_command() {
+        let commands = build_commands(vec![], vec!["ls".into(), "-la".into()]);
+        assert_eq!(commands, vec!["ls -la"]);
+    }
+
+    #[test]
+    fn build_commands_run_only() {
+        let commands = build_commands(vec!["top".into()], vec![]);
+        assert_eq!(commands, vec!["top"]);
+    }
+
+    #[test]
+    fn build_commands_none() {
+        assert!(build_commands(vec![], vec![]).is_empty());
+    }
+
+    #[test]
+    fn total_windows_defaults_to_two_without_commands() {
+        assert_eq!(total_windows(None, &[]), 2);
+    }
+
+    #[test]
+    fn total_windows_count_without_commands() {
+        assert_eq!(total_windows(Some(4), &[]), 4);
+    }
+
+    #[test]
+    fn total_windows_zero_count_without_commands_clamps_to_one() {
+        assert_eq!(total_windows(Some(0), &[]), 1);
+    }
+
+    #[test]
+    fn total_windows_commands_take_precedence_over_smaller_count() {
+        let cmds = vec!["a".into(), "b".into()];
+        assert_eq!(total_windows(Some(1), &cmds), 2);
+        // `-n 0` with commands still opens one window per command.
+        assert_eq!(total_windows(Some(0), &cmds), 2);
+    }
+
+    #[test]
+    fn total_windows_count_expands_beyond_commands() {
+        let cmds = vec!["a".into()];
+        assert_eq!(total_windows(Some(4), &cmds), 4);
     }
 }

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -1227,6 +1227,13 @@ mod drag_snap_pipeline {
         wm.set_panel_visible(false);
 
         let k0 = wm.create_window(NoopComponent);
+
+        // tile_window_key defers layout construction while managed_area is
+        // unmeasured (0x0, pre-first-render); register_managed_layout below
+        // builds the tree lazily from Mapped, non-floating windows. Explicitly
+        // map the window so it is picked up by that lazy build.
+        wm.transition_window(k0, term_wm_core::window::WindowState::Mapped);
+
         assert!(wm.tile_window(k0));
         wm.register_managed_layout(AREA);
 


### PR DESCRIPTION
### Added

- **`term-wm` multi-window commands:** a repeatable `-r, --run <CMD>` flag opens one window per command, and the trailing `-- CMD...` runs a single command (the whole argv joined) in a window after the `--run` windows; `-n, --count` sets the total window count. Fixes `-n 3 -- ls -la` previously spawning one window per token (`ls`, `-la`).
- **`term-wm` balanced tiling:** the tiling layout now reweights every split to its descendant leaf count on each window insert and remove, so all windows share equal area regardless of tree depth — fixing the uneven startup layout (one ½ window + two ¼ windows) and keeping tiles balanced as windows are opened or closed interactively. Startup windows are no longer tiled against an uninitialized 0×0 area: `tile_window` defers layout construction until the first render frame, and the tree is then built from the mapped, non-floating windows against the measured viewport — so multi-window launch orients to the real terminal aspect ratio instead of being baked early against a landscape fallback. Horizontal splits are biased so a tile must be at least 1.5× as wide as it is tall (in visual cell units) to split side-by-side — inserting windows into a half-screen column stacks them instead of spawning narrow full-height strips.

### Fixed

- **`term-wm` startup window orientation:** two windows launched in a tall/narrow terminal previously split side-by-side into thin vertical strips because the tiling tree was built before the real viewport was known (against a fixed landscape fallback size). Tiling is now deferred until the first render frame and built from the mapped windows against the measured terminal size, so startup orientation matches the actual aspect ratio (stacked when tall/narrow, side-by-side when wide).
- **`term-wm` trailing-command example:** the README's `-n 3 -- ls -la` (documented as running `ls -la` in the first window) didn't work — it spawned one window per token (`ls`, then `-la`). The `--` argv is now treated as a single command, and the README Usage section was updated to match (plus the new `-r, --run` multi-window syntax).