### PR TITLE
feat(term-session): New sessions start in caller's working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.9-alpha] - 2026-08-04
+
+### Added
+
+- **`PathWire` — a lossless path wire type:** `term-session` now transmits the caller's working directory as a dedicated `PathWire` newtype (`Option<PathWire>` on `SpawnRequest.cwd`) with a platform-native, byte-for-byte reversible encoding: Unix sends the raw `OsStr` bytes and Windows sends UTF-16 code units packed as little-endian `u16` pairs, so even non-UTF-8 Unix paths and unpaired-surrogate (WTF-16) Windows paths round-trip intact. The type ships inherent `encode` / `decode` / `to_path_buf` methods plus concrete `From<&Path>` / `From<PathBuf>` / `From<&str>` / `From<String>` conversions, and is wire-identical to a plain `Vec<u8>` (no ABI break). It is documented as **strictly same-host local IPC**: payloads carry no platform tag and are not portable across platforms — cross-OS decoding would silently garble; SSH remote sessions are unaffected (the daemon resolves the cwd on the remote host), and a canonical multi-platform encoding (e.g. WTF-8) was deliberately deferred.
+
+### Changed
+
+- **New sessions start in the caller's working directory:** a freshly spawned session now starts in the client's `current_dir` (captured at launch) instead of the daemon's frozen startup directory — previously every new channel's session inherited the daemon's cwd. The directory travels losslessly over the wire; `None`/empty falls back to the daemon's cwd; the mock/daemon E2E tests verify byte-for-byte fidelity for non-UTF-8 paths.
+
+### Fixed
+
+- **`term-session` connection failures print instead of silently exiting:** the client `dup2`'d its stderr into a tracing pipe at startup but never installed a tracing subscriber, so every connect/handshake/ABI error — e.g. a fresh client hitting a legacy daemon on the same socket — exited with code 1 and **zero output**. The redirect now happens only after the Attach/Spawn/channel handshake succeeds, and `main` preserves the original stderr FD so fatal errors, including mid-session disconnects, print `error: …` to the user's terminal after the TUI tears down. A unix-gated regression test (`connection_error_is_printed_to_stderr`) binds a fake wire-incompatible peer and asserts the client emits a diagnostic.
+- **Windows build of the path wire decoder:** `decode_path`'s Windows branch used `OsString::from_wide` without importing `OsString`, so the definitions crate did not compile for `x86_64-pc-windows-msvc`; imports are now scoped to their `cfg` blocks and the Windows cross-check passes.
+- **`term-session list` session line:** the redundant `session: session size: 114x56` phrasing is now just `shared size: 114x56`.
+
 ## [0.9.8-alpha] - 2026-08-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-resize-indicator"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3028,12 +3028,14 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "clap",
  "hostname",
+ "interprocess",
  "libc",
  "muxio-tokio-rpc-ipc-client",
+ "tempfile",
  "term-session-client",
  "term-session-mock",
  "term-session-muxio-service-definitions",
@@ -3045,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3072,15 +3074,16 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "libc",
+ "term-session-muxio-service-definitions",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3090,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3099,6 +3102,8 @@ dependencies = [
  "muxio-rpc-service-endpoint",
  "muxio-tokio-rpc-ipc-server",
  "portable-pty",
+ "tempfile",
+ "term-session-mock",
  "term-session-muxio-service-definitions",
  "term-wm-pty-engine",
  "tokio",
@@ -3109,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3147,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3165,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3187,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3196,21 +3201,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3228,11 +3233,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3248,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3273,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.8-alpha"
+version = "0.9.9-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,22 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.8-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.8-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.8-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.8-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.8-alpha" }
-term-wm = { path = ".", version = "0.9.8-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.8-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.8-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.8-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.8-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.8-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.8-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.8-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.8-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.8-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.8-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.9-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.9-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.9-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.9-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.9-alpha" }
+term-wm = { path = ".", version = "0.9.9-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.9-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.9-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.9-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.9-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.9-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.9-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.9-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.9-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.9-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.9-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/term-resize-indicator/Cargo.toml
+++ b/crates/term-resize-indicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "term-resize-indicator"
-description = "Draws a dotted-line border with terminal dimensions on resize."
+description = "Draws a box with centered dimensions in terminal applications."
 keywords = ["terminal", "tui", "ui"]
 categories = ["gui", "command-line-interface"]
 version.workspace = true
@@ -8,6 +8,8 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
+
+# Internal debug tool; not publishing for now
 publish = false
 
 [dependencies]

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -21,7 +21,7 @@ use muxio_tokio_rpc_ipc_client::{RpcCallPrebuffered, RpcIpcClient, RpcServiceCal
 use portable_pty::PtySize;
 use term_session_muxio_service_definitions::{
     Attach, AttachRequest, OnPtyResized, RpcMethodPrebuffered, STREAM_INPUT_METHOD_ID,
-    SUBSCRIBE_OUTPUT_METHOD_ID, Spawn,
+    SUBSCRIBE_OUTPUT_METHOD_ID, Spawn, SpawnRequest, SpawnResponse, path_wire,
 };
 use term_wm_events::{Event, KeyKind, KeyModifiers, MouseEventKind};
 use term_wm_pty_engine::Pane;
@@ -311,12 +311,6 @@ pub fn run_session(socket_path: &str, channel: &str, cmd: &[String]) -> io::Resu
     #[cfg(windows)]
     disable_quick_edit();
 
-    // Redirect stderr to tracing so macOS AppKit/NSPasteboard noise doesn't
-    // leak to the terminal display.  Best-effort: if it fails (non-Unix, etc.)
-    // the session still works, just without the noise suppression.
-    #[cfg(unix)]
-    let _ = redirect_fd_to_tracing(libc::STDERR_FILENO, true);
-
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| io::Error::other(format!("runtime: {e}")))?;
 
@@ -407,10 +401,28 @@ pub fn run_session(socket_path: &str, channel: &str, cmd: &[String]) -> io::Resu
         } else {
             Some(cmd.to_vec())
         };
-        let (_session_id, actual_cols, actual_rows) =
-            Spawn::call(&*client, (cmd, term_cols, term_rows))
-                .await
-                .map_err(|e| abi_fault(&e))?;
+        // The launch directory is captured here so a newly spawned session
+        // starts in the caller's cwd, not the daemon's. It is encoded
+        // losslessly (platform-native raw bytes, see `path_wire`), so even
+        // non-UTF-8 paths survive the wire byte-for-byte. `None` (current_dir
+        // failing) lets the server fall back to the daemon's cwd.
+        let launch_cwd = std::env::current_dir().ok().map(path_wire::encode_path);
+        let SpawnResponse {
+            id: _session_id,
+            cols: actual_cols,
+            rows: actual_rows,
+            ..
+        } = Spawn::call(
+            &*client,
+            SpawnRequest {
+                cmd,
+                cols: term_cols,
+                rows: term_rows,
+                cwd: launch_cwd,
+            },
+        )
+        .await
+        .map_err(|e| abi_fault(&e))?;
         let _ = conn_id;
         Ok::<(u16, u16), io::Error>((actual_cols, actual_rows))
     })?;
@@ -516,6 +528,16 @@ pub fn run_session(socket_path: &str, channel: &str, cmd: &[String]) -> io::Resu
 
     // Pass one stdout handle to init_terminal for the startup sequences
     // and TerminalGuard teardown; keep a second handle for rendering.
+    //
+    // Redirect stderr to tracing only now that the terminal UI is about to
+    // take over, so macOS AppKit/NSPasteboard noise doesn't leak to the
+    // terminal display. Deferred until AFTER the Attach/Spawn/channel handshake
+    // so any connect/ABI error above reaches the real stderr and `main` can
+    // print it, instead of being swallowed into the (unsubscribed) tracing
+    // pipe. Best-effort: if it fails the session still works, just without the
+    // noise suppression.
+    #[cfg(unix)]
+    let _ = redirect_fd_to_tracing(libc::STDERR_FILENO, true);
     let _guard = init_terminal(stdout())?;
     let mut out = stdout();
 

--- a/crates/term-session-mock/Cargo.toml
+++ b/crates/term-session-mock/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = { workspace = true }
+term-session-muxio-service-definitions = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }

--- a/crates/term-session-mock/src/main.rs
+++ b/crates/term-session-mock/src/main.rs
@@ -2,6 +2,7 @@ use std::io::{self, Read, Write};
 use std::time::Duration;
 
 use term_session_mock::{CHECK_PID_ALIVE, CHECK_PID_DEAD, process_is_alive};
+use term_session_muxio_service_definitions::path_wire;
 
 /// Deterministic mock binary for session server E2E tests.
 ///
