### PR TITLE
fix(term-session): Harden cwd/connection CI tests against cross-platform races

### DIFF
--- a/crates/term-session-muxio-service-definitions/src/path_wire.rs
+++ b/crates/term-session-muxio-service-definitions/src/path_wire.rs
@@ -144,7 +144,7 @@ pub fn decode_path(pw: &PathWire) -> PathBuf {
         use std::os::windows::ffi::OsStringExt;
         let bytes = &pw.0;
         debug_assert!(
-            bytes.len() % 2 == 0,
+            bytes.len().is_multiple_of(2),
             "windows cwd bytes must be u16 little-endian pairs"
         );
         let units = bytes

--- a/crates/term-session-server/src/session.rs
+++ b/crates/term-session-server/src/session.rs
@@ -183,9 +183,12 @@ mod tests {
 
     /// Poll `report` until the mock `pwd` child has written its cwd, with a
     /// generous timeout so a broken spawn fails the assertion instead of
-    /// hanging the test. Returns the raw report bytes so losslessness is
-    /// asserted byte-for-byte.
-    fn read_report(report: &Path) -> Vec<u8> {
+    /// hanging the test. Meanwhile `read_output()` pumps the PTY so the
+    /// child's DSR startup handshake completes (a Windows console child
+    /// stalls until the host answers `\x1b[6n`) — otherwise the mock never
+    /// runs and no report is written. Returns the raw report bytes so
+    /// losslessness is asserted byte-for-byte.
+    fn read_report(session: &mut Session, report: &Path) -> Vec<u8> {
         let deadline = Instant::now() + Duration::from_secs(REPORT_TIMEOUT_SECS);
         loop {
             if let Ok(content) = std::fs::read(report) {
@@ -195,12 +198,18 @@ mod tests {
                 Instant::now() < deadline,
                 "mock pwd never wrote the report at {report:?}"
             );
+            session.read_output();
             std::thread::sleep(Duration::from_millis(50));
         }
     }
 
     /// Spawn a session running `mock pwd <report>` with the given wire-encoded
     /// cwd and return the wire bytes the child reports.
+    ///
+    /// The mock is a console app spawned through a PTY, which on Windows
+    /// stalls at startup until the host answers its DSR cursor-position query
+    /// (`\x1b[6n` → `\x1b[row;colR`). The wait loop therefore pumps the PTY via
+    /// `read_output()` → `screen()`, mirroring the real daemon's poll/sync loop.
     fn spawn_pwd_report(cwd: Option<&PathWire>) -> PathWire {
         let dir = tempfile::tempdir().expect("report tempdir");
         let report = dir.path().join("pwd.txt");
@@ -210,9 +219,11 @@ mod tests {
             "pwd".to_string(),
             report.to_string_lossy().into_owned(),
         ];
-        let _session =
+        let mut session =
             Session::spawn(1, Some(cmd), TEST_COLS, TEST_ROWS, None, cwd).expect("spawn session");
-        PathWire::from(read_report(&report))
+        let bytes = read_report(&mut session, &report);
+        session.pty.kill_child().ok();
+        PathWire::from(bytes)
     }
 
     fn canonical_process_cwd() -> PathBuf {
@@ -225,19 +236,22 @@ mod tests {
         let client_dir = tempfile::tempdir().expect("client tempdir");
         let expected = std::fs::canonicalize(client_dir.path()).expect("canonicalize client dir");
         let reported = spawn_pwd_report(Some(&path_wire::encode_path(client_dir.path())));
-        assert_eq!(path_wire::decode_path(&reported), expected);
+        let reported = std::fs::canonicalize(&reported.decode()).expect("canonicalize reported");
+        assert_eq!(reported, expected);
     }
 
     #[test]
     fn spawn_falls_back_to_process_cwd_when_cwd_none() {
         let reported = spawn_pwd_report(None);
-        assert_eq!(path_wire::decode_path(&reported), canonical_process_cwd());
+        let reported = std::fs::canonicalize(&reported.decode()).expect("canonicalize reported");
+        assert_eq!(reported, canonical_process_cwd());
     }
 
     #[test]
     fn spawn_falls_back_to_process_cwd_when_cwd_empty() {
         let reported = spawn_pwd_report(Some(&PathWire::default()));
-        assert_eq!(path_wire::decode_path(&reported), canonical_process_cwd());
+        let reported = std::fs::canonicalize(&reported.decode()).expect("canonicalize reported");
+        assert_eq!(reported, canonical_process_cwd());
     }
 
     /// End-to-end losslessness proof: a non-UTF-8 cwd survives the full

--- a/crates/term-session-server/src/session.rs
+++ b/crates/term-session-server/src/session.rs
@@ -236,21 +236,21 @@ mod tests {
         let client_dir = tempfile::tempdir().expect("client tempdir");
         let expected = std::fs::canonicalize(client_dir.path()).expect("canonicalize client dir");
         let reported = spawn_pwd_report(Some(&path_wire::encode_path(client_dir.path())));
-        let reported = std::fs::canonicalize(&reported.decode()).expect("canonicalize reported");
+        let reported = std::fs::canonicalize(reported.decode()).expect("canonicalize reported");
         assert_eq!(reported, expected);
     }
 
     #[test]
     fn spawn_falls_back_to_process_cwd_when_cwd_none() {
         let reported = spawn_pwd_report(None);
-        let reported = std::fs::canonicalize(&reported.decode()).expect("canonicalize reported");
+        let reported = std::fs::canonicalize(reported.decode()).expect("canonicalize reported");
         assert_eq!(reported, canonical_process_cwd());
     }
 
     #[test]
     fn spawn_falls_back_to_process_cwd_when_cwd_empty() {
         let reported = spawn_pwd_report(Some(&PathWire::default()));
-        let reported = std::fs::canonicalize(&reported.decode()).expect("canonicalize reported");
+        let reported = std::fs::canonicalize(reported.decode()).expect("canonicalize reported");
         assert_eq!(reported, canonical_process_cwd());
     }
 

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -293,10 +293,15 @@ async fn session_starts_in_client_cwd() {
         tokio::time::sleep(Duration::from_millis(50)).await;
     };
     // The child's `current_dir()` is the OS-canonical path (on macOS `/var`
-    // resolves to `/private/var`), so canonicalize the expected dir.
+    // resolves to `/private/var`; on Windows it may be the 8.3 short form and
+    // differ from `canonicalize`'s long form + `\\?\` prefix), so canonicalize
+    // both sides before comparing.
+    let got_path = path_wire::decode_path(&path_wire::PathWire::from(got));
+    let got = std::fs::canonicalize(&got_path)
+        .unwrap_or_else(|e| panic!("failed to canonicalize reported cwd {got_path:?}: {e}"));
     let expected = std::fs::canonicalize(client_dir.path()).unwrap();
     assert_eq!(
-        path_wire::decode_path(&path_wire::PathWire::from(got)),
+        got,
         expected,
         "session must start in the client's launch directory, not the daemon's \
          startup directory ({:?})",

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -854,6 +854,29 @@ async fn kill_channel_respawns_with_stored_cmd() {
     // Re-attach (a fresh conn) and respawn — the stored cmd template is used.
     let c2 = connect_client_with_retry(guard.socket()).await;
     attach_client(&c2, &channel).await;
+
+    // Wait for the kill to fully land before respawning: the killed session
+    // lingers until the output-polling task observes its death, and a Spawn
+    // during that window would "reuse" the dying session instead of respawning —
+    // leaving the channel with no session right after respawn (CI-timing flake).
+    let start = std::time::Instant::now();
+    loop {
+        let channels = list_channels(&c2).await;
+        let ch = channels
+            .channels
+            .iter()
+            .find(|c| c.name == "test/kill_respawn");
+        let gone = ch.map(|c| c.session.is_none()).unwrap_or(true);
+        if gone {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "killed session never cleared from channel"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
     let SpawnResponse {
         id,
         cols: _,


### PR DESCRIPTION
Windows path comparisons were one-sided: the mock reports its cwd in the
8.3 short form (C:\Users\RUNNER~1\...) while std::fs::canonicalize expands
to the long form with a \\?\ prefix. Canonicalize both the reported and
expected directory before asserting (daemon_tests, session unit tests), so
short names and the extended-length prefix cancel out on both platforms.

The Windows session unit tests also stalled forever: a console child spawned
through a PTY waits for the host to answer its DSR cursor-position query
(\x1b[6n), so the mock never ran and never wrote its pwd report. The report
poll now pumps read_output()/screen() like the real daemon's poll loop, and
the spawned child is reaped after the report is read.

The macOS integration flake was a respawn race: KillChannel signals the
session, but the dying session lingers until the output-polling task
observes its death. A Spawn landing in that window reused the dying session
instead of respawning, leaving the channel with no session right after
respawn. kill_channel_respawns_with_stored_cmd now waits for the killed
session to be cleared from the channel before respawning.

Also resolve a clippy lint in path_wire (is_multiple_of instead of `% 2`).