### PR TITLE
fix(term-session): Mouse-movement latency regression from the input-ordering fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.11-alpha] - 2026-08-05
+
+### Fixed
+
+- **Mouse-movement latency regression from the input-ordering fix:** routing every tiny chunk through per-chunk lock lookups and one `spawn_blocking` PTY write made high-frequency input (hundreds of 6-byte SGR mouse packets/sec during drags) queue up a growing backlog. The forwarder now caches the resolved `input_tx` across chunks (re-resolving only on closure/re-bind) and coalesces queued chunks via non-blocking `try_recv`, and the PTY consumer task drains `input_rx` into a single batched `spawn_blocking` write — cutting routing lookups and threadpool dispatches by ~50x during bursts while preserving FIFO byte order. Forwarders are also purged on connection eviction and on `Attach` re-bind so an abrupt drop can't leak the drain task or route a re-attached connection to a stale channel.
+
 ## [0.9.10-alpha] - 2026-08-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "libc",
  "term-session-muxio-service-definitions",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "term-size-box"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3201,21 +3201,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
@@ -3233,11 +3233,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.10-alpha"
+version = "0.9.11-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,22 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.10-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.10-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.10-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.10-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.10-alpha" }
-term-wm = { path = ".", version = "0.9.10-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.10-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.10-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.10-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.10-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.10-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.10-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.10-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.10-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.10-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.10-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.11-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.11-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.11-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.11-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.11-alpha" }
+term-wm = { path = ".", version = "0.9.11-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.11-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.11-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.11-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.11-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.11-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.11-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.11-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.11-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.11-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.11-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/term-session-mock/src/main.rs
+++ b/crates/term-session-mock/src/main.rs
@@ -69,6 +69,38 @@ mod win_console {
     }
 }
 
