### PR TITLE
feat(pty-engine): Terminal line reflow on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.13-alpha] - 2026-08-06
+
+### Added
+
+- **Terminal line reflow on resize:** resizing a terminal window now re-wraps soft-wrapped lines (scrollback + visible) to the new column width instead of truncating them, so previously-buffered output is preserved when the window shrinks or grows. Wide/CJK characters are never split across rows and keep their SGR attributes; explicitly written trailing spaces and background-only regions are preserved. **Accepted limitation:** on a width shrink, a shell prompt that re-wraps may briefly show duplicated/stale prompt rows, because a shell's SIGWINCH redraw (`\r ESC[J`) erases only downward from the cursor and cannot reach the re-wrapped rows above it. This is a protocol limitation of shell-driven redraw (present in other reflowing terminals), not an emulator bug, and no data is lost.
+
+### Changed
+
+- **Replaced `vt100` with `term-wm-vt100` crates.io fork (0.16.2-patch1):** the reflow-patched fork is now used as a plain registry dependency in place of the upstream `vt100` crate.
+
+### Fixed
+
+- **ncurses apps (pico, nano) losing background colors on macOS:** the child `TERM` is now `xterm-256color` on macOS — whose shipped `screen-256color` terminfo lacks the `bce` (Background Color Erase) capability, causing ncurses to reset attributes before line erases and drop backgrounds — and `screen-256color` elsewhere (where that terminfo has `bce`).
+- **PTY reader-thread panic on poisoned mutexes:** `parser_read_loop` now recovers poisoned locks (`shared_parser`, `pending`, `last_bytes`, `status_cb`, `pending_title`, `dirty_cond`) via `into_inner()` instead of `.unwrap()`ing and crashing the I/O pipeline when a consumer panics while holding a lock.
+- **`generate_snapshot` / `screen_lines` lock contention:** the shared-parser `MutexGuard` is released immediately after cloning the `Screen`, so full-frame escape-code formatting no longer starves the reader thread during high-throughput output.
+
 ## [0.9.12-alpha] - 2026-08-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -34,9 +34,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -83,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -94,14 +94,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -140,19 +140,19 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -178,9 +178,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -233,7 +233,7 @@ checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -280,9 +280,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder-lite"
@@ -292,9 +292,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -335,9 +335,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -486,16 +486,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -648,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -658,26 +648,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -717,7 +707,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -744,13 +734,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -776,9 +766,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -799,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -828,16 +818,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -945,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -960,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -970,15 +954,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -987,38 +971,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1095,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
+checksum = "7360bd2cd76e0cd9032d42cf2922155cecea2685b0cfa4630c3246df030bcfd6"
 
 [[package]]
 name = "half"
@@ -1351,15 +1335,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1434,7 +1418,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1453,7 +1437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1516,9 +1500,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "line-clipping"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -1573,9 +1557,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1601,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -1647,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -1796,7 +1780,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
 ]
@@ -1809,7 +1793,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -1829,7 +1813,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1856,7 +1840,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1887,7 +1871,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2011,26 +1995,35 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "libm",
  "palette_derive",
+ "palette_math",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -2064,9 +2057,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2074,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2084,25 +2077,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
@@ -2132,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -2145,7 +2137,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2193,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-pty"
@@ -2253,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2270,7 +2262,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2300,9 +2292,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -2318,9 +2310,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2339,18 +2331,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2508,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2520,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2595,14 +2587,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -2663,9 +2655,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2673,22 +2665,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2706,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "serial2"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2737,7 +2729,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2815,15 +2807,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2885,12 +2877,12 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2938,7 +2930,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2964,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2992,7 +2984,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3005,12 +2997,12 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term-bench"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3020,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3039,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3057,16 +3049,16 @@ dependencies = [
  "term-wm-crossterm-adapter",
  "term-wm-events",
  "term-wm-pty-engine",
+ "term-wm-vt100",
  "tokio",
  "tracing",
  "unicode-width",
- "vt100",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "libc",
  "term-session-muxio-service-definitions",
@@ -3075,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3085,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3098,15 +3090,15 @@ dependencies = [
  "term-session-mock",
  "term-session-muxio-service-definitions",
  "term-wm-pty-engine",
+ "term-wm-vt100",
  "tokio",
  "tracing",
- "vt100",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "term-size-box"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3114,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3152,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3170,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3192,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3201,44 +3193,44 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "arboard",
- "base64 0.23.0",
+ "base64 0.23.1",
  "ctrlc",
  "indoc",
  "libc",
  "portable-pty",
  "term-session-mock",
  "term-wm-events",
+ "term-wm-vt100",
  "thiserror 2.0.19",
  "tracing",
- "vt100",
  "vte",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3254,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3271,20 +3263,31 @@ dependencies = [
  "term-wm-layout-engine",
  "term-wm-pty-engine",
  "term-wm-render",
+ "term-wm-vt100",
  "thiserror 2.0.19",
  "tracing",
- "vt100",
  "webbrowser",
 ]
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",
  "term-wm-sys-ui-components",
  "term-wm-ui-components",
+]
+
+[[package]]
+name = "term-wm-vt100"
+version = "0.16.2-patch1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9959cd123f952b4c7576063bfa6c516d8a3fb1f0ee048c3ff64e0bf03a3e6c"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
 ]
 
 [[package]]
@@ -3297,7 +3300,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3400,7 +3403,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3416,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -3439,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.52"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -3506,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3538,13 +3541,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3558,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3570,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -3596,7 +3599,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3796,9 +3799,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -3817,17 +3820,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width",
- "vte",
-]
 
 [[package]]
 name = "vte"
@@ -3914,7 +3906,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3939,15 +3931,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation",
  "jni",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",
