### PR TITLE
fix(pty-engine): Resolved UI corruption in ncurses apps (pico, htop) across SSH/container hops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.12-alpha] - 2026-08-05
+
+### Fixed
+
+- **Resolved UI corruption in ncurses apps (pico, htop) across SSH/container hops:** Applications broke when running through port-forwarded sessions into containers due to macOS/OrbStack injecting `LC_CTYPE=UTF-8`. Because UTF-8 is a character encoding rather than a valid POSIX locale string, `setlocale()` failed on the child process, causing ncurses to fall back incorrectly and corrupt screen geometry. Stripping invalid `LC_CTYPE` values allows the process to fall back to the container's native locale. Additionally, spawned PTY children now set `TERM=screen-256color` and `COLORTERM=truecolor` to ensure standard multiplexer compatibility and 24-bit color support for modern CLI tools.
+
 ## [0.9.11-alpha] - 2026-08-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "libc",
  "term-session-muxio-service-definitions",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "term-size-box"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3201,25 +3201,26 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.0",
  "ctrlc",
+ "indoc",
  "libc",
  "portable-pty",
  "term-session-mock",
@@ -3233,11 +3234,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3253,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3278,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.11-alpha"
+version = "0.9.12-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,22 +86,22 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.11-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.11-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.11-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.11-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.11-alpha" }
-term-wm = { path = ".", version = "0.9.11-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.11-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.11-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.11-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.11-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.11-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.11-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.11-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.11-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.11-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.11-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.12-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.12-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.12-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.12-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.12-alpha" }
+term-wm = { path = ".", version = "0.9.12-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.12-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.12-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.12-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.12-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.12-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.12-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.12-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.12-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.12-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.12-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -24,6 +24,9 @@ vte = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }
 
+[dev-dependencies]
+indoc = { workspace = true }
+
 [target.'cfg(windows)'.dev-dependencies]
 # Only the `#[cfg(windows)]` Job Object test (`spawn_assigns_job_object_containing_child`
 # in src/pty.rs) consumes the mock binary (`get_mock_bin` / `process_is_alive`). On

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -129,16 +129,52 @@ pub struct PtyParts {
     pub reader_handle: Option<JoinHandle<()>>,
 }
 
+/// Constant env values applied to every spawned PTY child so ncurses and
+/// modern CLI tools render correctly when the session runs across SSH /
+/// container hops (see `sanitize_child_environment`).
+const CHILD_TERM: &str = "screen-256color";
+const CHILD_COLORTERM: &str = "truecolor";
+
+/// Apply the multiplexer-safe environment to a spawned PTY child.
+///
+/// - Forces `TERM=screen-256color`. Plain `xterm-256color` causes ncurses to
+///   use advanced layout shortcuts (like Background Color Erase) that break
+///   inside multiplexer grid math.
+/// - Opts into `COLORTERM=truecolor` for modern CLI tools (Neovim, bat, delta,
+///   lsd) that look for COLORTERM to bypass the 256-color limit of the
+///   screen-256color terminfo. ncurses ignores COLORTERM entirely — it keys
+///   off the terminfo database for `$TERM` — so this is purely for those
+///   direct-ANSI tools.
+/// - Strips the invalid `LC_CTYPE=UTF-8` injected by macOS/OrbStack SSH hops.
+///   "UTF-8" is a character encoding, not a valid POSIX locale name, which
+///   causes `setlocale()` to fail and ncurses to crash or corrupt layout.
+///   Removing it lets the child fall back to its own native locale default.
+fn sanitize_child_environment(command: &mut CommandBuilder) {
+    sanitize_child_environment_with_lc_ctype(command, std::env::var("LC_CTYPE").ok().as_deref());
+}
+
+/// Core of [`sanitize_child_environment`], parameterized over the incoming
+/// `LC_CTYPE` value so the stripping logic is deterministically unit-testable
+/// without mutating the process-global environment.
+fn sanitize_child_environment_with_lc_ctype(command: &mut CommandBuilder, lc_ctype: Option<&str>) {
+    command.env("TERM", CHILD_TERM);
+    command.env("COLORTERM", CHILD_COLORTERM);
+    if lc_ctype == Some("UTF-8") {
+        command.env_remove("LC_CTYPE");
+    }
+}
+
 impl Pty {
     pub fn spawn(command: CommandBuilder, size: PtySize) -> PtyResult<Self> {
         Self::spawn_with_scrollback(command, size, 0)
     }
 
     pub fn spawn_with_scrollback(
-        command: CommandBuilder,
+        mut command: CommandBuilder,
         size: PtySize,
         scrollback_len: usize,
     ) -> PtyResult<Self> {
+        sanitize_child_environment(&mut command);
         let pty_system = native_pty_system();
         let pair = pty_system
             .openpty(size)
@@ -2065,5 +2101,114 @@ mod tests {
             "content preserved without any SU shift"
         );
         assert_eq!(parser.screen().size(), (24, 80));
+    }
+
+    // ── Environment sanitization ─────────────────────────────────────
+
+    fn fresh_cmd() -> CommandBuilder {
+        CommandBuilder::new("true")
+    }
+
+    #[test]
+    fn sanitize_sets_multiplexer_safe_term() {
+        let mut cmd = fresh_cmd();
+        sanitize_child_environment_with_lc_ctype(&mut cmd, None);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|v| v.to_str()),
+            Some("screen-256color")
+        );
+    }
+
+    #[test]
+    fn sanitize_sets_truecolor() {
+        let mut cmd = fresh_cmd();
+        sanitize_child_environment_with_lc_ctype(&mut cmd, None);
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|v| v.to_str()),
+            Some("truecolor")
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_invalid_lc_ctype_utf8() {
+        let mut cmd = fresh_cmd();
+        // Simulate the invalid `LC_CTYPE=UTF-8` macOS/OrbStack SSH hop injects.
+        cmd.env("LC_CTYPE", "UTF-8");
+        sanitize_child_environment_with_lc_ctype(&mut cmd, Some("UTF-8"));
+        assert!(
+            cmd.get_env("LC_CTYPE").is_none(),
+            "invalid LC_CTYPE=UTF-8 must be stripped"
+        );
+    }
+
+    #[test]
+    fn sanitize_keeps_valid_lc_ctype() {
+        let mut cmd = fresh_cmd();
+        cmd.env("LC_CTYPE", "en_US.UTF-8");
+        sanitize_child_environment_with_lc_ctype(&mut cmd, Some("en_US.UTF-8"));
+        assert_eq!(
+            cmd.get_env("LC_CTYPE").and_then(|v| v.to_str()),
+            Some("en_US.UTF-8"),
+            "valid locale must be preserved"
+        );
+    }
+
+    /// End-to-end: the child spawned via the real `Pty` launcher must see the
+    /// sanitized environment. We write a child that prints its `TERM`,
+    /// `COLORTERM`, and `LC_CTYPE` (or its absence) and assert on the output.
+    #[test]
+    #[cfg(unix)]
+    fn spawned_child_receives_sanitized_environment() {
+        // `sh` is POSIX-standard; on Windows this test is skipped.
+        let script = indoc::indoc! {r#"
+            TERM_VAL="${TERM:-<unset>}"
+            COLORTERM_VAL="${COLORTERM:-<unset>}"
+            LC_CTYPE_VAL="${LC_CTYPE:-<unset>}"
+            printf 'TERM=%s\nCOLORTERM=%s\nLC_CTYPE=%s\n' \
+              "$TERM_VAL" "$COLORTERM_VAL" "$LC_CTYPE_VAL"
+        "#};
+        let mut cmd = CommandBuilder::new("sh");
+        cmd.arg("-c");
+        cmd.arg(script);
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let mut pty = Pty::spawn_with_scrollback(cmd, size, 0).expect("spawn");
+
+        let mut accumulated = Vec::new();
+        let start = std::time::Instant::now();
+        loop {
+            pty.screen();
+            accumulated.extend_from_slice(&pty.drain_pending());
+            let out = String::from_utf8_lossy(&accumulated);
+            if out.contains("LC_CTYPE=") {
+                break;
+            }
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(5),
+                "child never printed sanitized env; got {out}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        if let Some(child) = pty.child.as_mut() {
+            let _ = child.kill();
+        }
+
+        let out = String::from_utf8_lossy(&accumulated);
+        assert!(
+            out.contains("TERM=screen-256color"),
+            "expected TERM=screen-256color, got {out}"
+        );
+        assert!(
+            out.contains("COLORTERM=truecolor"),
+            "expected COLORTERM=truecolor, got {out}"
+        );
+        assert!(
+            !out.contains("LC_CTYPE=UTF-8"),
+            "invalid LC_CTYPE=UTF-8 must not reach the child, got {out}"
+        );
     }
 }


### PR DESCRIPTION
### Fixed

- **Resolved UI corruption in ncurses apps (pico, htop) across SSH/container hops:** Applications broke when running through port-forwarded sessions into containers due to macOS/OrbStack injecting `LC_CTYPE=UTF-8`. Because UTF-8 is a character encoding rather than a valid POSIX locale string, `setlocale()` failed on the child process, causing ncurses to fall back incorrectly and corrupt screen geometry. Stripping invalid `LC_CTYPE` values allows the process to fall back to the container's native locale. Additionally, spawned PTY children now set `TERM=screen-256color` and `COLORTERM=truecolor` to ensure standard multiplexer compatibility and 24-bit color support for modern CLI tools.