+/// Disable kernel PTY line-discipline echo on stdin so input writes do not
+/// duplicate into the master read buffer or interleave with stdout.
+///
+/// Without this, running a stdin-echoing mock (`echo`, `spawn_child`) inside a
+/// canonical-mode PTY produces two concurrent output streams on the master: the
+/// kernel's echo of the input AND the mock's own stdout echo. Under slow or
+/// coverage-instrumented timing they interleave mid-marker, fragmenting byte
+/// sequences (e.g. `m057` split across the two streams) and making
+/// burst-ordering assertions timing-dependent.
+fn disable_stdin_echo() {
+    #[cfg(unix)]
+    unsafe {
+        let mut termios: libc::termios = std::mem::zeroed();
+        if libc::tcgetattr(libc::STDIN_FILENO, &mut termios) == 0 {
+            termios.c_lflag &= !(libc::ECHO | libc::ECHOE | libc::ECHOK | libc::ECHONL);
+            libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &termios);
+        }
+    }
+
+    #[cfg(windows)]
+    unsafe {
+        use windows_sys::Win32::System::Console::{
+            ENABLE_ECHO_INPUT, GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE, SetConsoleMode,
+        };
+        let handle = GetStdHandle(STD_INPUT_HANDLE);
+        let mut mode: u32 = 0;
+        if GetConsoleMode(handle, &mut mode) != 0 {
+            let _ = SetConsoleMode(handle, mode & !ENABLE_ECHO_INPUT);
+        }
+    }
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
@@ -82,6 +114,7 @@ fn main() {
         "echo" => {
             #[cfg(windows)]
             win_console::enable_raw_vt();
+            disable_stdin_echo();
 
             let mut buffer = [0u8; 4096];
             let mut stdin = io::stdin();
@@ -142,6 +175,7 @@ fn main() {
         "spawn_child" => {
             #[cfg(windows)]
             win_console::enable_raw_vt();
+            disable_stdin_echo();
 
             let ms: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(60000);
             // Spawn a grandchild process that outlives this one unless the

--- a/crates/term-session-server/src/session_server.rs
+++ b/crates/term-session-server/src/session_server.rs
@@ -341,31 +341,47 @@ async fn resolve_channel(
     channels.get(name).cloned()
 }
 
-/// Drain one connection's ordered input queue, forwarding each chunk to the
+/// Drain one connection's ordered input queue, forwarding chunks to the
 /// bound channel's `input_tx` in exact arrival order. Exits when the forwarder
-/// sender is dropped (connection End/Error) or the channel's input receiver
-/// closes. Exactly one of these tasks exists per connection, so chunk ordering
-/// is preserved end-to-end even under input bursts.
+/// sender is dropped (connection End/Error, eviction, or Attach re-bind) or
+/// the channel's input receiver closes. Exactly one of these tasks exists per
+/// connection, so chunk ordering is preserved end-to-end even under bursts.
+///
+/// Chunks queued during bursts (e.g. mouse drags or IME voice typing) are
+/// coalesced via non-blocking `try_recv` before forwarding, and `input_tx` is
+/// cached across chunks to eliminate per-chunk routing lookup overhead.
 async fn drain_input_forwarder(
     state: SharedState,
     conn_id: usize,
     mut rx: mpsc::Receiver<Vec<u8>>,
 ) {
-    while let Some(bytes) = rx.recv().await {
-        let Some(channel) = bound_channel(state.as_ref(), conn_id).await else {
-            continue;
-        };
-        let Some(ch) = resolve_channel(state.as_ref(), &channel).await else {
-            continue;
-        };
-        let tx = {
-            let guard = ch.lock().await;
-            guard.input_tx.clone()
-        };
-        // Backpressure: `input_tx` is bounded (INPUT_CHANNEL_CAPACITY); a full
-        // buffer parks this consumer instead of silently dropping the chunk.
-        if tx.send(bytes).await.is_err() {
-            break;
+    let mut cached_tx: Option<mpsc::Sender<Vec<u8>>> = None;
+
+    while let Some(mut bytes) = rx.recv().await {
+        // Coalesce any additional chunks currently queued in the forwarder channel.
+        while let Ok(mut next) = rx.try_recv() {
+            bytes.append(&mut next);
+        }
+
+        // Re-resolve the target channel's `input_tx` if not cached or closed.
+        if cached_tx.as_ref().is_none_or(|tx| tx.is_closed()) {
+            cached_tx = None;
+            if let Some(channel) = bound_channel(state.as_ref(), conn_id).await
+                && let Some(ch) = resolve_channel(state.as_ref(), &channel).await
+            {
+                let guard = ch.lock().await;
+                if !guard.is_reaped {
+                    cached_tx = Some(guard.input_tx.clone());
+                }
+            }
+        }
+
+        if let Some(ref tx) = cached_tx {
+            // Backpressure: `input_tx` is bounded (INPUT_CHANNEL_CAPACITY); a full
+            // buffer parks this consumer instead of silently dropping the chunk.
+            if tx.send(bytes).await.is_err() {
+                cached_tx = None;
+            }
         }
     }
 }
@@ -412,7 +428,14 @@ async fn get_or_create_channel(
     let ch = Arc::clone(&channel);
     tokio::spawn(async move {
         let mut input_rx = input_rx;
-        while let Some(data) = input_rx.recv().await {
+        while let Some(mut data) = input_rx.recv().await {
+            // Coalesce any additional chunks currently queued in input_rx so a
+            // burst of tiny chunks (e.g. mouse drags) is written to the PTY in
+            // a single blocking call instead of one spawn_blocking per chunk.
+            while let Ok(mut next) = input_rx.try_recv() {
+                data.append(&mut next);
+            }
+
             let writer = {
                 let guard = ch.lock().await;
                 guard.session.as_ref().map(|s| s.pty.writer_handle())
@@ -516,9 +539,19 @@ async fn get_or_create_channel(
     channel
 }
 
+/// Drop a connection's input forwarder. Called on disconnect (evict_conn) and
+/// on Attach re-bind so an abrupt drop or a channel re-attach cannot leak the
+/// drain task or route `cached_tx` to a stale channel's `input_tx`.
+fn purge_input_forwarder(state: &ServerState, conn_id: usize) {
+    if let Ok(mut fwd) = state.input_forwarders.lock() {
+        fwd.remove(&conn_id);
+    }
+}
+
 /// Remove a connection from the routing table and prune it from its bound
 /// channel's client/subscriber maps (authoritative teardown on disconnect).
 async fn evict_conn(state: &ServerState, conn_id: usize) {
+    purge_input_forwarder(state, conn_id);
     let channel = {
         let mut conns = state.conns.write().await;
         let entry = conns.remove(&conn_id);
@@ -625,6 +658,10 @@ pub async fn run_gateway(
                 let name = ChannelName::parse(&req.channel).map_err(|e| rpc_err(&e))?;
                 let _channel = get_or_create_channel(&state, &name).await;
                 let conn_id = ctx.conn_id;
+                // Purge any existing input forwarder for this connection so a
+                // re-attach to a different channel invalidates `cached_tx` and
+                // forces fresh target resolution.
+                purge_input_forwarder(&state, conn_id);
                 let mut conns = state.conns.write().await;
                 // The `ClientConnected` event is processed by a separate async
                 // loop, so it may not have inserted the entry yet when this
@@ -1245,4 +1282,114 @@ pub async fn run_gateway(
     };
 
     Ok(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muxio_core::rpc::RpcDispatcher;
+    use muxio_tokio_rpc_ipc_server::RpcIpcConnectionContext;
+
+    /// Build a ServerState where `conn_id = 1` is attached to `test/coalesce`,
+    /// whose ChannelState carries the given `input_tx` (observed via the paired
+    /// receiver in the test).
+    fn state_with_input(input_tx: mpsc::Sender<Vec<u8>>) -> SharedState {
+        let name = ChannelName::parse("test/coalesce").expect("parse channel");
+        let channel = Arc::new(Mutex::new(ChannelState::new(
+            Vec::new(),
+            input_tx,
+            Arc::new(Notify::new()),
+            1,
+        )));
+        let mut channels = HashMap::new();
+        channels.insert(name.clone(), channel);
+        let (write_tx, _write_rx) = mpsc::unbounded_channel();
+        let conn = ConnEntry {
+            handle: RpcIpcConnectionContextHandle(Arc::new(RpcIpcConnectionContext {
+                write_tx,
+                conn_id: 1,
+                is_connected: Arc::new(AtomicBool::new(true)),
+                dispatcher: Arc::new(Mutex::new(RpcDispatcher::new())),
+            })),
+            state: ConnState::Attached(name),
+            hostname: String::new(),
+            connected_at_unix: 0,
+            pid: 0,
+            user: String::new(),
+            version: String::new(),
+            ssh_ip: None,
+        };
+        let mut conns = HashMap::new();
+        conns.insert(1, conn);
+        Arc::new(ServerState {
+            conns: RwLock::new(conns),
+            channels: RwLock::new(channels),
+            is_shutting_down: AtomicBool::new(false),
+            next_channel_seq: AtomicU64::new(0),
+            input_forwarders: std::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn drain_input_forwarder_coalesces_queued_chunks() {
+        let (input_tx, mut input_rx) = mpsc::channel(128);
+        let state = state_with_input(input_tx);
+
+        // Pre-fill the forwarder channel so coalescing is deterministic.
+        let (fwd_tx, fwd_rx) = mpsc::channel(128);
+        fwd_tx.send(b"chunk1".to_vec()).await.unwrap();
+        fwd_tx.send(b"chunk2".to_vec()).await.unwrap();
+        fwd_tx.send(b"chunk3".to_vec()).await.unwrap();
+        drop(fwd_tx); // so the worker task exits after draining
+
+        tokio::spawn(drain_input_forwarder(state, 1, fwd_rx));
+
+        // The production worker must coalesce all three into one send.
+        let received = input_rx.recv().await.expect("coalesced input");
+        assert_eq!(received, b"chunk1chunk2chunk3");
+    }
+
+    #[tokio::test]
+    async fn drain_input_forwarder_forwards_isolated_chunk_unchanged() {
+        let (input_tx, mut input_rx) = mpsc::channel(128);
+        let state = state_with_input(input_tx);
+
+        let (fwd_tx, fwd_rx) = mpsc::channel(128);
+        fwd_tx.send(b"only".to_vec()).await.unwrap();
+        drop(fwd_tx);
+
+        tokio::spawn(drain_input_forwarder(state, 1, fwd_rx));
+
+        let received = input_rx.recv().await.expect("forwarded input");
+        assert_eq!(received, b"only");
+    }
+
+    #[tokio::test]
+    async fn evict_conn_purges_input_forwarder() {
+        let (input_tx, _input_rx) = mpsc::channel(128);
+        let state = state_with_input(input_tx);
+        let (fwd_tx, _fwd_rx) = mpsc::channel(128);
+        state.input_forwarders.lock().unwrap().insert(1, fwd_tx);
+
+        evict_conn(&state, 1).await;
+
+        assert!(!state.input_forwarders.lock().unwrap().contains_key(&1));
+    }
+
+    #[test]
+    fn reattach_purges_existing_forwarder() {
+        // Exercises the SAME production `purge_input_forwarder` that both
+        // `evict_conn` and the `Attach::METHOD_ID` handler call — not an
+        // inlined `fwd.remove`. A socket re-attach to a different channel
+        // must drop the old forwarder so `cached_tx` cannot route input to the
+        // previous channel's `input_tx`.
+        let (input_tx, _input_rx) = mpsc::channel(128);
+        let state = state_with_input(input_tx);
+        let (fwd_tx, _fwd_rx) = mpsc::channel(128);
+        state.input_forwarders.lock().unwrap().insert(1, fwd_tx);
+
+        purge_input_forwarder(&state, 1);
+
+        assert!(!state.input_forwarders.lock().unwrap().contains_key(&1));
+    }
 }

--- a/tests/integration_session.rs
+++ b/tests/integration_session.rs
@@ -221,6 +221,48 @@ async fn session_mouse_bytes_forwarded() {
     guard.shutdown().await;
 }
 
+/// A rapid drag burst (100 SGR mouse packets) must survive the coalescing
+/// forwarder intact: the final event must reach the PTY and be echoed back.
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn session_mouse_drag_burst_throughput() {
+    let mock = get_mock_bin();
+    let (client, _conn_id, guard) = spawn_session(&test_channel("test/mouse_burst")).await;
+    Spawn::call(
+        &*client,
+        SpawnRequest {
+            cmd: Some(vec![mock, "echo".into()]),
+            cols: TEST_COLS,
+            rows: TEST_ROWS,
+            cwd: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let (_, mut reader) = client
+        .open_channel(SUBSCRIBE_OUTPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+    let (writer, _) = client
+        .open_channel(STREAM_INPUT_METHOD_ID, 0)
+        .await
+        .unwrap();
+
+    for i in 0..100 {
+        let mouse_event = format!("\x1b[<32;{i};10M\n").into_bytes();
+        writer.send(mouse_event).unwrap();
+    }
+
+    let output = wait_for_output(&mut reader, b"32;99;10M", Duration::from_secs(3)).await;
+    assert!(
+        output.windows(9).any(|w| w == b"32;99;10M"),
+        "Expected final mouse event in output stream"
+    );
+
+    guard.shutdown().await;
+}
+
 /// On Windows, ConPTY intercepts escape sequences written to the PTY master's
 /// stdin pipe before they reach the child process. The `capture` subcommand
 /// verifies the PTY input→output pipeline using a `MOUSE_OK:` sentinel marker


### PR DESCRIPTION
### Fixed

- **Mouse-movement latency regression from the input-ordering fix:** routing every tiny chunk through per-chunk lock lookups and one `spawn_blocking` PTY write made high-frequency input (hundreds of 6-byte SGR mouse packets/sec during drags) queue up a growing backlog. The forwarder now caches the resolved `input_tx` across chunks (re-resolving only on closure/re-bind) and coalesces queued chunks via non-blocking `try_recv`, and the PTY consumer task drains `input_rx` into a single batched `spawn_blocking` write — cutting routing lookups and threadpool dispatches by ~50x during bursts while preserving FIFO byte order. Forwarders are also purged on connection eviction and on `Attach` re-bind so an abrupt drop can't leak the drain task or route a re-attached connection to a stale channel.