@@ -20,6 +21,8 @@ use term_session_mock::{CHECK_PID_ALIVE, CHECK_PID_DEAD, process_is_alive};
 ///   included), not just the session leader.
 /// - `check_pid <pid>` — exits 0 if the process is alive, non-zero otherwise.
 ///   Cross-platform liveness probe for tree-kill assertions.
+/// - `pwd <file>` — writes the process's current working directory to the given
+///   (absolute) file path, then exits. Lets E2E tests verify session cwd.
 pub const OSC52_TEST_PAYLOAD: &[u8] = b"c;dGVzdA==";
 
 #[cfg(windows)]
@@ -69,7 +72,9 @@ mod win_console {
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: term_session_mock <echo|osc52|sleep|exit|spawn_child|check_pid> [args]");
+        eprintln!(
+            "Usage: term_session_mock <echo|osc52|sleep|exit|spawn_child|check_pid|pwd> [args]"
+        );
         std::process::exit(1);
     }
 
@@ -188,6 +193,25 @@ fn main() {
         "exit" => {
             let code: i32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
             std::process::exit(code);
+        }
+        "pwd" => {
+            // Write the child process's actual working directory to an absolute
+            // file path (the session may be running in a different cwd than the
+            // test harness, so the output file must be given as an absolute
+            // path). Lets E2E tests verify where the daemon spawned the session.
+            let file = std::env::args_os()
+                .nth(2)
+                .expect("pwd requires an absolute output file path");
+            // Report the child's actual cwd as raw wire bytes (lossless, see
+            // `path_wire`), so the harness can assert a byte-for-byte round-trip
+            // even for non-UTF-8 paths.
+            let cwd = std::env::current_dir()
+                .map(|p| path_wire::encode_path(&p))
+                .unwrap_or_default();
+            if let Err(e) = std::fs::write(&file, &cwd) {
+                eprintln!("pwd: failed to write {:?}: {e}", file);
+                std::process::exit(1);
+            }
         }
         other => {
             eprintln!("Unknown subcommand: {other}");

--- a/crates/term-session-muxio-service-definitions/src/lib.rs
+++ b/crates/term-session-muxio-service-definitions/src/lib.rs
@@ -1,11 +1,14 @@
 pub mod channel;
 pub mod methods;
+pub mod path_wire;
 
 pub use channel::{ChannelName, GATEWAY_CHANNEL_ENV_VAR, gateway_channel_name, probe_ipc_endpoint};
 pub use methods::{
     Attach, AttachRequest, ChannelInfo, ClientInfo, CloseSession, KillChannel, KillClient,
     ListChannels, ListChannelsResponse, OnPtyResized, PushOutput, RPC_ERROR_LIVE_SESSIONS,
     RPC_ERROR_SHUTTING_DOWN, RPC_ERROR_UNATTACHED, ResizePty, STREAM_INPUT_METHOD_ID,
-    SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway, Spawn, WriteInput,
+    SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway, Spawn, SpawnRequest, SpawnResponse,
+    WriteInput,
 };
 pub use muxio_rpc_service::prebuffered::RpcMethodPrebuffered;
+pub use path_wire::PathWire;

--- a/crates/term-session-muxio-service-definitions/src/methods.rs
+++ b/crates/term-session-muxio-service-definitions/src/methods.rs
@@ -3,6 +3,8 @@ use std::io;
 use bitcode::{Decode, Encode};
 use muxio_rpc_service::{prebuffered::RpcMethodPrebuffered, rpc_method_id};
 
+use crate::path_wire::PathWire;
+
 // ── Error message constants ─────────────────────────────────────────
 // muxio's wire error only has Fail/System/NotFound codes, so structured
 // gateway errors are signalled with well-known message strings that both
@@ -66,15 +68,24 @@ impl RpcMethodPrebuffered for Attach {
 
 // ── Spawn ────────────────────────────────────────────────────────────
 
-#[derive(Encode, Decode)]
-struct SpawnRequest {
+/// Request for `Spawn`: join/respawn the session on a channel.
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct SpawnRequest {
     pub cmd: Option<Vec<String>>,
     pub cols: u16,
     pub rows: u16,
+    /// The client process's working directory at the time it launched, so a
+    /// newly spawned session starts there rather than in the daemon's cwd.
+    /// Encoded losslessly via [`crate::path_wire::encode_path`], so non-UTF-8
+    /// paths survive the wire byte-for-byte. The bytes are decoded in the
+    /// daemon's host OS context (same host), so the payload is only valid on
+    /// the host that produced it. `None`/empty falls back to the daemon's cwd.
+    pub cwd: Option<PathWire>,
 }
 
-#[derive(Encode, Decode)]
-struct SpawnResponse {
+/// Response for `Spawn`: the (possibly reused) session id and its geometry.
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct SpawnResponse {
     pub id: u64,
     pub cols: u16,
     pub rows: u16,
@@ -85,35 +96,25 @@ pub struct Spawn;
 impl RpcMethodPrebuffered for Spawn {
     const METHOD_ID: u64 = rpc_method_id!("session.spawn");
 
-    type Input = (Option<Vec<String>>, u16, u16);
-    type Output = (u64, u16, u16);
+    type Input = SpawnRequest;
+    type Output = SpawnResponse;
 
     fn encode_request(input: Self::Input) -> Result<Vec<u8>, io::Error> {
-        Ok(bitcode::encode(&SpawnRequest {
-            cmd: input.0,
-            cols: input.1,
-            rows: input.2,
-        }))
+        Ok(bitcode::encode(&input))
     }
 
     fn decode_request(bytes: &[u8]) -> Result<Self::Input, io::Error> {
-        let r = bitcode::decode::<SpawnRequest>(bytes)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok((r.cmd, r.cols, r.rows))
+        bitcode::decode::<SpawnRequest>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
     fn encode_response(output: Self::Output) -> Result<Vec<u8>, io::Error> {
-        Ok(bitcode::encode(&SpawnResponse {
-            id: output.0,
-            cols: output.1,
-            rows: output.2,
-        }))
+        Ok(bitcode::encode(&output))
     }
 
     fn decode_response(bytes: &[u8]) -> Result<Self::Output, io::Error> {
-        let r = bitcode::decode::<SpawnResponse>(bytes)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        Ok((r.id, r.cols, r.rows))
+        bitcode::decode::<SpawnResponse>(bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 }
 

--- a/crates/term-session-muxio-service-definitions/src/path_wire.rs
+++ b/crates/term-session-muxio-service-definitions/src/path_wire.rs
@@ -1,0 +1,265 @@
+//! Lossless conversion between OS paths and the raw bytes carried on the
+//! muxio wire.
+//!
+//! `PathWire` is **strictly intended for same-host local IPC**: the client and
+//! daemon run on the same machine. Do not use it for any other transport.
+//! Because the endpoints share a host, a platform-native encoding is safe: Unix
+//! sends the raw `OsStr` bytes and Windows sends UTF-16 code units packed as
+//! little-endian `u16` pairs. Both representations are byte-for-byte reversible
+//! — including non-UTF-8 paths on Unix and unpaired-surrogate (WTF-16) paths on
+//! Windows — which is what makes the session's launch directory round-trip
+//! losslessly.
+//!
+//! The bytes are therefore **not portable across platforms**. `PathWire` is a
+//! raw byte array with no platform tag, so decoding a payload on a different OS
+//! than the one that encoded it yields a silently garbled path rather than a
+//! structured error; a Unix path is also syntactically invalid as a Windows
+//! cwd and vice versa. Payloads must only ever travel between same-host
+//! processes. SSH remote sessions are unaffected: the daemon runs on the remote
+//! host, so the client's bytes are decoded in that same remote OS's native
+//! context. A canonical multi-platform encoding (e.g. WTF-8) was deliberately
+//! deferred in favor of zero-overhead native buffers for same-host local IPC.
+
+use std::path::{Path, PathBuf};
+
+use bitcode::{Decode, Encode};
+
+/// A byte buffer carrying a path's lossless wire encoding.
+///
+/// Strictly intended for same-host local IPC (client and daemon on the same
+/// machine); the platform-native encoding is therefore safe: Unix stores the
+/// raw `OsStr` bytes; Windows stores UTF-16 code units packed as little-endian
+/// `u16` pairs. Both are byte-for-byte reversible, so even non-UTF-8 / WTF-16
+/// paths round-trip intact.
+///
+/// The bytes are **not portable across platforms**: decoding a `PathWire` on a
+/// different OS than the one that encoded it yields a corrupt path (see module
+/// docs).
+///
+/// Distinct from a raw `Vec<u8>` (e.g. PTY input/output), so a path payload
+/// cannot be accidentally substituted for, or mixed with, arbitrary buffers.
+/// Dereferences to `[u8]` for reading.
+///
+/// Construct via [`PathWire::encode`] or the `From<&Path>` / `From<PathBuf>` /
+/// `From<&str>` / `From<String>` conversions to encode an OS path, or via
+/// `From<Vec<u8>>` / `PathWire(bytes)` to wrap already-encoded wire bytes.
+/// Reconstruct the path with [`PathWire::decode`] (or the `to_path_buf` alias).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Encode, Decode)]
+pub struct PathWire(pub Vec<u8>);
+
+impl std::ops::Deref for PathWire {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for PathWire {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for PathWire {
+    fn from(bytes: Vec<u8>) -> Self {
+        PathWire(bytes)
+    }
+}
+
+impl PathWire {
+    /// Encode a platform-native OS path into lossless wire bytes.
+    pub fn encode<P: AsRef<Path>>(path: P) -> Self {
+        encode_path(path)
+    }
+
+    /// Decode the wire bytes back into a platform-native `PathBuf`.
+    pub fn decode(&self) -> PathBuf {
+        decode_path(self)
+    }
+
+    /// Convenience alias following Rust `Path::to_path_buf` naming.
+    pub fn to_path_buf(&self) -> PathBuf {
+        self.decode()
+    }
+}
+
+impl From<&Path> for PathWire {
+    fn from(path: &Path) -> Self {
+        encode_path(path)
+    }
+}
+
+impl From<PathBuf> for PathWire {
+    fn from(path: PathBuf) -> Self {
+        encode_path(&path)
+    }
+}
+
+impl From<&str> for PathWire {
+    fn from(s: &str) -> Self {
+        encode_path(Path::new(s))
+    }
+}
+
+impl From<String> for PathWire {
+    fn from(s: String) -> Self {
+        encode_path(Path::new(&s))
+    }
+}
+
+/// Encode a path losslessly into wire bytes (see module docs).
+pub fn encode_path<P: AsRef<Path>>(path: P) -> PathWire {
+    #[cfg(unix)]
+    let bytes = {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_ref().as_os_str().as_bytes().to_vec()
+    };
+    #[cfg(windows)]
+    let bytes = {
+        use std::os::windows::ffi::OsStrExt;
+        let units: Vec<u16> = path.as_ref().as_os_str().encode_wide().collect();
+        let mut out = Vec::with_capacity(units.len() * 2);
+        for unit in units {
+            out.extend_from_slice(&unit.to_le_bytes());
+        }
+        out
+    };
+    #[cfg(not(any(unix, windows)))]
+    let bytes = path.as_ref().to_string_lossy().into_owned().into_bytes();
+    PathWire(bytes)
+}
+
+/// Reconstruct a path from wire bytes produced by [`encode_path`].
+pub fn decode_path(pw: &PathWire) -> PathBuf {
+    #[cfg(unix)]
+    {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        PathBuf::from(OsStr::from_bytes(&pw.0))
+    }
+    #[cfg(windows)]
+    {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+        let bytes = &pw.0;
+        debug_assert!(
+            bytes.len() % 2 == 0,
+            "windows cwd bytes must be u16 little-endian pairs"
+        );
+        let units = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect::<Vec<u16>>();
+        PathBuf::from(OsString::from_wide(&units))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        PathBuf::from(String::from_utf8_lossy(&pw.0).into_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PathWire, decode_path, encode_path};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn round_trips_plain_unicode_path() {
+        let dir = std::env::temp_dir().join("term-session path with spaces");
+        assert_eq!(decode_path(&encode_path(&dir)), dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn round_trips_non_utf8_path() {
+        use std::os::unix::ffi::OsStrExt;
+        let name = std::ffi::OsStr::from_bytes(b"cwd-\xff\xfe-non-utf8");
+        let dir = PathBuf::from(name);
+        assert_eq!(decode_path(&encode_path(&dir)), dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn round_trips_unpaired_surrogate_path() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+        // WTF-16 with an unpaired low surrogate: `0xDC00` cannot be represented
+        // in UTF-8, so only a wide round-trip can preserve it.
+        let units = vec![0x0058u16, 0xDC00, 0x0059]; // "X\u{DC00}Y"
+        let dir = PathBuf::from(OsString::from_wide(&units));
+        assert_eq!(decode_path(&encode_path(&dir)), dir);
+    }
+
+    #[test]
+    fn from_vec_wraps_raw_bytes() {
+        let raw = vec![b'/', b't', b'm', b'p', b'/', b'c', b'w', b'd'];
+        let pw = PathWire::from(raw.clone());
+        assert_eq!(pw, PathWire(raw));
+        assert_eq!(pw.as_ref(), b"/tmp/cwd");
+        assert!(!pw.is_empty());
+    }
+
+    #[test]
+    fn default_is_empty_sentinel() {
+        assert!(PathWire::default().is_empty());
+    }
+
+    #[test]
+    fn inherent_encode_matches_encode_path() {
+        let path = std::env::temp_dir().join("inherent-encode");
+        assert_eq!(PathWire::encode(&path), encode_path(&path));
+    }
+
+    #[test]
+    fn inherent_decode_round_trips() {
+        let path = std::env::temp_dir().join("inherent-decode");
+        assert_eq!(PathWire::encode(&path).decode(), path);
+    }
+
+    #[test]
+    fn to_path_buf_alias() {
+        let path = std::env::temp_dir().join("to-path-buf");
+        let pw = PathWire::encode(&path);
+        assert_eq!(pw.to_path_buf(), pw.decode());
+        assert_eq!(pw.to_path_buf(), path);
+    }
+
+    #[test]
+    fn option_map_decode_combinator() {
+        let path = std::env::temp_dir().join("option-map-decode");
+        let pw = PathWire::encode(&path);
+        let opt: Option<&PathWire> = Some(&pw);
+        assert_eq!(opt.map(PathWire::decode), Some(path));
+        let none: Option<&PathWire> = None;
+        assert_eq!(none.map(PathWire::decode), None);
+    }
+
+    #[test]
+    fn from_path_family_encodes_like_encode_path() {
+        let path = std::env::temp_dir().join("from-path-family");
+        let encoded = encode_path(&path);
+        assert_eq!(PathWire::from(path.clone()), encoded);
+        assert_eq!(PathWire::from(path.as_path()), encoded);
+        let s = path.to_string_lossy().into_owned();
+        assert_eq!(PathWire::from(s.as_str()), encoded);
+        assert_eq!(PathWire::from(s), encoded);
+    }
+
+    #[test]
+    fn from_str_treats_string_as_path() {
+        let pw = PathWire::from("/tmp/from-str");
+        assert_eq!(pw, encode_path(Path::new("/tmp/from-str")));
+        assert_eq!(pw.decode(), PathBuf::from("/tmp/from-str"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_pathbuf_round_trips_non_utf8() {
+        use std::os::unix::ffi::OsStrExt;
+        let name = std::ffi::OsStr::from_bytes(b"cwd-\xff\xfe-non-utf8");
+        let dir = PathBuf::from(name);
+        let pw = PathWire::from(dir.clone());
+        assert_eq!(decode_path(&pw), dir);
+    }
+}

--- a/crates/term-session-muxio-service-definitions/src/path_wire.rs
+++ b/crates/term-session-muxio-service-definitions/src/path_wire.rs
@@ -144,7 +144,7 @@ pub fn decode_path(pw: &PathWire) -> PathBuf {
         use std::os::windows::ffi::OsStringExt;
         let bytes = &pw.0;
         debug_assert!(
-            bytes.len() % 2 == 0,
+            bytes.len().is_multiple_of(2),
             "windows cwd bytes must be u16 little-endian pairs"
         );
         let units = bytes

--- a/crates/term-session-server/Cargo.toml
+++ b/crates/term-session-server/Cargo.toml
@@ -26,3 +26,7 @@ vt100 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+term-session-mock = { workspace = true }

--- a/crates/term-session-server/src/session.rs
+++ b/crates/term-session-server/src/session.rs
@@ -1,5 +1,6 @@
 use portable_pty::{CommandBuilder, PtySize};
 use term_session_muxio_service_definitions::ChannelName;
+use term_session_muxio_service_definitions::PathWire;
 use term_wm_pty_engine::{Pty, PtyResult, PtyStatus};
 
 pub struct Session {
@@ -17,11 +18,18 @@ fn default_shell_command() -> CommandBuilder {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "bash".to_string());
     #[cfg(windows)]
     let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
-    let mut cmd = CommandBuilder::new(shell);
-    if let Ok(cwd) = std::env::current_dir() {
-        cmd.cwd(cwd);
+    CommandBuilder::new(shell)
+}
+
+/// Resolve the working directory a newly spawned session should start in.
+/// Prefers the caller's launch directory (losslessly decoded wire bytes);
+/// falls back to this process's cwd (the daemon's) for legacy clients that
+/// send `None` or an empty payload.
+fn resolve_cwd(cwd: Option<&PathWire>) -> Option<std::path::PathBuf> {
+    match cwd {
+        Some(c) if !c.is_empty() => Some(c.decode()),
+        _ => std::env::current_dir().ok(),
     }
-    cmd
 }
 
 impl Session {
@@ -31,6 +39,7 @@ impl Session {
         cols: u16,
         rows: u16,
         channel: Option<&ChannelName>,
+        cwd: Option<&PathWire>,
     ) -> PtyResult<Self> {
         let size = PtySize {
             rows,
@@ -38,25 +47,25 @@ impl Session {
             pixel_width: 0,
             pixel_height: 0,
         };
-        let pty = if let Some(cmd_parts) = &cmd {
-            let mut builder = CommandBuilder::new(&cmd_parts[0]);
+        // Prefer the caller's launch directory; fall back to this process's
+        // cwd (the daemon's) for legacy clients that send no cwd.
+        let resolved_cwd = resolve_cwd(cwd);
+        let mut builder = if let Some(cmd_parts) = &cmd {
+            let mut b = CommandBuilder::new(&cmd_parts[0]);
             for arg in &cmd_parts[1..] {
-                builder.arg(arg);
+                b.arg(arg);
             }
-            if let Some(ch) = channel {
-                builder.env("TERM_WM_CHANNEL", ch.to_string());
-            }
-            if let Ok(cwd) = std::env::current_dir() {
-                builder.cwd(cwd);
-            }
-            Pty::spawn(builder, size)?
+            b
         } else {
-            let mut builder = default_shell_command();
-            if let Some(ch) = channel {
-                builder.env("TERM_WM_CHANNEL", ch.to_string());
-            }
-            Pty::spawn(builder, size)?
+            default_shell_command()
         };
+        if let Some(ch) = channel {
+            builder.env("TERM_WM_CHANNEL", ch.to_string());
+        }
+        if let Some(c) = resolved_cwd {
+            builder.cwd(c);
+        }
+        let pty = Pty::spawn(builder, size)?;
         Ok(Self {
             id,
             pty,
@@ -109,5 +118,141 @@ impl Session {
 
     pub fn set_status_callback(&mut self, cb: Option<Box<dyn Fn(PtyStatus) + Send + Sync>>) {
         self.pty.set_status_callback(cb);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Session, resolve_cwd};
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+
+    use term_session_muxio_service_definitions::path_wire;
+    use term_session_muxio_service_definitions::path_wire::PathWire;
+
+    const TEST_COLS: u16 = 80;
+    const TEST_ROWS: u16 = 24;
+    const REPORT_TIMEOUT_SECS: u64 = 10;
+
+    #[test]
+    fn resolve_cwd_uses_provided_dir() {
+        let dir = std::env::temp_dir().join("resolve-cwd-probe");
+        let probe = path_wire::encode_path(&dir);
+        assert_eq!(resolve_cwd(Some(&probe)), Some(dir));
+    }
+
+    #[test]
+    fn resolve_cwd_falls_back_to_process_dir_when_none() {
+        assert_eq!(resolve_cwd(None), std::env::current_dir().ok());
+    }
+
+    #[test]
+    fn resolve_cwd_falls_back_to_process_dir_when_empty() {
+        assert_eq!(
+            resolve_cwd(Some(&PathWire::default())),
+            std::env::current_dir().ok()
+        );
+    }
+
+    /// Try to create a directory whose name contains bytes that are not valid
+    /// UTF-8. Only possible on Unix, and some filesystems refuse it: macOS
+    /// requires valid UTF-8 filenames, so this returns `None` there and the
+    /// tests skip (losslessness is still covered by the pure `path_wire`
+    /// round-trip test, which needs no filesystem). Returns `Some` on Linux
+    /// etc., proving the cwd round-trip is byte-for-byte, not merely
+    /// UTF-8-equivalent.
+    #[cfg(unix)]
+    fn try_non_utf8_dir(base: &Path) -> Option<PathBuf> {
+        use std::os::unix::ffi::OsStrExt;
+        let name = std::ffi::OsStr::from_bytes(b"cwd-\xff\xfe-non-utf8");
+        let dir = base.join(name);
+        std::fs::create_dir_all(&dir).ok().map(|()| dir)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_cwd_round_trips_non_utf8_dir() {
+        let base = tempfile::tempdir().expect("tempdir");
+        let Some(dir) = try_non_utf8_dir(base.path()) else {
+            eprintln!("skipping: filesystem rejects non-UTF-8 directory names");
+            return;
+        };
+        let probe = path_wire::encode_path(&dir);
+        assert_eq!(resolve_cwd(Some(&probe)), Some(dir));
+    }
+
+    /// Poll `report` until the mock `pwd` child has written its cwd, with a
+    /// generous timeout so a broken spawn fails the assertion instead of
+    /// hanging the test. Returns the raw report bytes so losslessness is
+    /// asserted byte-for-byte.
+    fn read_report(report: &Path) -> Vec<u8> {
+        let deadline = Instant::now() + Duration::from_secs(REPORT_TIMEOUT_SECS);
+        loop {
+            if let Ok(content) = std::fs::read(report) {
+                return content;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "mock pwd never wrote the report at {report:?}"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Spawn a session running `mock pwd <report>` with the given wire-encoded
+    /// cwd and return the wire bytes the child reports.
+    fn spawn_pwd_report(cwd: Option<&PathWire>) -> PathWire {
+        let dir = tempfile::tempdir().expect("report tempdir");
+        let report = dir.path().join("pwd.txt");
+        let mock = term_session_mock::get_mock_bin();
+        let cmd = vec![
+            mock.to_string_lossy().into_owned(),
+            "pwd".to_string(),
+            report.to_string_lossy().into_owned(),
+        ];
+        let _session =
+            Session::spawn(1, Some(cmd), TEST_COLS, TEST_ROWS, None, cwd).expect("spawn session");
+        PathWire::from(read_report(&report))
+    }
+
+    fn canonical_process_cwd() -> PathBuf {
+        std::fs::canonicalize(std::env::current_dir().expect("process cwd"))
+            .expect("canonicalize process cwd")
+    }
+
+    #[test]
+    fn spawn_starts_in_specified_cwd() {
+        let client_dir = tempfile::tempdir().expect("client tempdir");
+        let expected = std::fs::canonicalize(client_dir.path()).expect("canonicalize client dir");
+        let reported = spawn_pwd_report(Some(&path_wire::encode_path(client_dir.path())));
+        assert_eq!(path_wire::decode_path(&reported), expected);
+    }
+
+    #[test]
+    fn spawn_falls_back_to_process_cwd_when_cwd_none() {
+        let reported = spawn_pwd_report(None);
+        assert_eq!(path_wire::decode_path(&reported), canonical_process_cwd());
+    }
+
+    #[test]
+    fn spawn_falls_back_to_process_cwd_when_cwd_empty() {
+        let reported = spawn_pwd_report(Some(&PathWire::default()));
+        assert_eq!(path_wire::decode_path(&reported), canonical_process_cwd());
+    }
+
+    /// End-to-end losslessness proof: a non-UTF-8 cwd survives the full
+    /// `Session::spawn` → child cwd → report pipeline byte-for-byte (skipped on
+    /// filesystems that reject non-UTF-8 names, e.g. macOS).
+    #[cfg(unix)]
+    #[test]
+    fn spawn_round_trips_non_utf8_cwd() {
+        let base = tempfile::tempdir().expect("tempdir");
+        let Some(dir) = try_non_utf8_dir(base.path()) else {
+            eprintln!("skipping: filesystem rejects non-UTF-8 directory names");
+            return;
+        };
+        let reported = spawn_pwd_report(Some(&path_wire::encode_path(&dir)));
+        let expected = std::fs::canonicalize(&dir).expect("canonicalize non-utf8 dir");
+        assert_eq!(path_wire::decode_path(&reported), expected);
     }
 }

--- a/crates/term-session-server/src/session.rs
+++ b/crates/term-session-server/src/session.rs
@@ -183,9 +183,12 @@ mod tests {
 
     /// Poll `report` until the mock `pwd` child has written its cwd, with a
     /// generous timeout so a broken spawn fails the assertion instead of
-    /// hanging the test. Returns the raw report bytes so losslessness is
-    /// asserted byte-for-byte.
-    fn read_report(report: &Path) -> Vec<u8> {
+    /// hanging the test. Meanwhile `read_output()` pumps the PTY so the
+    /// child's DSR startup handshake completes (a Windows console child
+    /// stalls until the host answers `\x1b[6n`) — otherwise the mock never
+    /// runs and no report is written. Returns the raw report bytes so
+    /// losslessness is asserted byte-for-byte.
+    fn read_report(session: &mut Session, report: &Path) -> Vec<u8> {
         let deadline = Instant::now() + Duration::from_secs(REPORT_TIMEOUT_SECS);
         loop {
             if let Ok(content) = std::fs::read(report) {
@@ -195,12 +198,18 @@ mod tests {
                 Instant::now() < deadline,
                 "mock pwd never wrote the report at {report:?}"
             );
+            session.read_output();
             std::thread::sleep(Duration::from_millis(50));
         }
     }
 
     /// Spawn a session running `mock pwd <report>` with the given wire-encoded
     /// cwd and return the wire bytes the child reports.
+    ///
+    /// The mock is a console app spawned through a PTY, which on Windows
+    /// stalls at startup until the host answers its DSR cursor-position query
+    /// (`\x1b[6n` → `\x1b[row;colR`). The wait loop therefore pumps the PTY via
+    /// `read_output()` → `screen()`, mirroring the real daemon's poll/sync loop.
     fn spawn_pwd_report(cwd: Option<&PathWire>) -> PathWire {
         let dir = tempfile::tempdir().expect("report tempdir");
         let report = dir.path().join("pwd.txt");
@@ -210,9 +219,11 @@ mod tests {
             "pwd".to_string(),
             report.to_string_lossy().into_owned(),
         ];
-        let _session =
+        let mut session =
             Session::spawn(1, Some(cmd), TEST_COLS, TEST_ROWS, None, cwd).expect("spawn session");
-        PathWire::from(read_report(&report))
+        let bytes = read_report(&mut session, &report);
+        session.pty.kill_child().ok();
+        PathWire::from(bytes)
     }
 
     fn canonical_process_cwd() -> PathBuf {
@@ -225,19 +236,22 @@ mod tests {
         let client_dir = tempfile::tempdir().expect("client tempdir");
         let expected = std::fs::canonicalize(client_dir.path()).expect("canonicalize client dir");
         let reported = spawn_pwd_report(Some(&path_wire::encode_path(client_dir.path())));
-        assert_eq!(path_wire::decode_path(&reported), expected);
+        let reported = std::fs::canonicalize(reported.decode()).expect("canonicalize reported");
+        assert_eq!(reported, expected);
     }
 
     #[test]
     fn spawn_falls_back_to_process_cwd_when_cwd_none() {
         let reported = spawn_pwd_report(None);
-        assert_eq!(path_wire::decode_path(&reported), canonical_process_cwd());
+        let reported = std::fs::canonicalize(reported.decode()).expect("canonicalize reported");
+        assert_eq!(reported, canonical_process_cwd());
     }
 
     #[test]
     fn spawn_falls_back_to_process_cwd_when_cwd_empty() {
         let reported = spawn_pwd_report(Some(&PathWire::default()));
-        assert_eq!(path_wire::decode_path(&reported), canonical_process_cwd());
+        let reported = std::fs::canonicalize(reported.decode()).expect("canonicalize reported");
+        assert_eq!(reported, canonical_process_cwd());
     }
 
     /// End-to-end losslessness proof: a non-UTF-8 cwd survives the full

--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -14,7 +14,8 @@ use term_session_muxio_service_definitions::{
     Attach, ChannelInfo, ChannelName, ClientInfo, CloseSession, KillChannel, KillClient,
     ListChannels, ListChannelsResponse, OnPtyResized, RPC_ERROR_LIVE_SESSIONS,
     RPC_ERROR_SHUTTING_DOWN, RPC_ERROR_UNATTACHED, ResizePty, STREAM_INPUT_METHOD_ID,
-    SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway, Spawn, WriteInput,
+    SUBSCRIBE_OUTPUT_METHOD_ID, SessionInfo, ShutdownGateway, Spawn, SpawnRequest, SpawnResponse,
+    WriteInput,
 };
 use term_wm_pty_engine::PtyStatus;
 
@@ -624,7 +625,12 @@ pub async fn run_gateway(
                 if state.is_shutting_down.load(Ordering::SeqCst) {
                     return Err(rpc_err(RPC_ERROR_SHUTTING_DOWN));
                 }
-                let (cmd, cols, rows) = Spawn::decode_request(&payload)?;
+                let SpawnRequest {
+                    cmd,
+                    cols,
+                    rows,
+                    cwd,
+                } = Spawn::decode_request(&payload)?;
                 let channel = bound_channel(state.as_ref(), ctx.conn_id).await;
                 let Some(channel) = channel else {
                     return Err(rpc_err(RPC_ERROR_UNATTACHED));
@@ -680,7 +686,8 @@ pub async fn run_gateway(
                         let g = ch.lock().await;
                         g.notify_clients(&targets, ncols, nrows);
                     }
-                    return Spawn::encode_response((id, cols, rows)).map_err(boxed_io);
+                    return Spawn::encode_response(SpawnResponse { id, cols, rows })
+                        .map_err(boxed_io);
                 }
 
                 // Respawn: new non-empty cmd overwrites the stored template;
@@ -695,8 +702,19 @@ pub async fn run_gateway(
                 } else {
                     None
                 };
+                // Spawn in the client's launch directory when provided (the
+                // caller expects to land where they ran `term-session`), else
+                // fall back to the daemon's cwd for legacy/empty payloads.
+                let effective_cwd = cwd.filter(|c| !c.is_empty());
                 let id = SESSION_ID;
-                let session = Session::spawn(id, effective_cmd, cols, rows, Some(&channel))?;
+                let session = Session::spawn(
+                    id,
+                    effective_cmd,
+                    cols,
+                    rows,
+                    Some(&channel),
+                    effective_cwd.as_ref(),
+                )?;
                 guard.set_session(session);
                 guard.recalculate_pty_size();
                 let targets: Vec<ClientEntry> = guard.clients.values().cloned().collect();
@@ -708,7 +726,12 @@ pub async fn run_gateway(
                     let g = ch.lock().await;
                     g.notify_clients(&targets, ncols, nrows);
                 }
-                Spawn::encode_response((sid, scol, srow)).map_err(boxed_io)
+                Spawn::encode_response(SpawnResponse {
+                    id: sid,
+                    cols: scol,
+                    rows: srow,
+                })
+                .map_err(boxed_io)
             }
         })
         .await

--- a/crates/term-session/Cargo.toml
+++ b/crates/term-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "term-session"
-description = "Run terminal sessions in a detached daemon and attach locally or over SSH. Works on macOS, Linux, and Windows."
+description = "Run and share terminal sessions in a detached daemon and attach locally or over SSH."
 keywords = ["terminal", "pty", "session", "multiplexer"]
 categories = ["command-line-utilities", "emulators", "network-programming", "os"]
 authors.workspace = true
@@ -29,6 +29,8 @@ tracing-subscriber = { workspace = true }
 windows-sys = { workspace = true }
 
 [dev-dependencies]
+interprocess = { workspace = true }
 muxio-tokio-rpc-ipc-client = { workspace = true }
+tempfile = { workspace = true }
 term-session-mock = { workspace = true }
 tokio = { workspace = true }

--- a/crates/term-session/README.md
+++ b/crates/term-session/README.md
@@ -1,5 +1,7 @@
 # term-session
 
+**ALPHA SOFTWARE: Expect breaking changes.**
+
 A cross-platform, layout-agnostic, headless terminal session host and multiplexer: one gateway, many sessions, each shared by many attached clients.
 
 `term-session` provides the persistence layer for terminal applications. It operates similarly to `tmux` or `GNU screen`, ensuring that running processes survive client disconnects. Any number of clients can **attach to and share the same live session simultaneously** — every attached terminal sees the same viewport and can type into the same process, across local terminals, SSH hops, or mixed platforms. Unlike traditional window managers, `term-session` enforces **no layout paradigm**. It is a pure session daemon.

--- a/crates/term-session/src/main.rs
+++ b/crates/term-session/src/main.rs
@@ -79,9 +79,36 @@ enum Command {
 }
 
 fn main() {
+    // Preserve the real stderr before `run_session` may `dup2` it into the
+    // tracing pipe (see `redirect_fd_to_tracing`): a fatal error returned
+    // after the terminal UI has started must still be visible to the user, so
+    // report it through this preserved handle instead of the (possibly
+    // redirected) fd 2. Best-effort: if `dup` fails, fall back to `eprintln!`.
+    #[cfg(unix)]
+    let orig_stderr: Option<std::fs::File> = {
+        use std::os::unix::io::FromRawFd;
+        let fd = unsafe { libc::dup(libc::STDERR_FILENO) };
+        if fd >= 0 {
+            Some(unsafe { std::fs::File::from_raw_fd(fd) })
+        } else {
+            None
+        }
+    };
+
     // Print errors as readable messages (Display), not Rust's Debug dump that
     // `main() -> Result` emits by default (e.g. `Custom { kind: ..., ... }`).
     if let Err(e) = run() {
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            match orig_stderr {
+                Some(mut f) => {
+                    let _ = writeln!(f, "error: {e}");
+                }
+                None => eprintln!("error: {e}"),
+            }
+        }
+        #[cfg(not(unix))]
         eprintln!("error: {e}");
         std::process::exit(1);
     }
@@ -160,7 +187,7 @@ fn list() -> io::Result<()> {
         let session = ch
             .session
             .as_ref()
-            .map(|s| format!("session size: {}x{}", s.cols, s.rows))
+            .map(|s| format!("shared size: {}x{}", s.cols, s.rows))
             .unwrap_or_else(|| "none".to_string());
         let nclients = ch.clients.len();
         println!();
@@ -169,7 +196,7 @@ fn list() -> io::Result<()> {
             "  created: {}",
             term_session::format_unix_relative(ch.created_at_unix)
         );
-        println!("  session: {}", session);
+        println!("  {session}");
         println!(
             "  clients: {}",
             if nclients == 0 {

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -293,10 +293,15 @@ async fn session_starts_in_client_cwd() {
         tokio::time::sleep(Duration::from_millis(50)).await;
     };
     // The child's `current_dir()` is the OS-canonical path (on macOS `/var`
-    // resolves to `/private/var`), so canonicalize the expected dir.
+    // resolves to `/private/var`; on Windows it may be the 8.3 short form and
+    // differ from `canonicalize`'s long form + `\\?\` prefix), so canonicalize
+    // both sides before comparing.
+    let got_path = path_wire::decode_path(&path_wire::PathWire::from(got));
+    let got = std::fs::canonicalize(&got_path)
+        .unwrap_or_else(|e| panic!("failed to canonicalize reported cwd {got_path:?}: {e}"));
     let expected = std::fs::canonicalize(client_dir.path()).unwrap();
     assert_eq!(
-        path_wire::decode_path(&path_wire::PathWire::from(got)),
+        got,
         expected,
         "session must start in the client's launch directory, not the daemon's \
          startup directory ({:?})",

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -14,7 +14,8 @@ use std::time::{Duration, Instant};
 
 use muxio_tokio_rpc_ipc_client::RpcCallPrebuffered;
 use term_session_muxio_service_definitions::{
-    Attach, AttachRequest, ChannelName, ListChannels, ShutdownGateway, Spawn, probe_ipc_endpoint,
+    Attach, AttachRequest, ChannelName, ListChannels, ShutdownGateway, Spawn, SpawnRequest,
+    SpawnResponse, path_wire, probe_ipc_endpoint,
 };
 
 /// The compiled `term-session` binary under test.
@@ -58,6 +59,20 @@ fn spawn_daemon(gateway: &str, selfcheck: bool) -> (Child, Option<PathBuf>) {
         .stderr(Stdio::null());
     let child = cmd.spawn().expect("spawn daemon");
     (child, marker)
+}
+
+/// Spawn the daemon with an explicit current directory (distinct from the
+/// test harness's cwd), so cwd-propagation tests can detect whether a session
+/// inherits the daemon's startup directory or the client's launch directory.
+fn spawn_daemon_in(gateway: &str, cwd: &std::path::Path) -> Child {
+    let mut cmd = Command::new(bin());
+    cmd.env("TERM_WM_GATEWAY", gateway)
+        .arg("--daemon")
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd.spawn().expect("spawn daemon")
 }
 
 /// Attach a client to a channel and return its server-assigned conn id,
@@ -137,15 +152,16 @@ async fn daemon_survives_all_clients_disconnecting() {
     attach_to(&client, channel, "t").await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![
+        SpawnRequest {
+            cmd: Some(vec![
                 mock_bin().to_string_lossy().to_string(),
                 "sleep".into(),
                 "60000".into(),
             ]),
-            80u16,
-            24u16,
-        ),
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -155,7 +171,17 @@ async fn daemon_survives_all_clients_disconnecting() {
     // fresh attach/spawn must succeed (session respawns / persists).
     let client2 = wait_connectable(&gateway).await;
     attach_to(&client2, channel, "t").await;
-    Spawn::call(&*client2, (None, 80u16, 24u16)).await.unwrap();
+    Spawn::call(
+        &*client2,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     ShutdownGateway::call(&*client2, true).await.unwrap();
     let _ = child.wait();
@@ -188,12 +214,97 @@ async fn daemon_survives_parent_death() {
     // exited — sessions are torn down only when their process ends).
     let client = wait_connectable(&gateway).await;
     attach_to(&client, channel, "t").await;
-    let (id, _, _) = Spawn::call(&*client, (None, 80u16, 24u16)).await.unwrap();
+    let SpawnResponse {
+        id,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
     assert_eq!(id, 1, "session from the orphaned daemon must persist");
 
     ShutdownGateway::call(&*client, true).await.unwrap();
     // Give the daemon time to run its teardown and exit.
     tokio::time::sleep(Duration::from_millis(1000)).await;
+}
+
+#[tokio::test]
+async fn session_starts_in_client_cwd() {
+    // A fresh gateway per run: `unique_gateway`'s counter resets per process,
+    // so a daemon left over from a failed run on the same name would hold the
+    // socket and this test would attach to the wrong (stale) gateway. Deriving
+    // the name from the current time guarantees no collision with leftovers.
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let gateway = format!("term-wm/dtest-client_cwd-{nonce}");
+    let channel = "test/client_cwd";
+
+    // Distinct directories: the daemon's startup cwd vs the client's launch
+    // cwd. The session must start in the latter, not the daemon's. TempDirs
+    // auto-cleanup on drop (after the daemon has been shut down).
+    let daemon_dir = tempfile::tempdir().expect("daemon tempdir");
+    let client_dir = tempfile::tempdir().expect("client tempdir");
+    let report_dir = tempfile::tempdir().expect("report tempdir");
+    let report = report_dir.path().join("pwd.txt");
+
+    let mut child = spawn_daemon_in(&gateway, daemon_dir.path());
+    let client = wait_connectable(&gateway).await;
+    attach_to(&client, channel, "cwd").await;
+
+    // Spawn `mock pwd <report>` with the client's launch directory. The mock
+    // writes the child's actual cwd to `report` (an absolute path) and exits.
+    Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: Some(vec![
+                mock_bin().to_string_lossy().to_string(),
+                "pwd".into(),
+                report.to_string_lossy().to_string(),
+            ]),
+            cols: 80u16,
+            rows: 24u16,
+            cwd: Some(path_wire::encode_path(client_dir.path())),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Poll for the report: the mock writes it right before exiting. The mock
+    // reports its cwd as raw wire bytes (lossless), so read them byte-for-byte.
+    let start = Instant::now();
+    let got = loop {
+        if let Ok(content) = std::fs::read(&report) {
+            break content;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "mock pwd never wrote the report"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    // The child's `current_dir()` is the OS-canonical path (on macOS `/var`
+    // resolves to `/private/var`), so canonicalize the expected dir.
+    let expected = std::fs::canonicalize(client_dir.path()).unwrap();
+    assert_eq!(
+        path_wire::decode_path(&path_wire::PathWire::from(got)),
+        expected,
+        "session must start in the client's launch directory, not the daemon's \
+         startup directory ({:?})",
+        daemon_dir.path()
+    );
+
+    ShutdownGateway::call(&*client, true).await.unwrap();
+    let _ = child.wait();
 }
 
 /// The daemon must never inherit the parent's open handles. Regression guard
@@ -407,19 +518,30 @@ async fn cli_kill_client_detaches_one_client() {
     attach_to(&c2, channel, "two").await;
     Spawn::call(
         &*c1,
-        (
-            Some(vec![
+        SpawnRequest {
+            cmd: Some(vec![
                 mock_bin().to_string_lossy().to_string(),
                 "sleep".into(),
                 "60000".into(),
             ]),
-            80u16,
-            24u16,
-        ),
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    Spawn::call(&*c2, (None, 80u16, 24u16)).await.unwrap();
+    Spawn::call(
+        &*c2,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     // Read the conn ids from `list` (as an operator would).
     let resp = ListChannels::call(&*c1, ()).await.unwrap();
@@ -629,7 +751,17 @@ async fn cli_list_renders_client_identity() {
     )
     .await
     .unwrap();
-    Spawn::call(&*client, (None, 80u16, 24u16)).await.unwrap();
+    Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let out = Command::new(bin())
         .env("TERM_WM_GATEWAY", &gateway)
@@ -669,15 +801,16 @@ async fn cli_stop_requires_force_when_live_sessions() {
     attach_to(&client, channel, "cli").await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![
+        SpawnRequest {
+            cmd: Some(vec![
                 mock_bin().to_string_lossy().to_string(),
                 "sleep".into(),
                 "60000".into(),
             ]),
-            80u16,
-            24u16,
-        ),
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -715,4 +848,53 @@ async fn cli_stop_requires_force_when_live_sessions() {
         String::from_utf8_lossy(&out.stderr)
     );
     let _ = child.wait();
+}
+
+/// Regression: a connection/handshake failure must surface on the client's
+/// stderr instead of being silently swallowed by the stderr→tracing redirect
+/// (see `redirect_fd_to_tracing` in `term-session-client`). The gateway is
+/// "occupied" by a socket that accepts and immediately feeds garbage + closes
+/// each connection (no muxio handshake), so Attach fails deterministically
+/// without auto-spawning a new daemon (probe succeeds because something is
+/// bound). Unix-only: the redirect is a unix `dup2` mechanism.
+#[cfg(unix)]
+#[test]
+fn connection_error_is_printed_to_stderr() {
+    use interprocess::local_socket::{GenericNamespaced, ListenerOptions, ToNsName, prelude::*};
+    use std::io::Write;
+
+    let gateway = unique_gateway("silent-exit");
+    let name = gateway
+        .as_str()
+        .to_ns_name::<GenericNamespaced>()
+        .expect("gateway ns name");
+    let listener = ListenerOptions::new()
+        .name(name)
+        .try_overwrite(true)
+        .create_sync()
+        .expect("bind dummy gateway");
+    let acceptor = std::thread::spawn(move || {
+        while let Ok(mut stream) = listener.accept() {
+            // Garbage + close: muxio decode fails rather than silently EOF.
+            let _ = stream.write_all(b"not-a-muxio-frame");
+        }
+    });
+
+    let out = Command::new(bin())
+        .env("TERM_WM_GATEWAY", &gateway)
+        .args(["--channel", "test/silent-exit"])
+        .output()
+        .expect("run client");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.trim().is_empty(),
+        "client must emit a diagnostic on a failed connection (silent-exit regression), got empty stderr"
+    );
+    assert!(
+        !out.status.success(),
+        "client must exit non-zero, got status: {:?}",
+        out.status.code()
+    );
+    drop(acceptor);
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -854,6 +854,29 @@ async fn kill_channel_respawns_with_stored_cmd() {
     // Re-attach (a fresh conn) and respawn — the stored cmd template is used.
     let c2 = connect_client_with_retry(guard.socket()).await;
     attach_client(&c2, &channel).await;
+
+    // Wait for the kill to fully land before respawning: the killed session
+    // lingers until the output-polling task observes its death, and a Spawn
+    // during that window would "reuse" the dying session instead of respawning —
+    // leaving the channel with no session right after respawn (CI-timing flake).
+    let start = std::time::Instant::now();
+    loop {
+        let channels = list_channels(&c2).await;
+        let ch = channels
+            .channels
+            .iter()
+            .find(|c| c.name == "test/kill_respawn");
+        let gone = ch.map(|c| c.session.is_none()).unwrap_or(true);
+        if gone {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "killed session never cleared from channel"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
     let SpawnResponse {
         id,
         cols: _,

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use term_session_muxio_service_definitions::{
     Attach, AttachRequest, CloseSession, KillChannel, KillClient, ResizePty,
-    STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, ShutdownGateway, Spawn,
+    STREAM_INPUT_METHOD_ID, SUBSCRIBE_OUTPUT_METHOD_ID, ShutdownGateway, Spawn, SpawnRequest,
+    SpawnResponse,
 };
 
 mod common;
@@ -20,9 +21,18 @@ use term_wm_pty_engine::clipboard::Osc52Extractor;
 async fn session_spawn_returns_id() {
     let mock = get_mock_bin();
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/spawn_returns_id")).await;
-    let (id, _, _) = Spawn::call(
+    let SpawnResponse {
+        id,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
         &*client,
-        (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -36,7 +46,12 @@ async fn session_input_output_roundtrip() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/input_output")).await;
     Spawn::call(
         &*client,
-        (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -67,7 +82,12 @@ async fn session_mouse_bytes_forwarded() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/mouse_forward")).await;
     Spawn::call(
         &*client,
-        (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -114,7 +134,12 @@ async fn session_mouse_bytes_forwarded() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/mouse_forward")).await;
     Spawn::call(
         &*client,
-        (Some(vec![mock, "capture".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "capture".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -150,7 +175,12 @@ async fn session_osc52_in_output() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/osc52_output")).await;
     Spawn::call(
         &*client,
-        (Some(vec![mock, "osc52".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "osc52".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -179,7 +209,12 @@ async fn session_osc52_via_osc52extractor() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/osc52_extractor")).await;
     Spawn::call(
         &*client,
-        (Some(vec![mock, "osc52".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "osc52".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -234,7 +269,12 @@ async fn session_resize() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/resize")).await;
     Spawn::call(
         &*client,
-        (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -250,11 +290,12 @@ async fn session_list_channels() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/list_channels")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock, "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -279,11 +320,12 @@ async fn session_close_session() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/close_session")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock, "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -320,11 +362,12 @@ async fn session_child_exit() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/child_exit")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock, "exit".into(), "0".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "exit".into(), "0".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -358,11 +401,12 @@ async fn session_child_exit_before_subscribe() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/child_exit_early")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock, "exit".into(), "0".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "exit".into(), "0".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -404,11 +448,12 @@ async fn session_reconnect() {
     attach_client(&client1, &channel).await;
     Spawn::call(
         &*client1,
-        (
-            Some(vec![mock.clone(), "echo".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -452,17 +497,18 @@ async fn term_bench_runs_to_completion() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/bench")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![
+        SpawnRequest {
+            cmd: Some(vec![
                 bench_bin.to_string_lossy().to_string(),
                 "-d".into(),
                 "1".into(),
                 "-f".into(),
                 "10".into(),
             ]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -513,17 +559,26 @@ async fn two_channels_run_concurrently_with_isolated_io() {
     attach_client(&b, &chan_b).await;
     Spawn::call(
         &*a,
-        (
-            Some(vec![mock.clone(), "echo".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    Spawn::call(&*b, (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*b,
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let (_, mut reader_b) = b.open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0).await.unwrap();
     let (writer_b, _) = b.open_channel(STREAM_INPUT_METHOD_ID, 0).await.unwrap();
@@ -557,15 +612,26 @@ async fn list_channels_reports_clients_and_geometry() {
     let _conn2 = attach_client(&c2, &channel).await;
     Spawn::call(
         &*c1,
-        (
-            Some(vec![mock, "sleep".into(), "60000".into()]),
-            120u16,
-            40u16,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "sleep".into(), "60000".into()]),
+            cols: 120u16,
+            rows: 40u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    Spawn::call(&*c2, (None, 80u16, 24u16)).await.unwrap();
+    Spawn::call(
+        &*c2,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let resp = list_channels(&c1).await;
     let channels = &resp.channels;
@@ -602,11 +668,12 @@ async fn list_channels_reports_clients_and_geometry() {
 async fn spawn_session_with_grandchild(client: &Arc<RpcIpcClient>, mock: &str) -> u32 {
     Spawn::call(
         &**client,
-        (
-            Some(vec![mock.to_string(), "spawn_child".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.to_string(), "spawn_child".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .expect("spawn with grandchild");
@@ -716,17 +783,26 @@ async fn kill_channel_kills_only_that_channel() {
     attach_client(&b, &chan_b).await;
     Spawn::call(
         &*a,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    Spawn::call(&*b, (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*b,
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let (_, mut reader_b) = b.open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0).await.unwrap();
 
@@ -761,11 +837,12 @@ async fn kill_channel_respawns_with_stored_cmd() {
     attach_client(&c, &channel).await;
     Spawn::call(
         &*c,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -777,9 +854,21 @@ async fn kill_channel_respawns_with_stored_cmd() {
     // Re-attach (a fresh conn) and respawn — the stored cmd template is used.
     let c2 = connect_client_with_retry(guard.socket()).await;
     attach_client(&c2, &channel).await;
-    let (id, _, _) = Spawn::call(&*c2, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    let SpawnResponse {
+        id,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
+        &*c2,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
     assert_eq!(id, 1);
     let channels = list_channels(&c2).await;
     let ch = channels
@@ -804,13 +893,26 @@ async fn kill_client_detaches_one_socket_only() {
     attach_client(&c2, &channel).await;
     Spawn::call(
         &*c1,
-        (Some(vec![mock, "echo".into()]), TEST_COLS, TEST_ROWS),
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    Spawn::call(&*c2, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*c2,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let (_, mut reader1) = c1
         .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
@@ -866,9 +968,17 @@ async fn kill_client_rejects_nonexistent_conn() {
     let channel = test_channel("test/kill_missing");
     let client = connect_client_with_retry(guard.socket()).await;
     attach_client(&client, &channel).await;
-    Spawn::call(&*client, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     // A conn_id that was never assigned must be rejected, not silently
     // accepted (KillClient must target a real attached client).
@@ -892,12 +1002,28 @@ async fn kill_client_rejects_wrong_channel() {
     let b = connect_client_with_retry(guard.socket()).await;
     let conn_a = attach_client(&a, &channel_a).await;
     attach_client(&b, &channel_b).await;
-    Spawn::call(&*a, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
-    Spawn::call(&*b, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*a,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
+    Spawn::call(
+        &*b,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     // conn_a is attached to channel_a; killing it "on channel_b" must fail and
     // must not detach it.
@@ -928,7 +1054,16 @@ async fn kill_client_rejects_wrong_channel() {
 async fn unattached_client_rejected() {
     let guard = spawn_gateway().await;
     let client = connect_client_with_retry(guard.socket()).await;
-    let result = Spawn::call(&*client, (None, TEST_COLS, TEST_ROWS)).await;
+    let result = Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await;
     assert!(result.is_err(), "unattached Spawn must be rejected");
     guard.shutdown().await;
 }
@@ -938,20 +1073,34 @@ async fn unattached_client_rejected() {
 async fn spawn_idempotent_on_live_session() {
     let mock = get_mock_bin();
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/spawn_idem")).await;
-    let (id1, _, _) = Spawn::call(
+    let SpawnResponse {
+        id: id1,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
         &*client,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            120u16,
-            40u16,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: 120u16,
+            rows: 40u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
     // Second Spawn with a DIFFERENT cmd must reuse the live session.
-    let (id2, cols, rows) = Spawn::call(
+    let SpawnResponse {
+        id: id2,
+        cols,
+        rows,
+    } = Spawn::call(
         &*client,
-        (Some(vec![mock, "exit".into(), "0".into()]), 80u16, 24u16),
+        SpawnRequest {
+            cmd: Some(vec![mock, "exit".into(), "0".into()]),
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -968,11 +1117,12 @@ async fn spawn_cmd_ignored_on_live_session() {
     let (client, _conn_id, guard) = spawn_session(&test_channel("test/cmd_ignored")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -982,13 +1132,18 @@ async fn spawn_cmd_ignored_on_live_session() {
     // ignored and the original `sleep` process kept running.
     let c2 = connect_client_with_retry(guard.socket()).await;
     attach_client(&c2, &test_channel("test/cmd_ignored")).await;
-    let (id2, _, _) = Spawn::call(
+    let SpawnResponse {
+        id: id2,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
         &*c2,
-        (
-            Some(vec![mock, "exit".into(), "0".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "exit".into(), "0".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -1024,18 +1179,51 @@ async fn session_multi_client_pty_constrained_to_smallest() {
     attach_client(&c2, &channel).await;
     attach_client(&c3, &channel).await;
 
-    let (pid1, _, _) = Spawn::call(
+    let SpawnResponse {
+        id: pid1,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
         &*c1,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            120u16,
-            40u16,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: 120u16,
+            rows: 40u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    let (_pid2, _, _) = Spawn::call(&*c2, (None, 80u16, 24u16)).await.unwrap();
-    let (_pid3, _, _) = Spawn::call(&*c3, (None, 100u16, 30u16)).await.unwrap();
+    let SpawnResponse {
+        id: _pid2,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
+        &*c2,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
+    let SpawnResponse {
+        id: _pid3,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
+        &*c3,
+        SpawnRequest {
+            cmd: None,
+            cols: 100u16,
+            rows: 30u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     // All clients should see 80x24 (c2 is smallest)
     let start = std::time::Instant::now();
@@ -1067,18 +1255,51 @@ async fn session_multi_client_disconnect_expands_pty() {
     attach_client(&c2, &channel).await;
     attach_client(&c3, &channel).await;
 
-    let (pid1, _, _) = Spawn::call(
+    let SpawnResponse {
+        id: pid1,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
         &*c1,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            120u16,
-            40u16,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: 120u16,
+            rows: 40u16,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
-    let (_pid2, _, _) = Spawn::call(&*c2, (None, 80u16, 24u16)).await.unwrap();
-    let (_pid3, _, _) = Spawn::call(&*c3, (None, 100u16, 30u16)).await.unwrap();
+    let SpawnResponse {
+        id: _pid2,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
+        &*c2,
+        SpawnRequest {
+            cmd: None,
+            cols: 80u16,
+            rows: 24u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
+    let SpawnResponse {
+        id: _pid3,
+        cols: _,
+        rows: _,
+    } = Spawn::call(
+        &*c3,
+        SpawnRequest {
+            cmd: None,
+            cols: 100u16,
+            rows: 30u16,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     // Drop c2 (smallest) → PTY expands to 100x30 (c3's size)
     drop(c2);
@@ -1121,11 +1342,12 @@ async fn shutdown_gateway_stops_daemon() {
     attach_client(&client, &channel).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock, "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -1154,21 +1376,23 @@ async fn list_channels_orders_channels_and_clients_by_creation() {
     attach_client(&cb, &test_channel("test/order_b")).await;
     Spawn::call(
         &*ca,
-        (
-            Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock.clone(), "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
     Spawn::call(
         &*cb,
-        (
-            Some(vec![mock, "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();
@@ -1178,9 +1402,17 @@ async fn list_channels_orders_channels_and_clients_by_creation() {
     // up in `list` once it has Spawned, so spawn it too.)
     let ca2 = connect_client_with_retry(&socket).await;
     attach_client(&ca2, &test_channel("test/order_a")).await;
-    Spawn::call(&*ca2, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*ca2,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let resp = list_channels(&ca).await;
     let names: Vec<&str> = resp.channels.iter().map(|c| c.name.as_str()).collect();
@@ -1223,9 +1455,17 @@ async fn list_channels_reports_client_identity() {
     )
     .await
     .unwrap();
-    Spawn::call(&*client, (None, TEST_COLS, TEST_ROWS))
-        .await
-        .unwrap();
+    Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: None,
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
 
     let resp = list_channels(&client).await;
     let ch = resp
@@ -1260,11 +1500,12 @@ async fn shutdown_refuses_without_force_when_live_sessions() {
     attach_client(&client, &test_channel("test/force")).await;
     Spawn::call(
         &*client,
-        (
-            Some(vec![mock, "sleep".into(), "60000".into()]),
-            TEST_COLS,
-            TEST_ROWS,
-        ),
+        SpawnRequest {
+            cmd: Some(vec![mock, "sleep".into(), "60000".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
     )
     .await
     .unwrap();


### PR DESCRIPTION
### Added

- **`PathWire` — a lossless path wire type:** `term-session` now transmits the caller's working directory as a dedicated `PathWire` newtype (`Option<PathWire>` on `SpawnRequest.cwd`) with a platform-native, byte-for-byte reversible encoding: Unix sends the raw `OsStr` bytes and Windows sends UTF-16 code units packed as little-endian `u16` pairs, so even non-UTF-8 Unix paths and unpaired-surrogate (WTF-16) Windows paths round-trip intact. The type ships inherent `encode` / `decode` / `to_path_buf` methods plus concrete `From<&Path>` / `From<PathBuf>` / `From<&str>` / `From<String>` conversions, and is wire-identical to a plain `Vec<u8>` (no ABI break). It is documented as **strictly same-host local IPC**: payloads carry no platform tag and are not portable across platforms — cross-OS decoding would silently garble; SSH remote sessions are unaffected (the daemon resolves the cwd on the remote host), and a canonical multi-platform encoding (e.g. WTF-8) was deliberately deferred.

### Changed

- **New sessions start in the caller's working directory:** a freshly spawned session now starts in the client's `current_dir` (captured at launch) instead of the daemon's frozen startup directory — previously every new channel's session inherited the daemon's cwd. The directory travels losslessly over the wire; `None`/empty falls back to the daemon's cwd; the mock/daemon E2E tests verify byte-for-byte fidelity for non-UTF-8 paths.

### Fixed

- **`term-session` connection failures print instead of silently exiting:** the client `dup2`'d its stderr into a tracing pipe at startup but never installed a tracing subscriber, so every connect/handshake/ABI error — e.g. a fresh client hitting a legacy daemon on the same socket — exited with code 1 and **zero output**. The redirect now happens only after the Attach/Spawn/channel handshake succeeds, and `main` preserves the original stderr FD so fatal errors, including mid-session disconnects, print `error: …` to the user's terminal after the TUI tears down. A unix-gated regression test (`connection_error_is_printed_to_stderr`) binds a fake wire-incompatible peer and asserts the client emits a diagnostic.
- **Windows build of the path wire decoder:** `decode_path`'s Windows branch used `OsString::from_wide` without importing `OsString`, so the definitions crate did not compile for `x86_64-pc-windows-msvc`; imports are now scoped to their `cfg` blocks and the Windows cross-check passes.
- **`term-session list` session line:** the redundant `session: session size: 114x56` phrasing is now just `shared size: 114x56`.