### PR TITLE
fix(term-session): Reject unknown flags instead of auto-attaching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ The format is based on Keep a Changelog and this project adheres to
 
 - **`term-session` commands must be interactive or long-running:** the README and CLI help now state that the spawned command must be interactive or long-running (a shell, editor, or long-lived process) — a short command like `ls` exits immediately and ends the session.
 
-[NOT YET POPULATED]
-
 ## [0.9.7-alpha] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.8-alpha] - 2026-08-04
+
+### Fixed
+
+- **`term-session` rejects unknown flags instead of auto-attaching:** a leading-hyphen token that is not a real flag (e.g. `term-session --list`, a typo for the `list` subcommand) previously slipped into the trailing command and silently opened the default channel session. The trailing command no longer accepts hyphen values before `--`, so clap now rejects unknown flags with `unexpected argument ...` and exits (code 2) without spawning a gateway. Commands passed after `--` (or trailing args after the first command word) still pass hyphen flags through untouched.
+
+### Changed
+
+- **`term-session` CLI help rewritten:** `--help` / bare-run help now opens with a concise one-line description sourced from the crate's new `Cargo.toml` description ("Run terminal sessions in a detached daemon and attach locally or over SSH."), and the subcommand/argument descriptions were trimmed to single-line summaries — `kill` no longer appends "(default)", `kill-client` drops the "from `term-session list`" hint, and `--channel` / `--gateway` state their defaults / env overrides inline.
+
+### Docs
+
+- **`term-session` commands must be interactive or long-running:** the README and CLI help now state that the spawned command must be interactive or long-running (a shell, editor, or long-lived process) — a short command like `ls` exits immediately and ends the session.
+
+[NOT YET POPULATED]
+
 ## [0.9.7-alpha] - 2026-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3196,21 +3196,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3228,11 +3228,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.7-alpha"