@@ -4059,7 +4051,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4089,7 +4081,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4100,7 +4092,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4285,9 +4277,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -4338,9 +4330,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"
@@ -4361,28 +4353,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4402,7 +4394,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4436,7 +4428,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.12-alpha"
+version = "0.9.13-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -86,29 +86,29 @@ serial_test = "3.5.0"
 shell-words = "1.1.1"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.12-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.12-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.12-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.12-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.12-alpha" }
-term-wm = { path = ".", version = "0.9.12-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.12-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.12-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.12-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.12-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.12-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.12-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.12-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.12-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.12-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.12-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.13-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.13-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.13-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.13-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.13-alpha" }
+term-wm = { path = ".", version = "0.9.13-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.13-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.13-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.13-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.13-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.13-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.13-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.13-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.13-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.13-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.13-alpha" }
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 unicode-width = "0.2.2"
-vt100 = "0.16.2"
+term-wm-vt100 = "0.16.2-patch1"
 vte = "0.15.0"
 webbrowser = "1.2.1"
 windows-sys = { version = "0.59", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,13 +102,13 @@ term-wm-render = { path = "crates/term-wm-render", version = "0.9.13-alpha" }
 term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.13-alpha" }
 term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.13-alpha" }
 term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.13-alpha" }
+term-wm-vt100 = "0.16.2-patch1"
 textwrap = "0.16.2"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 unicode-width = "0.2.2"
-term-wm-vt100 = "0.16.2-patch1"
 vte = "0.15.0"
 webbrowser = "1.2.1"
 windows-sys = { version = "0.59", features = [

--- a/crates/term-session-client/Cargo.toml
+++ b/crates/term-session-client/Cargo.toml
@@ -32,7 +32,7 @@ term-wm-pty-engine = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 unicode-width.workspace = true
-vt100 = { workspace = true }
+term-wm-vt100 = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/term-session-client/Cargo.toml
+++ b/crates/term-session-client/Cargo.toml
@@ -29,10 +29,10 @@ term-session-muxio-service-definitions = { workspace = true }
 term-wm-crossterm-adapter = { workspace = true }
 term-wm-events = { workspace = true }
 term-wm-pty-engine = { workspace = true }
+term-wm-vt100 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 unicode-width.workspace = true
-term-wm-vt100 = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/term-session-client/src/lib.rs
+++ b/crates/term-session-client/src/lib.rs
@@ -28,7 +28,7 @@ use term_wm_pty_engine::Pane;
 use term_wm_pty_engine::clipboard::{Clipboard, Osc52Extractor};
 use term_wm_pty_engine::input_encoding::{key_to_bytes, mouse_event_to_bytes};
 use term_wm_pty_engine::signal::install_sigint_handler;
-use vt100::{MouseProtocolEncoding, MouseProtocolMode, Parser, Screen};
+use term_wm_vt100::{MouseProtocolEncoding, MouseProtocolMode, Parser, Screen};
 
 /// Redirect an OS-level file descriptor (stdout or stderr) into `tracing`.
 ///
@@ -758,8 +758,8 @@ pub fn run_session(socket_path: &str, channel: &str, cmd: &[String]) -> io::Resu
 
 #[derive(Default, PartialEq, Clone, Copy)]
 struct CellStyle {
-    fg: vt100::Color,
-    bg: vt100::Color,
+    fg: term_wm_vt100::Color,
+    bg: term_wm_vt100::Color,
     bold: bool,
     dim: bool,
     italic: bool,
@@ -768,7 +768,7 @@ struct CellStyle {
 }
 
 impl CellStyle {
-    fn from_cell(cell: &vt100::Cell) -> Self {
+    fn from_cell(cell: &term_wm_vt100::Cell) -> Self {
         Self {
             fg: cell.fgcolor(),
             bg: cell.bgcolor(),
@@ -799,13 +799,13 @@ fn apply_sgr(out: &mut dyn Write, style: &CellStyle) -> io::Result<()> {
         write!(out, "\x1b[7m")?;
     }
     match style.fg {
-        vt100::Color::Idx(i) => write!(out, "\x1b[38;5;{}m", i)?,
-        vt100::Color::Rgb(r, g, b) => write!(out, "\x1b[38;2;{};{};{}m", r, g, b)?,
+        term_wm_vt100::Color::Idx(i) => write!(out, "\x1b[38;5;{}m", i)?,
+        term_wm_vt100::Color::Rgb(r, g, b) => write!(out, "\x1b[38;2;{};{};{}m", r, g, b)?,
         _ => {}
     }
     match style.bg {
-        vt100::Color::Idx(i) => write!(out, "\x1b[48;5;{}m", i)?,
-        vt100::Color::Rgb(r, g, b) => write!(out, "\x1b[48;2;{};{};{}m", r, g, b)?,
+        term_wm_vt100::Color::Idx(i) => write!(out, "\x1b[48;5;{}m", i)?,
+        term_wm_vt100::Color::Rgb(r, g, b) => write!(out, "\x1b[48;2;{};{};{}m", r, g, b)?,
         _ => {}
     }
     Ok(())
@@ -1069,13 +1069,13 @@ mod tests {
     /// identical screen state to a freshly allocated parser.
     #[test]
     fn test_prev_parser_resize_sync_matches_fresh_parser() {
-        let mut prev_parser = vt100::Parser::new(24, 80, 0);
+        let mut prev_parser = term_wm_vt100::Parser::new(24, 80, 0);
         prev_parser.process(b"initial screen content");
 
         // Simulate terminal window resize to 40x120
         let (new_rows, new_cols) = (40, 120);
         let new_formatted_content = {
-            let mut p = vt100::Parser::new(new_rows, new_cols, 0);
+            let mut p = term_wm_vt100::Parser::new(new_rows, new_cols, 0);
             p.process(b"resized screen content");
             p.screen().contents_formatted().to_vec()
         };
@@ -1086,7 +1086,7 @@ mod tests {
         prev_parser.process(&new_formatted_content);
 
         // Verify against a freshly created parser
-        let mut fresh_parser = vt100::Parser::new(new_rows, new_cols, 0);
+        let mut fresh_parser = term_wm_vt100::Parser::new(new_rows, new_cols, 0);
         fresh_parser.process(&new_formatted_content);
 
         assert_eq!(
@@ -1098,7 +1098,7 @@ mod tests {
 
     #[test]
     fn render_frame_outputs_correct_cup_and_sgr() {
-        let mut parser = vt100::Parser::new(4, 8, 0);
+        let mut parser = term_wm_vt100::Parser::new(4, 8, 0);
         parser.process(b"\x1b[31mhello\x1b[0m");
         let screen = parser.screen();
         let mut buf: Vec<u8> = Vec::new();

--- a/crates/term-session-client/src/remote_pane.rs
+++ b/crates/term-session-client/src/remote_pane.rs
@@ -15,7 +15,7 @@ pub struct RemotePane {
     pub id: u64,
     client: Option<std::sync::Arc<RpcIpcClient>>,
     rt: Handle,
-    parser: Arc<Mutex<vt100::Parser>>,
+    parser: Arc<Mutex<term_wm_vt100::Parser>>,
     exited: Cell<bool>,
     push_rx: Receiver<Vec<u8>>,
     input_writer: InputWriter,
@@ -35,7 +35,7 @@ impl RemotePane {
             id,
             client,
             rt,
-            parser: Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 0))),
+            parser: Arc::new(Mutex::new(term_wm_vt100::Parser::new(rows, cols, 0))),
             exited: Cell::new(false),
             push_rx,
             input_writer,
@@ -113,7 +113,7 @@ impl Pane for RemotePane {
         (self.input_writer)(input)
     }
 
-    fn shared_parser(&mut self) -> Arc<Mutex<vt100::Parser>> {
+    fn shared_parser(&mut self) -> Arc<Mutex<term_wm_vt100::Parser>> {
         self.parser.clone()
     }
 

--- a/crates/term-session-server/Cargo.toml
+++ b/crates/term-session-server/Cargo.toml
@@ -20,9 +20,9 @@ muxio-tokio-rpc-ipc-server = { workspace = true }
 portable-pty = { workspace = true }
 term-session-muxio-service-definitions = { workspace = true }
 term-wm-pty-engine = { workspace = true }
+term-wm-vt100 = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-term-wm-vt100 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }

--- a/crates/term-session-server/Cargo.toml
+++ b/crates/term-session-server/Cargo.toml
@@ -22,7 +22,7 @@ term-session-muxio-service-definitions = { workspace = true }
 term-wm-pty-engine = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-vt100 = { workspace = true }
+term-wm-vt100 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true }

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -18,7 +18,7 @@ portable-pty = { workspace = true }
 term-wm-events = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-vt100 = { workspace = true }
+term-wm-vt100 = { workspace = true }
 vte = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/term-wm-pty-engine/Cargo.toml
+++ b/crates/term-wm-pty-engine/Cargo.toml
@@ -16,9 +16,9 @@ ctrlc = { workspace = true }
 libc = { workspace = true }
 portable-pty = { workspace = true }
 term-wm-events = { workspace = true }
+term-wm-vt100 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-term-wm-vt100 = { workspace = true }
 vte = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/term-wm-pty-engine/src/input_encoding.rs
+++ b/crates/term-wm-pty-engine/src/input_encoding.rs
@@ -1,5 +1,5 @@
 use term_wm_events::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use vt100::{MouseProtocolEncoding, MouseProtocolMode};
+use term_wm_vt100::{MouseProtocolEncoding, MouseProtocolMode};
 
 /// Convert a [`KeyEvent`] to the byte sequence to send to the PTY.
 /// Set `application_cursor_keys=true` when DECCKM (DECSET 1) is active,

--- a/crates/term-wm-pty-engine/src/pane.rs
+++ b/crates/term-wm-pty-engine/src/pane.rs
@@ -33,8 +33,8 @@ pub trait Pane {
         None
     }
     /// Access the shared parser for zero-copy rendering.
-    fn shared_parser(&mut self) -> Arc<Mutex<vt100::Parser>> {
-        Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0)))
+    fn shared_parser(&mut self) -> Arc<Mutex<term_wm_vt100::Parser>> {
+        Arc::new(Mutex::new(term_wm_vt100::Parser::new(24, 80, 0)))
     }
     /// Reset the dirty flag. Returns true if dirty was set.
     fn take_dirty(&self) -> bool {
@@ -143,7 +143,7 @@ impl Pane for crate::Pty {
         self.tracker.is_application_cursor_keys_active()
     }
 
-    fn shared_parser(&mut self) -> Arc<Mutex<vt100::Parser>> {
+    fn shared_parser(&mut self) -> Arc<Mutex<term_wm_vt100::Parser>> {
         self.shared_parser.clone()
     }
 

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -2050,6 +2050,11 @@ mod tests {
         // Reflow must preserve previously-buffered scrollback content when the
         // terminal width shrinks (the non-alt-screen resize case), instead of
         // truncating the wrapped rows of a long line.
+        //
+        // The reflow logic lives in the `term-wm-vt100` fork, whose own test
+        // suite (including `reflow_preserves_scrollback_content`) runs in that
+        // fork's repository, not here. This test is a local regression guard
+        // against a future version of the fork losing the behavior.
         let mut parser = term_wm_vt100::Parser::new(24, 80, 2000);
         let long_line = "x".repeat(200);
         for i in 0..40 {

--- a/crates/term-wm-pty-engine/src/pty.rs
+++ b/crates/term-wm-pty-engine/src/pty.rs
@@ -86,7 +86,7 @@ pub struct Pty {
     /// Parsed screen shared between the reader thread and the main thread.
     /// The reader parses bytes into this parser in-place. The main thread
     /// locks it to read cells directly — zero clones.
-    pub(crate) shared_parser: Arc<Mutex<vt100::Parser>>,
+    pub(crate) shared_parser: Arc<Mutex<term_wm_vt100::Parser>>,
     /// Set by the reader thread when new content has been parsed.
     pub(crate) dirty: Arc<AtomicBool>,
     /// Condvar for I/O burst budget: reader waits here when budget exceeded
@@ -132,14 +132,27 @@ pub struct PtyParts {
 /// Constant env values applied to every spawned PTY child so ncurses and
 /// modern CLI tools render correctly when the session runs across SSH /
 /// container hops (see `sanitize_child_environment`).
+///
+/// macOS ships a defective `screen-256color` terminfo lacking the `bce`
+/// (Background Color Erase) capability, which makes ncurses apps (pico, nano)
+/// reset attributes before line erases and drop background colors.
+/// `xterm-256color` has `bce` and is safe on macOS now that the invalid
+/// `LC_CTYPE=UTF-8` is stripped (the grid-math crashes previously associated
+/// with it were caused by `setlocale` failing on that locale, not the terminfo
+/// entry). Other platforms keep `screen-256color` — their terminfo has `bce`.
+#[cfg(target_os = "macos")]
+const CHILD_TERM: &str = "xterm-256color";
+#[cfg(not(target_os = "macos"))]
 const CHILD_TERM: &str = "screen-256color";
 const CHILD_COLORTERM: &str = "truecolor";
 
 /// Apply the multiplexer-safe environment to a spawned PTY child.
 ///
-/// - Forces `TERM=screen-256color`. Plain `xterm-256color` causes ncurses to
-///   use advanced layout shortcuts (like Background Color Erase) that break
-///   inside multiplexer grid math.
+/// - Forces `TERM` to a terminfo entry with `bce` (Background Color Erase):
+///   `xterm-256color` on macOS (where Apple's `screen-256color` terminfo is
+///   broken and missing `bce`), `screen-256color` elsewhere. Without `bce`,
+///   ncurses apps reset attributes before line erases, which erases the
+///   background in the emulated screen.
 /// - Opts into `COLORTERM=truecolor` for modern CLI tools (Neovim, bat, delta,
 ///   lsd) that look for COLORTERM to bypass the 256-color limit of the
 ///   screen-256color terminfo. ncurses ignores COLORTERM entirely — it keys
@@ -239,7 +252,7 @@ impl Pty {
 
         let pending_title = Arc::new(Mutex::new(None));
         let foreground_title = Arc::new(Mutex::new(None));
-        let initial_parser = vt100::Parser::new(size.rows, size.cols, scrollback_len);
+        let initial_parser = term_wm_vt100::Parser::new(size.rows, size.cols, scrollback_len);
         let tracker = std::sync::Arc::new(crate::PtyStateTracker::new(size.rows));
         let reader_tracker = std::sync::Arc::clone(&tracker);
         let shared_parser = Arc::new(Mutex::new(initial_parser));
@@ -357,6 +370,17 @@ impl Pty {
     }
 
     pub fn resize(&mut self, size: PtySize) -> PtyResult<()> {
+        // NOTE (accepted limitation): resizing triggers universal grid reflow
+        // (vt100 `set_size`), which preserves all scrollback data. On a width
+        // shrink, a shell prompt that re-wraps into multiple rows may briefly
+        // show duplicated/stale prompt rows on the host, because the shell's
+        // SIGWINCH redraw (`\r ESC[J`) only erases downward from the cursor and
+        // cannot reach the re-wrapped rows above it. This is a protocol
+        // limitation of shell-driven redraw (present in other reflowing
+        // terminals) and is intentionally not worked around in the emulator:
+        // any emulator/compositor-side correction would destroy buffered data
+        // or corrupt cursor coordinates. No data is ever lost.
+        //
         // WORKAROUND: vt100 0.16.2 Grid::col_wrap (grid.rs:683) panics with a
         // subtraction overflow at cols=1; rows=1 causes similar issues. Clamp
         // the minimum so the PTY emulator doesn't crash when the terminal is
@@ -471,8 +495,14 @@ impl Pty {
 
     pub fn screen_lines(&mut self) -> Vec<String> {
         self.screen(); // sync dirty state
-        let parser = self.shared_parser.lock().unwrap();
-        let screen = parser.screen();
+        // Clone the screen out of the lock and drop the guard before any
+        // string formatting, so the reader thread can keep ingesting bytes.
+        let screen = self
+            .shared_parser
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .screen()
+            .clone();
         let contents = screen.contents();
         let mut lines: Vec<String> = contents.lines().map(|line| line.to_string()).collect();
         if lines.len() < self.size.rows as usize {
@@ -611,8 +641,15 @@ impl Pty {
     /// with a formatted snapshot of the current parser state.
     pub fn generate_snapshot(&mut self) -> Vec<u8> {
         self.screen();
-        let parser = self.shared_parser.lock().unwrap();
-        parser.screen().state_formatted()
+        // Clone the screen out of the lock and drop the guard before the
+        // O(rows x cols) escape-code formatting, so the reader thread can keep
+        // ingesting bytes while the snapshot is built.
+        self.shared_parser
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .screen()
+            .clone()
+            .state_formatted()
     }
 
     pub fn bytes_received(&self) -> usize {
@@ -688,7 +725,7 @@ struct ParserReadLoopArgs {
     bytes_received: Arc<AtomicUsize>,
     last_bytes: Arc<Mutex<Vec<u8>>>,
     dsr_requested: Arc<AtomicBool>,
-    shared_parser: Arc<Mutex<vt100::Parser>>,
+    shared_parser: Arc<Mutex<term_wm_vt100::Parser>>,
     dirty: Arc<AtomicBool>,
     dirty_cond: Arc<(std::sync::Mutex<()>, Condvar)>,
     pending_title: Arc<Mutex<Option<String>>>,
@@ -747,13 +784,12 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 if let Some(text) = osc52.finish() {
                     clipboard.set(&text);
                     if let Some(ref capture) = osc52_text {
-                        *capture.lock().unwrap() = Some(text);
+                        *capture.lock().unwrap_or_else(|err| err.into_inner()) = Some(text);
                     }
                 }
                 // Send wakeup for final screen, then exited.
-                if let Ok(guard) = status_cb.lock()
-                    && let Some(ref cb) = *guard
-                {
+                let guard = status_cb.lock().unwrap_or_else(|err| err.into_inner());
+                if let Some(ref cb) = *guard {
                     cb(crate::PtyStatus::Wakeup);
                     if !exited_emitted.swap(true, Ordering::AcqRel) {
                         cb(crate::PtyStatus::Exited);
@@ -769,18 +805,16 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 if buf[..n].windows(DSR_PATTERN_LEN).any(|w| w == b"\x1b[6n") {
                     dsr_requested.store(true, Ordering::Relaxed);
                 }
-                if let Ok(mut last) = last_bytes.lock() {
-                    last.clear();
-                    last.extend_from_slice(&buf[..n]);
-                }
-                if let Ok(mut p) = pending.lock() {
-                    p.extend_from_slice(&buf[..n]);
-                    // Cap pending to prevent unbounded growth when no
-                    // consumer calls drain_pending() (local terminal mode).
-                    const PENDING_CAP: usize = 1024 * 1024; // 1 MB
-                    if p.len() > PENDING_CAP {
-                        p.clear();
-                    }
+                let mut last = last_bytes.lock().unwrap_or_else(|err| err.into_inner());
+                last.clear();
+                last.extend_from_slice(&buf[..n]);
+                let mut p = pending.lock().unwrap_or_else(|err| err.into_inner());
+                p.extend_from_slice(&buf[..n]);
+                // Cap pending to prevent unbounded growth when no
+                // consumer calls drain_pending() (local terminal mode).
+                const PENDING_CAP: usize = 1024 * 1024; // 1 MB
+                if p.len() > PENDING_CAP {
+                    p.clear();
                 }
 
                 // Process bytes through the application state tracker
@@ -794,9 +828,8 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                         prev_routing,
                         new_routing
                     );
-                    if let Ok(guard) = status_cb.lock()
-                        && let Some(ref cb) = *guard
-                    {
+                    let guard = status_cb.lock().unwrap_or_else(|err| err.into_inner());
+                    if let Some(ref cb) = *guard {
                         cb(crate::PtyStatus::DirectInputChanged(new_routing));
                     } else {
                         tracing::error!("[STAGE 1] status_cb is NONE when transition occurred!");
@@ -805,13 +838,12 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
 
                 // Process bytes directly into the shared parser.
                 {
-                    let mut shared = shared_parser.lock().unwrap();
+                    let mut shared = shared_parser.lock().unwrap_or_else(|err| err.into_inner());
                     shared.process(&buf[..n]);
                 }
 
-                if let Some(title) = extract_osc_title(&buf[..n])
-                    && let Ok(mut guard) = pending_title.lock()
-                {
+                if let Some(title) = extract_osc_title(&buf[..n]) {
+                    let mut guard = pending_title.lock().unwrap_or_else(|err| err.into_inner());
                     *guard = Some(title);
                 }
                 // Intercept OSC 52 clipboard sequences (cross-chunk buffering).
@@ -820,7 +852,7 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 if let Some(text) = osc52.push(&buf[..n], &prev_tail) {
                     clipboard.set(&text);
                     if let Some(ref capture) = osc52_text {
-                        *capture.lock().unwrap() = Some(text);
+                        *capture.lock().unwrap_or_else(|err| err.into_inner()) = Some(text);
                     }
                 }
 
@@ -836,9 +868,8 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 // Prevents flooding the IPC channel with thousands of redundant
                 // PtyWakeup messages per second at unthrottled ingestion speeds.
                 if !dirty.swap(true, Ordering::AcqRel) {
-                    if let Ok(guard) = status_cb.lock()
-                        && let Some(ref cb) = *guard
-                    {
+                    let guard = status_cb.lock().unwrap_or_else(|err| err.into_inner());
+                    if let Some(ref cb) = *guard {
                         cb(crate::PtyStatus::Wakeup);
                     }
                     // Reset budget because a new render cycle has begun
@@ -851,9 +882,9 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 // reader thread from consuming 100% CPU on infinite streams.
                 if bytes_since_render >= IO_BURST_BUDGET {
                     let (lock, cvar) = &*dirty_cond;
-                    let mut guard = lock.lock().unwrap();
+                    let mut guard = lock.lock().unwrap_or_else(|err| err.into_inner());
                     while dirty.load(Ordering::Acquire) {
-                        guard = cvar.wait(guard).unwrap();
+                        guard = cvar.wait(guard).unwrap_or_else(|err| err.into_inner());
                     }
                     bytes_since_render = 0;
                 }
@@ -864,8 +895,8 @@ fn parser_read_loop(args: ParserReadLoopArgs) {
                 // This is intentional mechanical backpressure.
             }
             Err(_) => {
-                if let Ok(guard) = status_cb.lock()
-                    && let Some(ref cb) = *guard
+                let guard = status_cb.lock().unwrap_or_else(|err| err.into_inner());
+                if let Some(ref cb) = *guard
                     && !exited_emitted.swap(true, Ordering::AcqRel)
                 {
                     cb(crate::PtyStatus::Exited);
@@ -1133,7 +1164,7 @@ mod tests {
             bytes_received: Arc::new(AtomicUsize::new(0)),
             last_bytes: Arc::new(Mutex::new(Vec::new())),
             dsr_requested: Arc::new(AtomicBool::new(false)),
-            shared_parser: Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0))),
+            shared_parser: Arc::new(Mutex::new(term_wm_vt100::Parser::new(24, 80, 0))),
             dirty: Arc::new(AtomicBool::new(false)),
             dirty_cond: Arc::new((Mutex::new(()), Condvar::new())),
             pending_title: Arc::new(Mutex::new(None)),
@@ -1570,7 +1601,7 @@ mod tests {
         pty.screen();
 
         // Simulate reader thread publishing a new screen via shared parser.
-        let mut new_parser = vt100::Parser::new(24, 80, 100);
+        let mut new_parser = term_wm_vt100::Parser::new(24, 80, 100);
         new_parser.process(b"hello world");
         {
             let mut shared = pty.shared_parser.lock().unwrap();
@@ -1613,7 +1644,7 @@ mod tests {
         let mut pty = Pty::spawn_with_scrollback(cmd, size, 100).expect("spawn_with_scrollback");
 
         // Publish a new screen via shared parser.
-        let mut new_parser = vt100::Parser::new(24, 80, 100);
+        let mut new_parser = term_wm_vt100::Parser::new(24, 80, 100);
         new_parser.process(b"content");
         {
             let mut shared = pty.shared_parser.lock().unwrap();
@@ -1663,7 +1694,7 @@ mod tests {
         for i in 0..30 {
             writeln!(lines, "line {}", i).unwrap();
         }
-        let mut parser = vt100::Parser::new(24, 80, 100);
+        let mut parser = term_wm_vt100::Parser::new(24, 80, 100);
         parser.process(&lines);
         {
             let mut shared = pty.shared_parser.lock().unwrap();
@@ -1711,7 +1742,7 @@ mod tests {
         );
 
         // New shared parser data replaces the mutation (expected).
-        let mut parser2 = vt100::Parser::new(24, 80, 100);
+        let mut parser2 = term_wm_vt100::Parser::new(24, 80, 100);
         parser2.process(b"fresh output");
         {
             let mut shared = pty.shared_parser.lock().unwrap();
@@ -1753,7 +1784,7 @@ mod tests {
         for i in 0..30 {
             writeln!(lines, "line {}", i).unwrap();
         }
-        let mut parser = vt100::Parser::new(24, 80, 100);
+        let mut parser = term_wm_vt100::Parser::new(24, 80, 100);
         parser.process(&lines);
         {
             let mut shared = pty.shared_parser.lock().unwrap();
@@ -1989,12 +2020,12 @@ mod tests {
         }
 
         // ── OLD: create parser at 30 cols, replay all history ──
-        let mut old = vt100::Parser::new(24, 30, 100);
+        let mut old = term_wm_vt100::Parser::new(24, 30, 100);
         old.process(&history);
         let old_text = old.screen().contents();
 
         // ── NEW: process at 80 cols, then set_size to 30 ──
-        let mut new = vt100::Parser::new(24, 80, 100);
+        let mut new = term_wm_vt100::Parser::new(24, 80, 100);
         new.process(&history);
         new.screen_mut().set_size(24, 30);
         let new_text = new.screen().contents();
@@ -2010,7 +2041,59 @@ mod tests {
         assert_eq!(
             new_text.lines().count(),
             5,
-            "set_size must preserve 5 separate rows"
+            "set_size must preserve all 5 logical lines (via reflow)"
+        );
+    }
+
+    #[test]
+    fn reflow_preserves_scrollback_content_on_width_shrink() {
+        // Reflow must preserve previously-buffered scrollback content when the
+        // terminal width shrinks (the non-alt-screen resize case), instead of
+        // truncating the wrapped rows of a long line.
+        let mut parser = term_wm_vt100::Parser::new(24, 80, 2000);
+        let long_line = "x".repeat(200);
+        for i in 0..40 {
+            parser.process(format!("line {i}: {}\r\n", long_line).as_bytes());
+        }
+
+        // Count every written character across the whole scrollback + screen.
+        let count_chars =
+            |parser: &mut term_wm_vt100::Parser| -> std::collections::BTreeMap<char, usize> {
+                let (rows, cols) = parser.screen().size();
+                parser.screen_mut().set_scrollback(usize::MAX);
+                let sb = parser.screen().scrollback();
+                let mut map = std::collections::BTreeMap::new();
+                for i in 0..sb {
+                    parser.screen_mut().set_scrollback(sb - i);
+                    for c in 0..cols {
+                        if let Some(cell) = parser.screen().cell(0, c) {
+                            for ch in cell.contents().chars() {
+                                *map.entry(ch).or_insert(0) += 1;
+                            }
+                        }
+                    }
+                }
+                parser.screen_mut().set_scrollback(0);
+                for r in 0..rows {
+                    for c in 0..cols {
+                        if let Some(cell) = parser.screen().cell(r, c) {
+                            for ch in cell.contents().chars() {
+                                *map.entry(ch).or_insert(0) += 1;
+                            }
+                        }
+                    }
+                }
+                parser.screen_mut().set_scrollback(0);
+                map
+            };
+
+        let before = count_chars(&mut parser);
+        parser.screen_mut().set_size(24, 40);
+        let after = count_chars(&mut parser);
+
+        assert_eq!(
+            before, after,
+            "width shrink must not lose scrollback content"
         );
     }
 
@@ -2059,7 +2142,7 @@ mod tests {
 
     #[test]
     fn cursor_bounded_shrink_preserves_bottom_when_cursor_at_bottom() {
-        let mut parser = vt100::Parser::new(30, 80, 200);
+        let mut parser = term_wm_vt100::Parser::new(30, 80, 200);
         for i in 0..30 {
             parser.process(format!("line {}\r\n", i).as_bytes());
         }
@@ -2083,7 +2166,7 @@ mod tests {
 
     #[test]
     fn cursor_bounded_shrink_skips_when_cursor_above_new_height() {
-        let mut parser = vt100::Parser::new(30, 80, 200);
+        let mut parser = term_wm_vt100::Parser::new(30, 80, 200);
         for i in 0..10 {
             parser.process(format!("line {}\r\n", i).as_bytes());
         }
@@ -2115,7 +2198,7 @@ mod tests {
         sanitize_child_environment_with_lc_ctype(&mut cmd, None);
         assert_eq!(
             cmd.get_env("TERM").and_then(|v| v.to_str()),
-            Some("screen-256color")
+            Some(expected_child_term())
         );
     }
 
@@ -2199,8 +2282,9 @@ mod tests {
 
         let out = String::from_utf8_lossy(&accumulated);
         assert!(
-            out.contains("TERM=screen-256color"),
-            "expected TERM=screen-256color, got {out}"
+            out.contains(&format!("TERM={}", expected_child_term())),
+            "expected TERM={}, got {out}",
+            expected_child_term()
         );
         assert!(
             out.contains("COLORTERM=truecolor"),
@@ -2210,5 +2294,11 @@ mod tests {
             !out.contains("LC_CTYPE=UTF-8"),
             "invalid LC_CTYPE=UTF-8 must not reach the child, got {out}"
         );
+    }
+
+    /// Mirrors the platform-specific `CHILD_TERM` so tests assert the value the
+    /// sanitizer actually applies on this platform.
+    fn expected_child_term() -> &'static str {
+        CHILD_TERM
     }
 }

--- a/crates/term-wm-ui-components/Cargo.toml
+++ b/crates/term-wm-ui-components/Cargo.toml
@@ -24,9 +24,9 @@ term-wm-core = { workspace = true }
 term-wm-layout-engine = { workspace = true }
 term-wm-pty-engine = { workspace = true }
 term-wm-render = { workspace = true }
+term-wm-vt100 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-term-wm-vt100 = { workspace = true }
 webbrowser = { workspace = true }
 
 [dev-dependencies]

--- a/crates/term-wm-ui-components/Cargo.toml
+++ b/crates/term-wm-ui-components/Cargo.toml
@@ -26,7 +26,7 @@ term-wm-pty-engine = { workspace = true }
 term-wm-render = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-vt100 = { workspace = true }
+term-wm-vt100 = { workspace = true }
 webbrowser = { workspace = true }
 
 [dev-dependencies]

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use portable_pty::{CommandBuilder, PtySize};
 use ratatui::style::{Color as TColor, Modifier, Style};
 use term_wm_core::events::{Event, KeyCode, KeyKind, MouseButton, MouseEvent, MouseEventKind};
-use vt100::MouseProtocolEncoding;
+use term_wm_vt100::MouseProtocolEncoding;
 
 use crate::helpers::{
     color_to_ratatui, decorate_link_style, layout_rect_to_clipped_rect, localize_coordinate,
@@ -730,12 +730,12 @@ impl TerminalComponent {
 /// RAII guard that saves and restores the vt100 scrollback position.
 /// Guarantees restoration even on panic or early return.
 struct ScrollbackGuard<'a> {
-    screen: &'a mut vt100::Screen,
+    screen: &'a mut term_wm_vt100::Screen,
     original_offset: usize,
 }
 
 impl<'a> ScrollbackGuard<'a> {
-    fn new(screen: &'a mut vt100::Screen) -> Self {
+    fn new(screen: &'a mut term_wm_vt100::Screen) -> Self {
         let original_offset = screen.scrollback();
         Self {
             screen,
@@ -1024,7 +1024,10 @@ impl SelectionHost for RenderDragHost<'_> {
 }
 
 #[allow(dead_code)]
-fn resolve_colors(cell: &vt100::Cell, screen: &vt100::Screen) -> (Option<TColor>, Option<TColor>) {
+fn resolve_colors(
+    cell: &term_wm_vt100::Cell,
+    screen: &term_wm_vt100::Screen,
+) -> (Option<TColor>, Option<TColor>) {
     let mut fg = resolve_color(cell.fgcolor(), screen.fgcolor());
     let bg = resolve_color(cell.bgcolor(), screen.bgcolor());
     if cell.bold() {
@@ -1036,9 +1039,9 @@ fn resolve_colors(cell: &vt100::Cell, screen: &vt100::Screen) -> (Option<TColor>
 /// Like `resolve_colors` but takes pre-computed default fg/bg colors
 /// to avoid redundant `screen.fgcolor()`/`bgcolor()` calls per cell.
 fn resolve_colors_with_defaults(
-    cell: &vt100::Cell,
-    default_fg: vt100::Color,
-    default_bg: vt100::Color,
+    cell: &term_wm_vt100::Cell,
+    default_fg: term_wm_vt100::Color,
+    default_bg: term_wm_vt100::Color,
 ) -> (Option<TColor>, Option<TColor>) {
     let mut fg = resolve_color(cell.fgcolor(), default_fg);
     let bg = resolve_color(cell.bgcolor(), default_bg);
@@ -1048,23 +1051,26 @@ fn resolve_colors_with_defaults(
     (fg, bg)
 }
 
-fn vt_color_to_ratatui(color: vt100::Color) -> Option<TColor> {
+fn vt_color_to_ratatui(color: term_wm_vt100::Color) -> Option<TColor> {
     #[allow(unused_imports)]
     use term_wm_core::term_color::map_rgb_to_color;
     match color {
-        vt100::Color::Default => None,
-        vt100::Color::Idx(idx) => Some(TColor::Indexed(idx)),
-        vt100::Color::Rgb(r, g, b) => Some(crate::helpers::map_rgb_to_ratatui(r, g, b)),
+        term_wm_vt100::Color::Default => None,
+        term_wm_vt100::Color::Idx(idx) => Some(TColor::Indexed(idx)),
+        term_wm_vt100::Color::Rgb(r, g, b) => Some(crate::helpers::map_rgb_to_ratatui(r, g, b)),
     }
 }
 
-fn resolve_color(color: vt100::Color, screen_default: vt100::Color) -> Option<TColor> {
+fn resolve_color(
+    color: term_wm_vt100::Color,
+    screen_default: term_wm_vt100::Color,
+) -> Option<TColor> {
     match color {
-        vt100::Color::Default => match screen_default {
+        term_wm_vt100::Color::Default => match screen_default {
             // Default to Reset (No Color) which ratatui treats as "Inherit" or "Transparent" usually.
             // But since this is a Terminal component, we treat Default as Black/Opaque if undefined,
             // otherwise we risk bleeding through windows underneath.
-            vt100::Color::Default => None,
+            term_wm_vt100::Color::Default => None,
             other => vt_color_to_ratatui(other),
         },
         other => vt_color_to_ratatui(other),
@@ -1085,7 +1091,7 @@ fn brighten_indexed(color: Option<TColor>) -> Option<TColor> {
 /// byte sequence written to the child PTY (wrapped vs. raw).
 #[cfg(test)]
 struct TestPane {
-    parser: std::sync::Arc<std::sync::Mutex<vt100::Parser>>,
+    parser: std::sync::Arc<std::sync::Mutex<term_wm_vt100::Parser>>,
     current_scrollback: usize,
     max_sb: usize,
     alt_screen: bool,
@@ -1098,7 +1104,9 @@ struct TestPane {
 impl TestPane {
     fn new(max_sb: usize) -> Self {
         Self {
-            parser: std::sync::Arc::new(std::sync::Mutex::new(vt100::Parser::new(24, 80, max_sb))),
+            parser: std::sync::Arc::new(std::sync::Mutex::new(term_wm_vt100::Parser::new(
+                24, 80, max_sb,
+            ))),
             current_scrollback: 0,
             max_sb,
             alt_screen: false,
@@ -1111,7 +1119,9 @@ impl TestPane {
     fn with_kill_tracker(max_sb: usize) -> (Self, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
         let kill_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let pane = Self {
-            parser: std::sync::Arc::new(std::sync::Mutex::new(vt100::Parser::new(24, 80, max_sb))),
+            parser: std::sync::Arc::new(std::sync::Mutex::new(term_wm_vt100::Parser::new(
+                24, 80, max_sb,
+            ))),
             current_scrollback: 0,
             max_sb,
             alt_screen: false,
@@ -1174,7 +1184,7 @@ impl Pane for TestPane {
         Ok(())
     }
 
-    fn shared_parser(&mut self) -> std::sync::Arc<std::sync::Mutex<vt100::Parser>> {
+    fn shared_parser(&mut self) -> std::sync::Arc<std::sync::Mutex<term_wm_vt100::Parser>> {
         self.parser.clone()
     }
 
@@ -1601,24 +1611,24 @@ mod tests {
 
     #[test]
     fn vt_color_and_resolve_color() {
-        assert_eq!(vt_color_to_ratatui(vt100::Color::Default), None);
+        assert_eq!(vt_color_to_ratatui(term_wm_vt100::Color::Default), None);
         assert_eq!(
-            vt_color_to_ratatui(vt100::Color::Idx(5)),
+            vt_color_to_ratatui(term_wm_vt100::Color::Idx(5)),
             Some(TColor::Indexed(5))
         );
         // RGB passthrough depends on COLORTERM truecolor support;
-        // on terminals without it, vt100::Color::Rgb maps to a nearest
+        // on terminals without it, term_wm_vt100::Color::Rgb maps to a nearest
         // indexed color. Assert the function produces *some* color.
-        assert!(vt_color_to_ratatui(vt100::Color::Rgb(1, 2, 3)).is_some());
+        assert!(vt_color_to_ratatui(term_wm_vt100::Color::Rgb(1, 2, 3)).is_some());
 
         // resolve_color: when both default -> None
         assert_eq!(
-            resolve_color(vt100::Color::Default, vt100::Color::Default),
+            resolve_color(term_wm_vt100::Color::Default, term_wm_vt100::Color::Default),
             None
         );
         // when screen default is idx, default maps to that
         assert_eq!(
-            resolve_color(vt100::Color::Default, vt100::Color::Idx(7)),
+            resolve_color(term_wm_vt100::Color::Default, term_wm_vt100::Color::Idx(7)),
             Some(TColor::Indexed(7))
         );
     }


### PR DESCRIPTION
### Added

- **Terminal line reflow on resize:** resizing a terminal window now re-wraps soft-wrapped lines (scrollback + visible) to the new column width instead of truncating them, so previously-buffered output is preserved when the window shrinks or grows. Wide/CJK characters are never split across rows and keep their SGR attributes; explicitly written trailing spaces and background-only regions are preserved. **Accepted limitation:** on a width shrink, a shell prompt that re-wraps may briefly show duplicated/stale prompt rows, because a shell's SIGWINCH redraw (`\r ESC[J`) erases only downward from the cursor and cannot reach the re-wrapped rows above it. This is a protocol limitation of shell-driven redraw (present in other reflowing terminals), not an emulator bug, and no data is lost.

### Changed

- **Replaced `vt100` with `term-wm-vt100` crates.io fork (0.16.2-patch1):** the reflow-patched fork is now used as a plain registry dependency in place of the upstream `vt100` crate.

### Fixed

- **ncurses apps (pico, nano) losing background colors on macOS:** the child `TERM` is now `xterm-256color` on macOS — whose shipped `screen-256color` terminfo lacks the `bce` (Background Color Erase) capability, causing ncurses to reset attributes before line erases and drop backgrounds — and `screen-256color` elsewhere (where that terminfo has `bce`).
- **PTY reader-thread panic on poisoned mutexes:** `parser_read_loop` now recovers poisoned locks (`shared_parser`, `pending`, `last_bytes`, `status_cb`, `pending_title`, `dirty_cond`) via `into_inner()` instead of `.unwrap()`ing and crashing the I/O pipeline when a consumer panics while holding a lock.
- **`generate_snapshot` / `screen_lines` lock contention:** the shared-parser `MutexGuard` is released immediately after cloning the `Screen`, so full-frame escape-code formatting no longer starves the reader thread during high-throughput output.