+version = "0.9.8-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,22 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.7-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.7-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.7-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.7-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.7-alpha" }
-term-wm = { path = ".", version = "0.9.7-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.7-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.7-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.7-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.7-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.7-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.7-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.7-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.7-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.7-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.7-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.8-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.8-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.8-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.8-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.8-alpha" }
+term-wm = { path = ".", version = "0.9.8-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.8-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.8-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.8-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.8-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.8-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.8-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.8-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.8-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.8-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.8-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/term-session/Cargo.toml
+++ b/crates/term-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "term-session"
-description = "Generic terminal session reproducer: run a PTY in a detached server and attach any number of terminals, locally or over SSH."
+description = "Run terminal sessions in a detached daemon and attach locally or over SSH. Works on macOS, Linux, and Windows."
 keywords = ["terminal", "pty", "session", "multiplexer"]
 categories = ["command-line-utilities", "emulators", "network-programming", "os"]
 authors.workspace = true

--- a/crates/term-session/README.md
+++ b/crates/term-session/README.md
@@ -27,6 +27,8 @@ The command is passed as trailing arguments after `--` (the POSIX end-of-options
 
 **A command is honored only when the channel has no live session** (or its session has exited) — it then becomes the command the channel spawns/respawns. Attaching to a channel with a **running** session ignores the command entirely: you join the existing process, sharing its live viewport with every other attached client (like `tmux`/`screen`).
 
+**The command must be interactive or long-running** (a shell, an editor like `vim`, or any long-lived process). A short-lived command such as `ls` finishes in milliseconds and exits immediately, ending the session — nothing to attach to. If you want to inspect output from a quick command, run it inside an interactive shell instead (e.g. `term-session --channel work -- sh -c 'ls && exec $SHELL'`).
+
 Multiple terminals can attach to the same channel to share one session.
 
 ## Architecture

--- a/crates/term-session/src/main.rs
+++ b/crates/term-session/src/main.rs
@@ -12,7 +12,9 @@ use term_session_muxio_service_definitions::ChannelName;
     name = env!("CARGO_PKG_NAME"),
     version = env!("CARGO_PKG_VERSION"),
     about = env!("CARGO_PKG_DESCRIPTION"),
-    long_about = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"), ": ", env!("CARGO_PKG_DESCRIPTION")),
+    long_about = concat!(
+        env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"), ": ", env!("CARGO_PKG_DESCRIPTION"),
+    ),
 )]
 struct Cli {
     #[command(subcommand)]
@@ -27,21 +29,20 @@ struct Cli {
     #[arg(long, hide = true)]
     daemon_selfcheck: Option<std::path::PathBuf>,
 
-    /// Channel name (namespace/name); falls back to TERM_WM_CHANNEL env, then "default/main".
-    /// Implicitly attaches when given without a subcommand.
+    /// Channel name [default: default/main or $TERM_WM_CHANNEL]
     #[arg(long)]
     channel: Option<String>,
 
-    /// Command to run (and its arguments); if omitted, launches the default shell.
-    /// Anything after `--` is passed straight through as the spawned argv
-    /// (e.g. `--channel work -- git log --oneline`). Only used when the channel
-    /// has no live session; attaching to a running session ignores the command
-    /// and joins the existing process. Implicitly attaches when given without
-    /// a subcommand.
-    #[arg(value_name = "CMD", num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
+    /// Command and arguments to spawn (defaults to shell).
+    ///
+    /// Anything after `--` is passed verbatim. Only used when starting a new
+    /// session; attaching to an active channel joins the existing process.
+    /// Must be interactive or long-running (e.g. shell, `vim`, `htop`); quick
+    /// commands like `ls` exit immediately.
+    #[arg(value_name = "CMD", num_args = 0.., trailing_var_arg = true)]
     cmd: Vec<String>,
 
-    /// Override the gateway channel name (env TERM_WM_GATEWAY also works).
+    /// Gateway name override [or $TERM_WM_GATEWAY]
     #[arg(long)]
     gateway: Option<String>,
 }
@@ -51,7 +52,7 @@ enum Command {
     /// List channels and their sessions/clients.
     #[command(name = "ls", alias = "list")]
     List,
-    /// Kill a channel's session and detach all its sockets (default).
+    /// Kill a channel's session and detach all sockets.
     Kill {
         /// Channel name to kill.
         channel: String,
@@ -59,7 +60,7 @@ enum Command {
         #[arg(long)]
         kill_session: bool,
     },
-    /// Detach a single client by its conn id (from `term-session list`).
+    /// Detach a single client by conn ID.
     #[command(name = "kill-client")]
     KillClient {
         /// Channel name.

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -479,8 +479,8 @@ fn bare_term_session_shows_help_and_does_not_connect() {
         "help should mention --channel, got: {stderr}"
     );
     assert!(
-        stderr.contains("list"),
-        "help should list list, got: {stderr}"
+        stderr.contains("ls"),
+        "help should list the ls subcommand, got: {stderr}"
     );
     assert!(
         stderr.contains("stop"),
@@ -575,6 +575,37 @@ async fn dash_dash_disambiguates_command_from_subcommand() {
     ShutdownGateway::call(&*rpc, true).await.unwrap();
     let _ = client.kill();
     let _ = client.wait();
+}
+
+#[tokio::test]
+async fn unknown_flag_errors_without_spawning_gateway() {
+    // A leading-hyphen token that is not a real flag (e.g. `--list`, a typo for
+    // the `list` subcommand) must be rejected by clap, never swallowed into the
+    // trailing command and auto-attached. Each must exit non-zero and leave no
+    // gateway behind.
+    for flag in ["--list", "--bogus", "-x"] {
+        let gateway = unique_gateway("unknown_flag");
+        let gw = ChannelName::parse(&gateway).expect("gateway name");
+        let out = Command::new(bin())
+            .env("TERM_WM_GATEWAY", &gateway)
+            .arg(flag)
+            .output()
+            .expect("run with unknown flag");
+        assert_ne!(
+            out.status.code(),
+            Some(0),
+            "`{flag}` must not exit successfully"
+        );
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
+            "`{flag}` must be reported as an unexpected argument, got: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !probe_ipc_endpoint(&gw),
+            "`{flag}` must not auto-spawn a gateway"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Fixed

- **`term-session` rejects unknown flags instead of auto-attaching:** a leading-hyphen token that is not a real flag (e.g. `term-session --list`, a typo for the `list` subcommand) previously slipped into the trailing command and silently opened the default channel session. The trailing command no longer accepts hyphen values before `--`, so clap now rejects unknown flags with `unexpected argument ...` and exits (code 2) without spawning a gateway. Commands passed after `--` (or trailing args after the first command word) still pass hyphen flags through untouched.

### Changed

- **`term-session` CLI help rewritten:** `--help` / bare-run help now opens with a concise one-line description sourced from the crate's new `Cargo.toml` description ("Run terminal sessions in a detached daemon and attach locally or over SSH."), and the subcommand/argument descriptions were trimmed to single-line summaries — `kill` no longer appends "(default)", `kill-client` drops the "from `term-session list`" hint, and `--channel` / `--gateway` state their defaults / env overrides inline.

### Docs

- **`term-session` commands must be interactive or long-running:** the README and CLI help now state that the spawned command must be interactive or long-running (a shell, editor, or long-lived process) — a short command like `ls` exits immediately and ends the session.