### PR TITLE
feat(config): Simplify app construction and add extensibility hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Filename Conventions
 - Do NOT include the word `component` in filenames (avoid `terminal_component.rs`).
 
 - Window-manager-specific components (in the `term-wm-sys-ui-components` crate) must use the `wm_` filename prefix and `Wm` type prefix.
-	- Example: `WmDebugLogComponent` -> `wm_debug_log.rs`, `WmCommandPaletteOverlay` -> `wm_menu_overlay.rs`.
+	- Example: `WmDebugLogComponent` -> `wm_debug_log.rs`, `WmCommandPaletteComponent` -> `wm_command_palette.rs`.
 	- This applies to top-level files and files within category subdirectories (e.g., `sys/wm_help_overlay.rs`).
 	- Internal types (handles, writers, etc.) that are not components do not require the `Wm` prefix.
 
@@ -30,7 +30,7 @@ Component Implementation Placement
 
 Shared ScrollView
 - The shared scroll abstraction is `ScrollViewComponent` (not `ScrollView`). Use `ScrollViewComponent` wherever scrolling behavior is required.
-- Export `ScrollViewComponent` from `src/components/mod.rs` so other components may import it as `crate::components::scroll_view::ScrollViewComponent` or via `crate::components::ScrollViewComponent` if re-exported.
+- Export `ScrollViewComponent` from the crate's `src/lib.rs` so other components may import it via the crate root.
 
 Helper-Method Naming
 - Avoid naming inherent helpers `render` when the `Component::render` trait method exists; prefer `render_content` or another distinct name to prevent accidental recursion.
@@ -54,10 +54,11 @@ Component Developer API (Facade Pattern)
 - Do NOT call `ctx.screen_area()` in `on_mouse` — the framework has already converted to local coordinates.
 
 Module Exports
-- Keep `src/components/mod.rs` updated to re-export the canonical `*Component` names used across the repo.
+- Keep `src/lib.rs` updated to re-export the canonical `*Component` names used across the repo
+  (`pub use term_wm_ui_components::*`).
 
 Refactor & Verification Workflow
-- When renaming or moving a component, update all call sites and `mod.rs` exports.
+- When renaming or moving a component, update all call sites and the crate `lib.rs` exports.
 - After making changes, run:
 
 ```bash
@@ -68,7 +69,7 @@ cargo test
 If failures appear unrelated to your change, stop and ask for guidance.
 
 Pane Trait for Testability
-- `TerminalComponent` stores `Box<dyn Pane>` (defined in `crates/term-wm-core/src/pane.rs`).
+- `TerminalComponent` stores `Box<dyn Pane>` (defined in `crates/term-wm-pty-engine/src/pane.rs`).
 - Always use the `Pane` trait (not `Pty` directly) as the field type so that tests can inject `TestPane`.
 - `TestPane` lives in `crates/term-wm-ui-components/src/terminal.rs` under `#[cfg(test)]`. It wraps a `vt100::Parser` (for `screen()`) but tracks `scrollback`, `max_sb`, and `alt_screen` with its own fields.
 - To create a `TerminalComponent` for tests: `TerminalComponent::from_pane(Box::new(TestPane::new(max_sb)))`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.14-alpha] - 2026-08-07
+
+### Added
+
+- **Application extensibility — spatial & custom actions:** `TermWmAction` now ships a set of app-agnostic viewport actions (`ZoomIn`, `ZoomOut`, `ResetZoom`, `PanLeft`/`PanRight`/`PanUp`/`PanDown`, `CycleViewMode`) that any canvas, plot, or image component can bind keys to, plus a `Custom(u16)` action that lets host applications map keys to their own app-state triggers without modifying the framework enum. Applications bind them via `WmConfig.keybindings`, and the focused component interprets them in `update()`.
+- **Repeatable app task scheduling:** hosts can now schedule recurring work from the app itself. A new `AppTask` payload carries the closure, `TaskHandle::schedule_repeating` gained a "fire immediately" mode, cancelled tasks are purged eagerly, and the runner drains app tasks each cycle — keeping the event loop awake and capping the idle poll sleep so scheduled callbacks fire on time even under the power-saver profile.
+- **Configurable app construction:** two new standalone constructors, `TermWmApp::new_with_config(ctx, config)` and `TermWmApp::new_with_actions(ctx, config, actions)`, let host apps start from a custom `WmConfig` (e.g. custom keybindings) and/or an explicit command-palette action allow-list. A new `DEFAULT_SUPPORTED_MENU_ACTIONS` constant documents the default palette action set.
+- **Non-closable windows:** `wm.set_closable(key, false)` makes a window unclosable — its chrome ✕ button is hidden, the Command Palette's Close entry is disabled, and every close path (including PTY-child exit) is ignored.
+- **Smarter list scrolling:** a shared "keep selection visible" scroll-follow now applies to `ListComponent`, `ToggleListComponent`, and the Command Palette — the selected item stays in view without clobbering manual scrolls and re-engages after a viewport resize. A new `update_items()` on the list components replaces items in place while preserving the selection and any manual scroll, for live-refresh UIs.
+- **Horizontal scrolling for lists:** a new column-aware `slice_by_columns` helper slices horizontally-scrolled content by visual columns, padding boundary-crossing wide/CJK characters so rows stay column-aligned; the list components can now scroll sideways.
+
+### Changed
+
+- **Config surface simplified:** the confusing `TermWmApp::new/bare/embedded` convenience constructors and the `bare_custom`/`embedded_custom` variants are gone — only `new_custom`, `from_wm`, `new_with_config`, and `new_with_actions` remain. The `WmConfig::standalone()`/`minimal()` and `KeyBindings::standalone()`/`minimal()` presets were removed; `WmConfig::default()` is now the single full-featured configuration. `AppBuilder::bare()` is now `AppBuilder::new()`.
+- **Shared workspace dependencies:** every crate's dependencies now route through `[workspace.dependencies]` (single-source versioning) instead of being declared per-crate.
+- **Horizontal scrollbar thumb** now renders as a lower-half block (`▄`) grounded to the bottom edge of the row, keeping the track visible above it.
+- **Inner borders removed** from the list components, so each item row maps one-to-one to a content row.
+- **Bottom-panel keybinding hints** are now computed from a single shared source and no longer mutated during the render pass — the hints set during layout are exactly what's drawn.
+- **`examples/dual_image.rs`** resolves its default demo image against the crate root, so it loads regardless of the current working directory.
+
+### Fixed
+
+- **Monocle + Command Palette showed unfiltered keybindings:** with the Command Palette open in cramped monocle mode, the bottom panel re-pushed the *unfiltered* hint set during rendering, clobbering the layer-filtered hints set during layout (so Global actions like Ctrl+A appeared alongside palette actions). The render pass no longer mutates the panel, so palette-layer-filtered hints are shown consistently in every mode.
+- **`examples/dual_image.rs` could not find its default image** when launched from a directory other than the project root.
+
+### Dependencies
+
+- `resvg` 0.47.0 → 0.48.1
+- `serial_test` 3.5.0 → 4.0.1
+- `windows-sys` 0.59 → 0.61
+
+
 ## [0.9.13-alpha] - 2026-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,20 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -490,15 +504,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -896,6 +901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,16 +920,15 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser",
 ]
 
 [[package]]
@@ -1092,6 +1105,18 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -1298,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "indexmap"
@@ -2484,6 +2509,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
+dependencies = [
+ "bytemuck",
+ "font-types",
+ "once_cell",
+]
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,10 +2565,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",
@@ -2606,24 +2643,6 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
-]
-
-[[package]]
-name = "rustybuzz"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
 ]
 
 [[package]]
@@ -2709,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -2723,13 +2742,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2847,6 +2866,16 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
 
 [[package]]
 name = "slab"
@@ -3002,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3012,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3026,12 +3055,12 @@ dependencies = [
  "term-session-server",
  "tokio",
  "tracing-subscriber",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term-session-client"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3053,21 +3082,21 @@ dependencies = [
  "tokio",
  "tracing",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "libc",
  "term-session-muxio-service-definitions",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3077,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3093,12 +3122,12 @@ dependencies = [
  "term-wm-vt100",
  "tokio",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term-size-box"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3106,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3144,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "criterion",
  "crossterm",
@@ -3162,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3184,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3193,21 +3222,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.1",
@@ -3221,16 +3250,16 @@ dependencies = [
  "thiserror 2.0.19",
  "tracing",
  "vte",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3246,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3266,12 +3295,13 @@ dependencies = [
  "term-wm-vt100",
  "thiserror 2.0.19",
  "tracing",
+ "unicode-width",
  "webbrowser",
 ]
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",
@@ -3642,15 +3672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,18 +3702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,12 +3712,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -3759,26 +3762,26 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "data-url",
  "flate2",
  "fontdb",
+ "harfrust",
  "imagesize",
  "kurbo",
  "log",
  "pico-args",
  "roxmltree 0.21.1",
- "rustybuzz",
  "simplecss",
  "siphasher",
+ "skrifa",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
- "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -4121,20 +4124,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4148,42 +4142,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4193,21 +4165,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4217,21 +4177,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4241,33 +4189,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.13-alpha"
+version = "0.9.14-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -81,27 +81,29 @@ portable-pty = "0.9.0"
 proptest = "1.11.0"
 pulldown-cmark = "0.13.0"
 ratatui = "0.30.0"
-resvg = "0.47.0"
-serial_test = "3.5.0"
+resvg = "0.48.1"
+serial_test = "4.0.1"
 shell-words = "1.1.1"
+slotmap = "1.1"
+smallvec = "1.15"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.13-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.13-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.13-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.13-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.13-alpha" }
-term-wm = { path = ".", version = "0.9.13-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.13-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.13-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.13-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.13-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.13-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.13-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.13-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.13-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.13-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.13-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.14-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.14-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.14-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.14-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.14-alpha" }
+term-wm = { path = ".", version = "0.9.14-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.14-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.14-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.14-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.14-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.14-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.14-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.14-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.14-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.14-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.14-alpha" }
 term-wm-vt100 = "0.16.2-patch1"
 textwrap = "0.16.2"
 thiserror = "2.0.18"
@@ -111,7 +113,7 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 unicode-width = "0.2.2"
 vte = "0.15.0"
 webbrowser = "1.2.1"
-windows-sys = { version = "0.59", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
     "Win32_Security",
@@ -164,9 +166,9 @@ muxio-tokio-rpc-ipc-client = { workspace = true }
 proptest = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
-term-session-client = { path = "crates/term-session-client" }
+term-session-client = { workspace = true }
 term-session-mock = { workspace = true }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions" }
-term-session-server = { path = "crates/term-session-server" }
+term-session-muxio-service-definitions = { workspace = true }
+term-session-server = { workspace = true }
 term-wm-render = { workspace = true }
 tokio = { workspace = true }

--- a/crates/term-wm-console/src/console_event_source.rs
+++ b/crates/term-wm-console/src/console_event_source.rs
@@ -35,6 +35,10 @@ pub struct ConsoleEventSource {
     /// Set by the runner when there's pending work (e.g. countdown timer)
     /// to force frequent polling regardless of recent input activity.
     pending_work: bool,
+    /// Cap on the poll sleep, set by the runner to the next scheduler /
+    /// frame-pacer deadline so pending tasks fire on time even when idle
+    /// (PowerSaver would otherwise block for 3600s).
+    max_sleep_duration: Option<Duration>,
 }
 
 impl Default for ConsoleEventSource {
@@ -50,6 +54,7 @@ impl ConsoleEventSource {
             event_queue: VecDeque::new(),
             last_event_at: None,
             pending_work: false,
+            max_sleep_duration: None,
         }
     }
 
@@ -143,8 +148,16 @@ impl EventSource for ConsoleEventSource {
         self.pending_work = pending;
     }
 
+    fn set_max_sleep_duration(&mut self, duration: Option<Duration>) {
+        self.max_sleep_duration = duration;
+    }
+
     fn poll_interval(&self) -> Duration {
-        self.current_profile().poll_interval()
+        let base = self.current_profile().poll_interval();
+        match self.max_sleep_duration {
+            Some(max_sleep) => base.min(max_sleep),
+            None => base,
+        }
     }
 
     fn current_profile(&self) -> PowerProfile {

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -841,7 +841,9 @@ pub fn render_overlays<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Te
                 .register(hitbox_id, ComponentOwner::Layer(layer_id), top_area);
         }
 
-        // Bottom panel overlay in monocle mode — keybinding hints
+        // Bottom panel overlay in monocle mode — keybinding hints. Hints are
+        // set during the layout phase (register_managed_layout); the render
+        // phase only draws the component's already-established state.
         let bottom_area = LayoutRect {
             x: full_area.x,
             y: full_area.y + i32::from(full_area.height).saturating_sub(1),
@@ -849,12 +851,7 @@ pub fn render_overlays<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Te
             height: 1,
         };
         let mut bottom_hb = HitboxRegistry::new();
-        // Extract hints before mutable borrow (borrow checker safety).
-        let hints = wm
-            .keybindings()
-            .bottom_hints(term_wm_core::constants::MAX_BOTTOM_HINTS);
         if let Some(p) = wm.get_semantic_component_mut(ComponentTag::BottomPanel) {
-            p.process_action(&ComponentAction::SetKeybindingHints(hints));
             let ctx = ComponentContext::new(false).with_screen_area(bottom_area);
             p.render(backend, bottom_area, &ctx, &mut bottom_hb);
         }

--- a/crates/term-wm-core/Cargo.toml
+++ b/crates/term-wm-core/Cargo.toml
@@ -20,13 +20,13 @@ crossbeam-channel = { workspace = true }
 linkify = { workspace = true }
 nucleo-matcher = { workspace = true }
 portable-pty = { workspace = true, optional = true }
-slotmap = "1.1"
-smallvec = "1.15"
+slotmap = { workspace = true }
+smallvec = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 term-wm-events = { workspace = true }
 term-wm-layout-engine = { workspace = true }
 term-wm-pty-engine = { workspace = true }
 term-wm-render = { workspace = true }
-textwrap = "0.16"
+textwrap = { workspace = true }
 tracing = { workspace = true }
 unicode-width = { workspace = true }

--- a/crates/term-wm-core/src/actions.rs
+++ b/crates/term-wm-core/src/actions.rs
@@ -131,6 +131,33 @@ pub enum TermWmAction {
     /// Send the OpenCommandPalette key combo bytes to the focused window
     /// (payload-free for palette-layer keybinding).
     SendSuperKeyToFocusedWindow,
+
+    // --- Generic spatial / viewport actions (app-agnostic) ---
+    // Valid for any canvas, image, or plotting component. Applications bind
+    // keys to these via `WmConfig.keybindings`; the focused component's
+    // `update()` interprets them.
+    /// Zoom into the focused canvas/plot.
+    ZoomIn,
+    /// Zoom out of the focused canvas/plot.
+    ZoomOut,
+    /// Reset the zoom level of the focused canvas/plot.
+    ResetZoom,
+    /// Pan the focused canvas/plot left.
+    PanLeft,
+    /// Pan the focused canvas/plot right.
+    PanRight,
+    /// Pan the focused canvas/plot up.
+    PanUp,
+    /// Pan the focused canvas/plot down.
+    PanDown,
+    /// Cycle the focused component's view mode (e.g. summary <-> focused).
+    CycleViewMode,
+
+    // --- Application extensibility hatch ---
+    // Lets host applications map keys to their own application-state triggers
+    // without modifying the framework enum. The numeric code is
+    // application-defined; components interpret it in `update()`.
+    Custom(u16),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -197,7 +224,8 @@ impl TermWmAction {
             | TermWmAction::LinkClicked(_)
             | TermWmAction::ProcessExited
             | TermWmAction::ProfileChange(_)
-            | TermWmAction::RequestKeyboardFocus(_) => Category::System,
+            | TermWmAction::RequestKeyboardFocus(_)
+            | TermWmAction::Custom(_) => Category::System,
             TermWmAction::Callback(_)
             | TermWmAction::CycleNextWindow
             | TermWmAction::CyclePrevWindow
@@ -254,7 +282,15 @@ impl TermWmAction {
             | TermWmAction::MouseToBytes(_)
             | TermWmAction::ScrollView(_)
             | TermWmAction::ScrollToTop
-            | TermWmAction::ScrollToBottom => Category::Scrolling,
+            | TermWmAction::ScrollToBottom
+            | TermWmAction::ZoomIn
+            | TermWmAction::ZoomOut
+            | TermWmAction::ResetZoom
+            | TermWmAction::PanLeft
+            | TermWmAction::PanRight
+            | TermWmAction::PanUp
+            | TermWmAction::PanDown
+            | TermWmAction::CycleViewMode => Category::Scrolling,
 
             TermWmAction::ToggleSelection
             | TermWmAction::PasteClipboard
@@ -349,6 +385,15 @@ impl fmt::Display for TermWmAction {
             TermWmAction::Callback(_) => "Callback",
             TermWmAction::SendSuperKeyToWindow(_) => "Send SUPER key to window",
             TermWmAction::SendSuperKeyToFocusedWindow => "Send SUPER key to focused window",
+            TermWmAction::ZoomIn => "Zoom in",
+            TermWmAction::ZoomOut => "Zoom out",
+            TermWmAction::ResetZoom => "Reset zoom",
+            TermWmAction::PanLeft => "Pan left",
+            TermWmAction::PanRight => "Pan right",
+            TermWmAction::PanUp => "Pan up",
+            TermWmAction::PanDown => "Pan down",
+            TermWmAction::CycleViewMode => "Cycle view",
+            TermWmAction::Custom(_) => "Custom action",
         };
         write!(f, "{}", s)
     }

--- a/crates/term-wm-core/src/component_context.rs
+++ b/crates/term-wm-core/src/component_context.rs
@@ -203,6 +203,50 @@ impl ScrollHandle {
             inner.pending_offset_x = Some(clamped);
         }
     }
+
+    /// Keep the content row `selected_row` within the viewport, but ONLY when the
+    /// selection index or the viewport size changed since the last call. This
+    /// preserves manual (mouse) scrolls while still re-following after a terminal
+    /// resize (viewport_rows shrank and the selection fell out of view).
+    ///
+    /// Contract: `selected_row` is the row of the selected item in the SAME
+    /// content coordinate space as `offset_y` / `content_height`. Callers map
+    /// their own convention (e.g. ListComponent passes `selected + 1` because its
+    /// content height includes its self-drawn top border; CommandPalette passes
+    /// the 0-indexed display row). `viewport_rows` is the number of item rows
+    /// actually visible in that same space.
+    ///
+    /// IMPORTANT (ordering): the upper clamp uses the authoritative physical
+    /// `inner.max_offset_y()` (= content_height - inner.height). Pre-render callers
+    /// (CommandPaletteComponent, which runs this before its child
+    /// `list_scroll.render()` updates `inner.height`) MUST sync `scroll.height` to
+    /// the current physical viewport first so `max_offset_y()` evaluates correctly.
+    pub fn ensure_selection_visible(
+        &self,
+        selected_row: usize,
+        viewport_rows: usize,
+        last_selected: &mut usize,
+        last_viewport_rows: &mut usize,
+    ) {
+        if selected_row == *last_selected && viewport_rows == *last_viewport_rows {
+            return;
+        }
+        *last_selected = selected_row;
+        *last_viewport_rows = viewport_rows;
+        let mut inner = self.scroll.borrow_mut();
+        let current = inner.offset_y;
+        let new_offset = if selected_row < current {
+            selected_row
+        } else if selected_row >= current.saturating_add(viewport_rows) {
+            selected_row.saturating_sub(viewport_rows).saturating_add(1)
+        } else {
+            return; // already visible
+        };
+        let max = inner.max_offset_y();
+        let clamped = new_offset.min(max);
+        inner.offset_y = clamped;
+        inner.pending_offset_y = Some(clamped);
+    }
 }
 
 impl ComponentContext {
@@ -230,7 +274,7 @@ impl ComponentContext {
             hover_pos: None,
             keybindings: None,
             config: DEFAULT_CONFIG
-                .get_or_init(|| Arc::new(WmConfig::standalone()))
+                .get_or_init(|| Arc::new(WmConfig::default()))
                 .clone(),
             screen_area: None,
             active_hitbox: None,

--- a/crates/term-wm-core/src/config.rs
+++ b/crates/term-wm-core/src/config.rs
@@ -28,10 +28,10 @@ impl std::error::Error for ConfigError {}
 
 /// Monomorphic builder for [`WindowManager`].
 ///
-/// Configure the compositor's internal features. The only distinction
-/// is whether it boots with default system UI (inject components via
-/// `.top_panel()` / `.bottom_panel()` / `.command_menu()`) or as a
-/// blank canvas (`.bare()` with no chrome).
+/// Start with [`AppBuilder::new`], inject system UI via `.top_panel()` /
+/// `.bottom_panel()` / `.fab()` and `.supported_menu_actions()`, then
+/// `.build()`. The builder begins from `WmConfig::default()`; tweak with
+/// `.config()`, `.theme()`, `.keybindings()`, and `.hint_visibility()`.
 pub struct AppBuilder<L: WmComponent> {
     config: WmConfig,
     app_ctx: Option<Arc<AppContext>>,
@@ -41,10 +41,17 @@ pub struct AppBuilder<L: WmComponent> {
     supported_menu_actions: Option<Vec<TermWmAction>>,
 }
 
+impl<L: WmComponent> Default for AppBuilder<L> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<L: WmComponent> AppBuilder<L> {
-    /// Blank canvas — full standalone config, no chrome injected.
-    /// Use `.config(WmConfig::minimal())` for a minimal preset.
-    pub fn bare() -> Self {
+    /// Blank canvas — starts from `WmConfig::default()` (the full-featured
+    /// standalone config) with no chrome injected. Use `.config()` to swap in a
+    /// different configuration.
+    pub fn new() -> Self {
         Self {
             config: WmConfig::default(),
             app_ctx: None,

--- a/crates/term-wm-core/src/constants.rs
+++ b/crates/term-wm-core/src/constants.rs
@@ -2,6 +2,24 @@
 
 use std::time::Duration;
 
+use crate::actions::TermWmAction;
+
+/// Default actions available in the WM command menu when no explicit
+/// allow-list is configured via `AppBuilder::supported_menu_actions`.
+pub const DEFAULT_SUPPORTED_MENU_ACTIONS: &[TermWmAction] = &[
+    TermWmAction::CloseMenu,
+    TermWmAction::ToggleMouseCapture,
+    TermWmAction::ToggleClipboardMode,
+    TermWmAction::ToggleWindowSelection,
+    TermWmAction::NewWindow,
+    TermWmAction::ToggleDebugWindow,
+    TermWmAction::ToggleSystemPanel,
+    TermWmAction::Help,
+    TermWmAction::ExitUi,
+    TermWmAction::ToggleMonocle,
+    TermWmAction::ToggleTiling,
+];
+
 /// Minimum number of visible cells a floating window must keep within the
 /// viewport so the user can grab its chrome again.
 pub const MIN_FLOATING_VISIBLE_MARGIN: u16 = 4;

--- a/crates/term-wm-core/src/keybindings.rs
+++ b/crates/term-wm-core/src/keybindings.rs
@@ -62,6 +62,11 @@ impl fmt::Display for KeyCombo {
 
 use std::collections::BTreeMap;
 
+/// Maps [`TermWmAction`]s to the key combinations that trigger them.
+///
+/// [`KeyBindings::default`] ships the full built-in binding set. Use
+/// [`KeyBindings::new`] for an empty map that you populate via
+/// [`KeyBindings::add`].
 #[derive(Debug, Clone)]
 pub struct KeyBindings {
     map: BTreeMap<TermWmAction, Vec<KeyCombo>>,
@@ -108,21 +113,8 @@ impl Default for KeyBindings {
 }
 
 impl KeyBindings {
-    /// Full standalone defaults — same as `Default`.
-    pub fn standalone() -> Self {
-        Self::default()
-    }
-
-    /// Minimal defaults: excludes Windows and Menu category actions.
-    pub fn minimal() -> Self {
-        let mut kb = Self::default();
-        kb.map.retain(|action, _| {
-            let cat = action.category();
-            cat != Category::Windows && cat != Category::Menu
-        });
-        kb
-    }
-
+    /// Start with an empty binding map (no shortcuts bound). Populate it with
+    /// [`KeyBindings::add`].
     pub fn new() -> Self {
         Self {
             map: BTreeMap::new(),

--- a/crates/term-wm-core/src/runner.rs
+++ b/crates/term-wm-core/src/runner.rs
@@ -17,7 +17,7 @@ use crate::hitbox_registry::HitboxRegistry;
 use crate::io::EventSource;
 use crate::io::FramePacer;
 use crate::layout::{LayoutNode, TilingLayout};
-use crate::task_scheduler::TaskScheduler;
+use crate::task_scheduler::{AppTask, TaskHandle, TaskScheduler};
 use crate::window::{WindowKey, WindowManager};
 use std::collections::VecDeque;
 
@@ -59,6 +59,16 @@ pub trait WindowManagerHost<
     /// Called by the runner each frame to render.
     /// The default implementation does nothing — apps override this to draw.
     fn render(&mut self, _backend: &mut dyn term_wm_render::RenderBackend) {}
+
+    /// Called once by `run_with_defaults` after the app-task scheduler is
+    /// installed, BEFORE the event loop starts. Override to schedule recurring
+    /// app tasks (e.g. via `TaskHandle::schedule_repeating` with an
+    /// `AppTask` callback).
+    fn on_app_scheduler_ready(&mut self, _handle: TaskHandle<AppTask<Self>>)
+    where
+        Self: Sized,
+    {
+    }
 
     fn handle_app_event(&mut self, _event: &Event) -> bool {
         false
@@ -265,6 +275,7 @@ pub fn run_event_loop<C, L, Ov, Rt, D, A, FDraw, FMap>(
     driver: &mut D,
     app: &mut A,
     system_scheduler: TaskScheduler<SystemTask>,
+    app_scheduler: TaskScheduler<AppTask<A>>,
     _map_region: FMap,
     mut draw: FDraw,
 ) -> io::Result<()>
@@ -279,6 +290,7 @@ where
     FMap: Fn(WindowKey) -> WindowKey + Copy,
 {
     let system_handle = system_scheduler.handle();
+    let app_handle = app_scheduler.handle();
     let mut profile_tracker =
         crate::power_profile::PowerProfileTracker::new(driver.current_profile());
     let mut frame_pacer = FramePacer::new();
@@ -334,6 +346,11 @@ where
                         }
                     }
                 }
+            }
+
+            // Drain app-level callback tasks (each carries its own closure).
+            for (_id, task) in app_handle.drain_expired() {
+                task.run(app);
             }
 
             // System tasks may have mutated state (notifications, tab outline,
@@ -406,10 +423,15 @@ where
                 // past a pending task timeout (e.g. SuperPassthrough).
                 // Also clamp to the FramePacer deadline so the poll wakes
                 // up when a delayed render is due, even without input.
-                let deadline = match (fp_deadline, system_handle.time_until_next()) {
-                    (Some(fp), Some(sys)) => Some(fp.min(sys)),
-                    (Some(fp), None) => Some(fp),
-                    (None, sys_or_none) => sys_or_none,
+                // The app scheduler (callback tasks) is included so a
+                // recurring app task keeps the loop awake when idle.
+                let app_next = app_handle.time_until_next();
+                let deadline = match (fp_deadline, system_handle.time_until_next(), app_next) {
+                    (Some(fp), Some(sys), Some(app)) => Some(fp.min(sys).min(app)),
+                    (Some(fp), Some(sys), None) => Some(fp.min(sys)),
+                    (Some(fp), None, Some(app)) => Some(fp.min(app)),
+                    (Some(fp), None, None) => Some(fp),
+                    (None, s, a) => s.or(a),
                 };
                 driver.set_max_sleep_duration(deadline);
                 if let Some(profile) = profile_tracker.poll(driver.current_profile()) {
@@ -754,7 +776,7 @@ where
         let handler_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(handler));
 
         system_handle.set_keep_awake(!app.wm().overlays().is_empty());
-        driver.set_pending_work(system_handle.is_keep_awake_active());
+        driver.set_pending_work(system_handle.is_keep_awake_active() || app_handle.has_pending());
         match handler_result {
             Ok(result) => result,
             Err(_) => {
@@ -800,11 +822,16 @@ where
     let system_handle = system_scheduler.handle();
     app.wm().set_system_task_handle(system_handle);
 
+    let app_scheduler = TaskScheduler::<AppTask<A>>::new();
+    let app_handle = app_scheduler.handle();
+    app.on_app_scheduler_ready(app_handle);
+
     run_event_loop(
         output,
         driver,
         app,
         system_scheduler,
+        app_scheduler,
         |key| key,
         |backend, app| {
             app.render(backend);
@@ -933,7 +960,7 @@ mod tests {
         assert!(auto_layout_for_windows(&empty).is_none());
 
         let mut wm = crate::window::WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -959,7 +986,7 @@ mod tests {
         }
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -993,7 +1020,7 @@ mod tests {
 
         let mut app = FakeApp {
             wm: WindowManager::<TestComponent>::with_config(
-                crate::wm_config::WmConfig::standalone(),
+                crate::wm_config::WmConfig::default(),
                 std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
                 None,
                 crate::window::LayerManager::new(),
@@ -1056,7 +1083,7 @@ mod tests {
 
         let mut app = FakeApp {
             wm: WindowManager::<TestComponent>::with_config(
-                crate::wm_config::WmConfig::standalone(),
+                crate::wm_config::WmConfig::default(),
                 std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
                 None,
                 crate::window::LayerManager::new(),
@@ -1120,7 +1147,7 @@ mod tests {
 
         let mut app = FakeApp {
             wm: WindowManager::<TestComponent>::with_config(
-                crate::wm_config::WmConfig::standalone(),
+                crate::wm_config::WmConfig::default(),
                 std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
                 None,
                 crate::window::LayerManager::new(),
@@ -1175,7 +1202,7 @@ mod tests {
 
         let mut app = FakeApp {
             wm: WindowManager::<TestComponent>::with_config(
-                crate::wm_config::WmConfig::standalone(),
+                crate::wm_config::WmConfig::default(),
                 std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
                 None,
                 crate::window::LayerManager::new(),
@@ -1314,7 +1341,7 @@ mod tests {
 
     fn make_keys(n: usize) -> Vec<WindowKey> {
         let mut wm = crate::window::WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1371,7 +1398,7 @@ mod tests {
     #[test]
     fn auto_layout_two_windows_creates_split() {
         let mut wm = crate::window::WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1393,7 +1420,7 @@ mod tests {
     #[test]
     fn auto_layout_three_windows_all_present() {
         let mut wm = crate::window::WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1412,7 +1439,7 @@ mod tests {
     #[test]
     fn auto_layout_multiple_windows_uses_all() {
         let mut wm = crate::window::WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1492,7 +1519,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1521,7 +1548,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1551,7 +1578,7 @@ mod tests {
             }
         }
         let wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1574,7 +1601,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1604,7 +1631,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1637,7 +1664,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1680,7 +1707,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1708,7 +1735,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1739,7 +1766,7 @@ mod tests {
             }
         }
         let wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1773,7 +1800,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1812,7 +1839,7 @@ mod tests {
             }
         }
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -1972,6 +1999,7 @@ mod power_calibration_tests {
             &mut driver,
             &mut app,
             crate::task_scheduler::TaskScheduler::<crate::actions::SystemTask>::new(),
+            crate::task_scheduler::TaskScheduler::<crate::task_scheduler::AppTask<_>>::new(),
             |k| k,
             |_backend, app| {
                 app.draws += 1;

--- a/crates/term-wm-core/src/task_scheduler.rs
+++ b/crates/term-wm-core/src/task_scheduler.rs
@@ -447,7 +447,10 @@ mod tests {
 
         // Lazy cancel must be visible to the queue queries: the cancelled
         // entry is purged from the top of the heap.
-        assert!(!handle.has_pending(), "cancelled task should not be pending");
+        assert!(
+            !handle.has_pending(),
+            "cancelled task should not be pending"
+        );
         assert!(
             handle.time_until_next().is_none(),
             "cancelled task should not have a next deadline"

--- a/crates/term-wm-core/src/task_scheduler.rs
+++ b/crates/term-wm-core/src/task_scheduler.rs
@@ -111,16 +111,23 @@ impl<T> TaskHandle<T> {
     ///
     /// The payload is cloned on each re-insertion.  The next deadline is
     /// computed as `original_deadline + interval` to prevent timer drift
-    /// under load.
-    pub fn schedule_repeating(&self, interval: Duration, payload: T) -> TaskId
+    /// under load.  When `fire_immediate` is true the first fire happens on
+    /// the next `drain_expired` (deadline = now); otherwise it waits one
+    /// interval.
+    pub fn schedule_repeating(&self, interval: Duration, fire_immediate: bool, payload: T) -> TaskId
     where
         T: Clone,
     {
         let mut inner = self.inner.borrow_mut();
         let id = TaskId(inner.next_id);
         inner.next_id += 1;
+        let deadline = if fire_immediate {
+            Instant::now()
+        } else {
+            Instant::now() + interval
+        };
         inner.heap.push(HeapEntry {
-            deadline: Instant::now() + interval,
+            deadline,
             interval: Some(interval),
             payload,
             id,
@@ -139,7 +146,8 @@ impl<T> TaskHandle<T> {
     /// Returns `true` when any tasks are pending (both expired and
     /// non-expired) or [`keep_awake`](Self::set_keep_awake) is active.
     pub fn has_pending(&self) -> bool {
-        let inner = self.inner.borrow();
+        let mut inner = self.inner.borrow_mut();
+        self.purge_cancelled(&mut inner);
         inner.keep_awake || !inner.heap.is_empty()
     }
 
@@ -159,10 +167,23 @@ impl<T> TaskHandle<T> {
     /// Returns the duration until the next deadline, or [`None`] when the
     /// scheduler is empty.
     pub fn time_until_next(&self) -> Option<Duration> {
-        let inner = self.inner.borrow();
+        let mut inner = self.inner.borrow_mut();
+        self.purge_cancelled(&mut inner);
         let deadline = inner.heap.peek()?.deadline;
         let remaining = deadline.saturating_duration_since(Instant::now());
         Some(remaining)
+    }
+
+    /// Pop and discard any cancelled entries at the top of the heap so that
+    /// queries like [`has_pending`](Self::has_pending) and
+    /// [`time_until_next`](Self::time_until_next) reflect only live tasks.
+    fn purge_cancelled(&self, inner: &mut SchedulerInner<T>) {
+        while let Some(entry) = inner.heap.peek() {
+            if !inner.cancelled.remove(&entry.id) {
+                break;
+            }
+            inner.heap.pop();
+        }
     }
 
     /// Drain all expired tasks.
@@ -224,6 +245,44 @@ impl<T> TaskHandle<T> {
         }
 
         result
+    }
+}
+
+/// Shared, single-threaded callback handle used by [`AppTask`]. A manual
+/// `Clone` shares the `Rc` without requiring `A: Clone`.
+type AppCallback<A> = Rc<RefCell<Box<dyn FnMut(&mut A)>>>;
+
+/// A callback-carrying app task payload. Clone shares the underlying
+/// callback (Rc), so a repeating task fires the same closure each interval.
+///
+/// Unlike a plain payload value, the app task carries the closure itself, so
+/// multiple distinct repeating tasks are naturally differentiated — each
+/// schedules its own callback and the runner invokes the matching one.
+pub struct AppTask<A> {
+    callback: AppCallback<A>,
+}
+
+// Manual Clone: derives the inner Rc only, WITHOUT injecting an `A: Clone`
+// bound. `#[derive(Clone)]` would require `A: Clone` (AppState is !Clone).
+impl<A> Clone for AppTask<A> {
+    fn clone(&self) -> Self {
+        Self {
+            callback: Rc::clone(&self.callback),
+        }
+    }
+}
+
+impl<A> AppTask<A> {
+    /// Wrap a callback that receives the application state.
+    pub fn new<F: FnMut(&mut A) + 'static>(f: F) -> Self {
+        Self {
+            callback: Rc::new(RefCell::new(Box::new(f))),
+        }
+    }
+
+    /// Invoke the callback with the current application state.
+    pub fn run(&self, app: &mut A) {
+        (self.callback.borrow_mut())(app);
     }
 }
 
@@ -289,7 +348,7 @@ mod tests {
     #[test]
     fn repeating_task_fires_multiple_times() {
         let handle = TaskScheduler::<&str>::new().handle();
-        handle.schedule_repeating(Duration::from_millis(10), "tick");
+        handle.schedule_repeating(Duration::from_millis(10), false, "tick");
         std::thread::sleep(Duration::from_millis(35));
         let expired = handle.drain_expired();
         // Should have fired ~3 times (10ms, 20ms, 30ms)
@@ -302,7 +361,7 @@ mod tests {
     #[test]
     fn cancel_repeating_stops_future_fires() {
         let handle = TaskScheduler::<&str>::new().handle();
-        let id = handle.schedule_repeating(Duration::from_millis(10), "tick");
+        let id = handle.schedule_repeating(Duration::from_millis(10), false, "tick");
 
         // Wait for the first interval
         std::thread::sleep(Duration::from_millis(15));
@@ -334,7 +393,7 @@ mod tests {
     #[test]
     fn anti_drift_uses_original_deadline() {
         let handle = TaskScheduler::<&str>::new().handle();
-        let id = handle.schedule_repeating(Duration::from_secs(60), "slow");
+        let id = handle.schedule_repeating(Duration::from_secs(60), false, "slow");
         // Access the inner heap directly and verify the deadline computation
         let inner = handle.inner.borrow();
         let entry = inner.heap.peek().unwrap();
@@ -375,5 +434,100 @@ mod tests {
         assert!(sched.handle().is_keep_awake_active());
         sched.handle().set_keep_awake(false);
         assert!(!sched.handle().is_keep_awake_active());
+    }
+
+    #[test]
+    fn cancel_once_before_deadline_suppresses() {
+        let handle = TaskScheduler::<&str>::new().handle();
+        let id = handle.schedule_once(Duration::from_secs(60), "x");
+        assert!(handle.has_pending());
+        assert!(handle.time_until_next().is_some());
+
+        handle.cancel(id);
+
+        // Lazy cancel must be visible to the queue queries: the cancelled
+        // entry is purged from the top of the heap.
+        assert!(!handle.has_pending(), "cancelled task should not be pending");
+        assert!(
+            handle.time_until_next().is_none(),
+            "cancelled task should not have a next deadline"
+        );
+        assert!(handle.drain_expired().is_empty());
+        assert!(handle.drain_expired_once().is_empty());
+    }
+
+    #[test]
+    fn cancel_once_after_deadline_not_yet_drained_suppresses() {
+        let handle = TaskScheduler::<&str>::new().handle();
+        let id = handle.schedule_once(Duration::from_millis(1), "x");
+        std::thread::sleep(Duration::from_millis(10));
+        // Deadline elapsed but not drained yet — cancel must still suppress.
+        handle.cancel(id);
+        assert!(handle.drain_expired_once().is_empty());
+        assert!(handle.drain_expired().is_empty());
+    }
+
+    #[test]
+    fn cancel_repeating_before_first_fire_suppresses_all() {
+        let handle = TaskScheduler::<&str>::new().handle();
+        let id = handle.schedule_repeating(Duration::from_millis(10), false, "tick");
+        handle.cancel(id);
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(
+            handle.drain_expired().is_empty(),
+            "cancelled repeating task must never fire"
+        );
+    }
+
+    #[test]
+    fn cancel_repeating_fire_immediate_suppresses() {
+        let handle = TaskScheduler::<&str>::new().handle();
+        let id = handle.schedule_repeating(Duration::from_millis(10), true, "tick");
+        handle.cancel(id);
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(
+            handle.drain_expired().is_empty(),
+            "cancelled fire_immediate task must never fire"
+        );
+    }
+
+    #[test]
+    fn cancel_repeating_fire_immediate_then_stops_after_first() {
+        let handle = TaskScheduler::<&str>::new().handle();
+        let id = handle.schedule_repeating(Duration::from_millis(10), true, "tick");
+
+        // fire_immediate: fires on the first drain (deadline = now).
+        let first = handle.drain_expired();
+        assert_eq!(first.len(), 1, "fire_immediate should fire on first drain");
+        assert_eq!(first[0].0, id);
+
+        // Cancel after the immediate fire; future re-inserted fires suppressed.
+        handle.cancel(id);
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(
+            handle.drain_expired().is_empty(),
+            "repeating fire_immediate task must stop after cancel"
+        );
+    }
+
+    #[test]
+    fn cancel_via_shared_handle() {
+        let sched = TaskScheduler::<&str>::new();
+        let h1 = sched.handle();
+        let h2 = sched.handle();
+
+        let once_id = h1.schedule_once(Duration::from_millis(1), "once");
+        let repeat_id = h2.schedule_repeating(Duration::from_millis(10), true, "repeat");
+
+        // Cancel both through a different handle clone.
+        h2.cancel(once_id);
+        h1.cancel(repeat_id);
+
+        std::thread::sleep(Duration::from_millis(25));
+        assert!(
+            h1.drain_expired().is_empty(),
+            "cancelled tasks must not fire via any handle"
+        );
+        assert!(h2.drain_expired_once().is_empty());
     }
 }

--- a/crates/term-wm-core/src/window/entry.rs
+++ b/crates/term-wm-core/src/window/entry.rs
@@ -109,6 +109,9 @@ pub struct Window {
     component_key: ComponentKey,
     /// What happens when this window is closed.
     close_policy: ClosePolicy,
+    /// Whether the window may be closed (via chrome ✕, palette, action, or
+    /// PTY-child exit). Non-closable windows can never be removed.
+    closable: bool,
     /// Persistent HitboxId for the window's content area.
     content_hitbox_id: HitboxId,
     /// Which leaf component within this window currently holds keyboard focus.
@@ -136,6 +139,7 @@ impl Window {
             chrome_config: ModeChromeConfig::default(),
             component_key,
             close_policy: ClosePolicy::default(),
+            closable: true,
             content_hitbox_id: HitboxId::new(),
             active_keyboard_focus: None,
             tracker: None,
@@ -250,6 +254,14 @@ impl Window {
 
     pub fn set_close_policy(&mut self, policy: ClosePolicy) {
         self.close_policy = policy;
+    }
+
+    pub fn closable(&self) -> bool {
+        self.closable
+    }
+
+    pub fn set_closable(&mut self, closable: bool) {
+        self.closable = closable;
     }
 
     // ── Hitbox ────────────────────────────────────────────────────────────────

--- a/crates/term-wm-core/src/window/window_manager/chrome.rs
+++ b/crates/term-wm-core/src/window/window_manager/chrome.rs
@@ -95,11 +95,19 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// - `Unmap`: transition to `Unmapped` only.  The component and key
     ///   stay alive so the window can be re-shown via `transition_window`.
     pub fn close_window(&mut self, key: WindowKey) {
+        let w = match self.window(key) {
+            Some(w) => w,
+            None => {
+                tracing::warn!(window_key = ?key, "close_window invoked on unknown or destroyed window");
+                return;
+            }
+        };
+        if !w.closable() {
+            tracing::debug!(window_key = ?key, "ignoring close: window is not closable");
+            return;
+        }
         tracing::debug!(window_key = ?key, "closing window");
-        let policy = self
-            .window(key)
-            .map(|w| w.close_policy())
-            .unwrap_or_default();
+        let policy = w.close_policy();
         self.transition_window(key, WindowState::Unmapped);
 
         if policy == ClosePolicy::Destroy {
@@ -126,7 +134,7 @@ mod tests {
 
     fn make_wm() -> WindowManager<NoopComponent> {
         WindowManager::<NoopComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),

--- a/crates/term-wm-core/src/window/window_manager/command_palette.rs
+++ b/crates/term-wm-core/src/window/window_manager/command_palette.rs
@@ -181,12 +181,12 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
                     disabled: false,
                 }));
 
-                // Close window
+                // Close window (disabled for non-closable windows)
                 items.push(MenuDisplayItem::Item(MenuItem {
                     label: format!("Close {}", title).into(),
                     icon: Some("X"),
                     action: crate::actions::TermWmAction::CloseWindow(focused),
-                    disabled: false,
+                    disabled: !self.window(focused).is_some_and(|w| w.closable()),
                 }));
 
                 // Maximize / Restore
@@ -303,7 +303,7 @@ mod tests {
 
     fn make_wm<O: Overlay<TermWmAction>>() -> WindowManager<TestComponent, NoopWmComponent, O> {
         WindowManager::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -273,50 +273,45 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         // Height is determined by the component's consume_area; no-op here
     }
 
+    /// Compute the keybinding hints to display in the bottom panel for the
+    /// current input mode.
+    ///
+    /// Honors `hint_visibility` (non-`Always` → empty) and
+    /// `wm_command_menu_enabled`. When the command menu is enabled, hints are
+    /// filtered to the active `ActionLayer` (CommandPalette / Help / Global)
+    /// derived from `input_mode`, so opening the Command Palette shows only
+    /// palette-layer shortcuts.
+    pub fn bottom_panel_hints(&self) -> Vec<(TermWmAction, Vec<String>)> {
+        match self.hint_visibility {
+            crate::wm_config::HintVisibility::Always => {
+                if self.config.wm_command_menu_enabled {
+                    let layer = match self.input_mode {
+                        crate::actions::WmInputMode::CommandPalette => ActionLayer::CommandPalette,
+                        crate::actions::WmInputMode::Help => ActionLayer::Help,
+                        _ => ActionLayer::Global,
+                    };
+                    self.keybindings()
+                        .bottom_hints_for_layer(crate::constants::MAX_BOTTOM_HINTS, layer)
+                } else {
+                    self.keybindings()
+                        .bottom_hints(crate::constants::MAX_BOTTOM_HINTS)
+                }
+            }
+            _ => Vec::new(),
+        }
+    }
+
     pub fn register_managed_layout(&mut self, area: Rect) {
         self.last_frame_area = area;
         // Show CommandPalette-filtered hints when the command palette is open,
         // Global-only hints when closed.
-        match self.hint_visibility {
-            crate::wm_config::HintVisibility::Always => {
-                let layer = match self.input_mode {
-                    crate::actions::WmInputMode::CommandPalette => ActionLayer::CommandPalette,
-                    crate::actions::WmInputMode::Help => ActionLayer::Help,
-                    _ => ActionLayer::Global,
-                };
-                if self.config.wm_command_menu_enabled {
-                    let hints = self
-                        .keybindings()
-                        .bottom_hints_for_layer(crate::constants::MAX_BOTTOM_HINTS, layer);
-                    if let Some(p) = self
-                        .get_semantic_component_mut(super::layer_manager::ComponentTag::BottomPanel)
-                    {
-                        p.process_action(&crate::components::ComponentAction::SetKeybindingHints(
-                            hints,
-                        ));
-                    }
-                } else {
-                    let hints = self
-                        .keybindings()
-                        .bottom_hints(crate::constants::MAX_BOTTOM_HINTS);
-                    if let Some(p) = self
-                        .get_semantic_component_mut(super::layer_manager::ComponentTag::BottomPanel)
-                    {
-                        p.process_action(&crate::components::ComponentAction::SetKeybindingHints(
-                            hints,
-                        ));
-                    }
-                }
-            }
-            _ => {
-                if let Some(p) =
-                    self.get_semantic_component_mut(super::layer_manager::ComponentTag::BottomPanel)
-                {
-                    p.process_action(&crate::components::ComponentAction::SetKeybindingHints(
-                        Vec::new(),
-                    ));
-                }
-            }
+        let hints = self.bottom_panel_hints();
+        if let Some(p) =
+            self.get_semantic_component_mut(super::layer_manager::ComponentTag::BottomPanel)
+        {
+            p.process_action(&crate::components::ComponentAction::SetKeybindingHints(
+                hints,
+            ));
         }
         // Compute whether the panel should be active from config + visibility,
         // BEFORE calling consume_area (which needs this state to claim space).
@@ -930,7 +925,7 @@ mod tests {
 
     fn make_wm() -> WindowManager<NoopComponent> {
         let mut wm = WindowManager::<NoopComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -945,11 +940,66 @@ mod tests {
         wm
     }
 
+    fn actions_in_hints(hints: &[(TermWmAction, Vec<String>)]) -> Vec<TermWmAction> {
+        hints.iter().map(|(action, _)| action.clone()).collect()
+    }
+
+    #[test]
+    fn bottom_panel_hints_global_by_default() {
+        let wm = make_wm();
+        let hints = wm.bottom_panel_hints();
+        let actions = actions_in_hints(&hints);
+        assert!(
+            actions.contains(&TermWmAction::OpenCommandPalette),
+            "default (passthrough) mode should include the Global OpenCommandPalette action, got {actions:?}"
+        );
+        assert!(!hints.is_empty());
+    }
+
+    #[test]
+    fn bottom_panel_hints_command_palette_layer_when_palette_open() {
+        let mut wm = make_wm();
+        wm.open_command_palette_overlay(crate::components::NoopOverlay);
+        assert_eq!(wm.input_mode, crate::actions::WmInputMode::CommandPalette);
+        let hints = wm.bottom_panel_hints();
+        let actions = actions_in_hints(&hints);
+        assert!(
+            !actions.contains(&TermWmAction::OpenCommandPalette),
+            "palette mode should exclude the Global OpenCommandPalette action, got {actions:?}"
+        );
+        assert!(
+            actions.contains(&TermWmAction::FocusNext),
+            "palette mode should include a CommandPalette-layer action, got {actions:?}"
+        );
+    }
+
+    #[test]
+    fn bottom_panel_hints_empty_when_hint_visibility_not_always() {
+        let mut wm = make_wm();
+        wm.set_hint_visibility(crate::wm_config::HintVisibility::OnDemand);
+        assert!(wm.bottom_panel_hints().is_empty());
+    }
+
+    #[test]
+    fn bottom_panel_hints_unfiltered_when_command_menu_disabled() {
+        let mut wm = make_wm();
+        wm.config.wm_command_menu_enabled = false;
+        wm.open_command_palette_overlay(crate::components::NoopOverlay);
+        let hints = wm.bottom_panel_hints();
+        let actions = actions_in_hints(&hints);
+        assert!(
+            actions.contains(&TermWmAction::OpenCommandPalette),
+            "with the command menu disabled, hints should be unfiltered (include Global actions), got {actions:?}"
+        );
+    }
+
     #[test]
     fn startup_two_windows_stack_vertically_on_tall_area() {
         // Unseeded WM: managed_area is 0x0 until the first frame registers it.
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm = WindowManager::<NoopComponent>::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -1004,8 +1054,10 @@ mod tests {
         // Regression: on a wide 120x24 viewport, the third window lands in a
         // half-screen column (60x24). It must stack there rather than split
         // side-by-side into narrow full-height strips.
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm = WindowManager::<NoopComponent>::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -1390,7 +1442,7 @@ mod window_mode_tests {
 
     fn make_wm() -> WindowManager<NoopComponent> {
         let mut wm = WindowManager::<NoopComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -453,6 +453,21 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         }
     }
 
+    /// Mark a window as closable (default) or not. Non-closable windows are
+    /// ignored by `close_window` (all close paths, including PTY-child exit),
+    /// their chrome ✕ button is hidden, and the palette "Close" entry is
+    /// disabled.
+    pub fn set_closable(&mut self, key: WindowKey, closable: bool) {
+        if let Some(w) = self.windows.get_mut(key) {
+            w.set_closable(closable);
+        }
+    }
+
+    /// Whether the window may be closed. Unknown keys return `false`.
+    pub fn is_closable(&self, key: WindowKey) -> bool {
+        self.window(key).is_some_and(|w| w.closable())
+    }
+
     /// Access the Reaper for async child-process teardown.
     pub fn reaper(&self) -> &Reaper {
         &self.reaper
@@ -767,21 +782,8 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         layer_manager: layer_manager::LayerManager<L>,
         semantic_registry: HashMap<layer_manager::ComponentTag, layer_manager::LayerId>,
     ) -> Self {
-        let supported_menu_actions = supported_menu_actions.unwrap_or_else(|| {
-            vec![
-                TermWmAction::CloseMenu,
-                TermWmAction::ToggleMouseCapture,
-                TermWmAction::ToggleClipboardMode,
-                TermWmAction::ToggleWindowSelection,
-                TermWmAction::NewWindow,
-                TermWmAction::ToggleDebugWindow,
-                TermWmAction::ToggleSystemPanel,
-                TermWmAction::Help,
-                TermWmAction::ExitUi,
-                TermWmAction::ToggleMonocle,
-                TermWmAction::ToggleTiling,
-            ]
-        });
+        let supported_menu_actions = supported_menu_actions
+            .unwrap_or_else(|| crate::constants::DEFAULT_SUPPORTED_MENU_ACTIONS.to_vec());
         let mouse_capture_enabled = config.mouse_capture_enabled;
         let clipboard = Some(crate::clipboard::Clipboard::new());
         let floating_resize_offscreen = config.floating_resize_offscreen;
@@ -2637,11 +2639,14 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             return Vec::new();
         }
         let is_maxed = self.window(focused).is_some_and(|w| w.is_maximized());
-        let mut btns = vec![WmButton {
-            action: TermWmAction::CloseWindow(focused),
-            label: "Close Window",
-            symbol: "X",
-        }];
+        let mut btns = Vec::new();
+        if self.window(focused).is_some_and(|w| w.closable()) {
+            btns.push(WmButton {
+                action: TermWmAction::CloseWindow(focused),
+                label: "Close Window",
+                symbol: "X",
+            });
+        }
         if !self.is_monocle() {
             btns.push(WmButton {
                 action: TermWmAction::MaximizeWindow(focused),
@@ -2884,7 +2889,7 @@ mod tests {
     #[test]
     fn map_layout_node_maps_leaf_to_windowkey() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -2916,7 +2921,7 @@ mod tests {
     fn click_focusing_topmost_window() {
         use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -2964,7 +2969,7 @@ mod tests {
     #[test]
     fn handle_mouse_focus_click_skipped_in_monocle() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3019,7 +3024,7 @@ mod tests {
     fn enforce_min_visible_margin_horizontal() {
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3058,7 +3063,7 @@ mod tests {
     fn enforce_min_visible_margin_vertical() {
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3094,7 +3099,7 @@ mod tests {
     fn maximize_persists_across_resize() {
         use crate::window::FloatRectSpec;
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3128,7 +3133,7 @@ mod tests {
     fn maximize_tiled_then_focus_other_unmaximizes_and_retiles() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3185,7 +3190,7 @@ mod tests {
         use crate::layout::{LayoutNode, TilingLayout};
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3242,7 +3247,7 @@ mod tests {
     fn tiled_maximize_toggle_unmaximize() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3296,7 +3301,7 @@ mod tests {
     fn tiled_maximize_void_id_set() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3334,7 +3339,7 @@ mod tests {
     fn floating_maximize_toggle_unmaximize() {
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3378,7 +3383,7 @@ mod tests {
     fn tiled_maximize_then_advance_focus_unmaximizes() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3418,7 +3423,7 @@ mod tests {
     fn tiled_maximize_then_mouse_click_focus_unmaximizes() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3465,7 +3470,7 @@ mod tests {
     fn tiled_maximize_single_window() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3504,7 +3509,7 @@ mod tests {
     fn tiled_maximize_three_windows() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3555,7 +3560,7 @@ mod tests {
     fn tiled_maximize_then_minimize_and_restore() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3601,7 +3606,7 @@ mod tests {
     fn tiled_maximize_minimize_restore_focus_other_stays_in_tree() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3663,7 +3668,7 @@ mod tests {
     fn minimize_restore_single_tiled_window_takes_full_area() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3703,7 +3708,7 @@ mod tests {
     fn toggle_maximize_already_maximized() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3733,7 +3738,7 @@ mod tests {
     fn focus_same_window_when_maximized() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3766,7 +3771,7 @@ mod tests {
     fn close_maximized_tiled_removes_void() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3805,7 +3810,7 @@ mod tests {
     fn close_maximized_floating_restores_normally() {
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3837,7 +3842,7 @@ mod tests {
     fn unmap_maximized_tiled_removes_void() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3878,7 +3883,7 @@ mod tests {
     #[test]
     fn try_spawn_floating_default_behavior_matrix() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3928,7 +3933,7 @@ mod tests {
     #[test]
     fn focus_add_preserves_existing_valid_focus() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3952,7 +3957,7 @@ mod tests {
     #[test]
     fn advance_focus_cycles_order_forward_and_backward() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -3980,7 +3985,7 @@ mod tests {
     fn take_synthetic_event_clears_on_take() {
         use crate::events::{Event, KeyCode, KeyEvent, KeyKind, KeyModifiers};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4008,7 +4013,7 @@ mod tests {
     #[test]
     fn select_fallback_focus_handles_empty_and_populated_ring() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4032,7 +4037,7 @@ mod tests {
     fn open_window_when_tiled_window_is_maximized_unmaximizes_and_shows_both() {
         use crate::layout::{LayoutNode, TilingLayout};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4102,7 +4107,7 @@ mod tests {
         use crate::layout::{LayoutNode, TilingLayout};
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4177,7 +4182,7 @@ mod tests {
     #[test]
     fn select_fallback_focus_handles_empty_ring_safely() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4199,7 +4204,7 @@ mod tests {
     fn minimize_and_restore_preserves_floating_rect() {
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4257,7 +4262,7 @@ mod tests {
     fn localize_event_converts_to_local_coords() {
         use crate::events::{MouseButton, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4304,7 +4309,7 @@ mod tests {
         use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4361,7 +4366,7 @@ mod tests {
         use crate::window::{FloatRect, FloatRectSpec};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4466,7 +4471,7 @@ mod tests {
     fn hit_test_uses_visible_bounds_for_floating_windows() {
         use crate::window::{FloatRect, FloatRectSpec};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4508,7 +4513,7 @@ mod tests {
     fn hover_targets_respects_occlusion() {
         use crate::layout::tiling::SplitHandle;
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4566,7 +4571,7 @@ mod tests {
     fn drag_hitbox_detaches_to_floating() {
         use crate::events::{Event, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4665,7 +4670,7 @@ mod tests {
         use crate::window::{FloatRect, FloatRectSpec};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4745,7 +4750,7 @@ mod tests {
         use crate::window::{FloatRect, FloatRectSpec};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4919,7 +4924,7 @@ mod tests {
     fn adjust_event_rebases_app_mouse_coordinates() {
         use crate::events::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -4960,7 +4965,7 @@ mod tests {
     fn hover_scroll_routes_to_non_focused_window() {
         use crate::events::{Event, KeyModifiers, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5007,7 +5012,7 @@ mod tests {
     fn hover_scroll_over_focused_window_routes_normally() {
         use crate::events::{Event, KeyModifiers, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5050,7 +5055,7 @@ mod tests {
     fn hover_scroll_outside_all_windows_routes_to_focused() {
         use crate::events::{Event, KeyModifiers, MouseEvent, MouseEventKind};
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5092,7 +5097,7 @@ mod tests {
     #[test]
     fn direct_mode_defaults_to_false() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5106,7 +5111,7 @@ mod tests {
     #[test]
     fn direct_mode_is_per_window() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5121,8 +5126,10 @@ mod tests {
 
     #[test]
     fn drag_snap_timeout_none_disables_remaining() {
-        let mut config = WmConfig::standalone();
-        config.drag_snap_timeout = None;
+        let config = WmConfig {
+            drag_snap_timeout: None,
+            ..Default::default()
+        };
         let mut wm = WindowManager::<TestComponent>::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -5137,7 +5144,7 @@ mod tests {
     #[test]
     fn drag_snap_remaining_none_when_no_drag() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5150,7 +5157,7 @@ mod tests {
     #[test]
     fn drag_snap_remaining_returns_some_when_dragging() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5181,7 +5188,7 @@ mod tests {
     #[test]
     fn drag_snap_remaining_zero_when_expired() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5204,7 +5211,7 @@ mod tests {
             snap_applied: false,
         });
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5233,7 +5240,7 @@ mod tests {
     #[test]
     fn apply_drag_snap_if_pending_no_drag_is_noop() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5248,8 +5255,10 @@ mod tests {
         use crate::layout::InsertPosition;
         use crate::window::{FloatRect, FloatRectSpec};
 
-        let mut config = WmConfig::standalone();
-        config.drag_snap_timeout = Some(SHORT_SNAP_TIMEOUT);
+        let config = WmConfig {
+            drag_snap_timeout: Some(SHORT_SNAP_TIMEOUT),
+            ..Default::default()
+        };
         let mut wm = WindowManager::<TestComponent>::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -5330,7 +5339,7 @@ mod tests {
     #[test]
     fn power_profile_change_updates_value() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5350,7 +5359,7 @@ mod tests {
         use crate::layout::{LayoutNode, TilingLayout};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5393,7 +5402,7 @@ mod tests {
         use crate::window::FloatRectSpec;
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5507,7 +5516,7 @@ mod tests {
         use crate::layout::{LayoutNode, TilingLayout};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5546,7 +5555,7 @@ mod tests {
     #[test]
     fn drag_last_event_updated_on_drag_events() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5663,7 +5672,7 @@ mod tests {
     #[test]
     fn transition_window_realized_to_mapped() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5693,7 +5702,7 @@ mod tests {
     #[test]
     fn transition_window_mapped_to_iconic_retains_z_order() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5720,7 +5729,7 @@ mod tests {
     #[test]
     fn transition_window_iconic_to_mapped_restores_z_order() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5748,7 +5757,7 @@ mod tests {
         use crate::window::{FloatRect, FloatRectSpec};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5821,7 +5830,7 @@ mod tests {
     #[test]
     fn transition_window_mapped_to_unmapped_cleans_up() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5863,7 +5872,7 @@ mod tests {
     #[test]
     fn close_window_cleans_up_layout_and_state() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5895,7 +5904,7 @@ mod tests {
     #[test]
     fn close_window_removes_all_windows_from_slotmap() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5921,7 +5930,7 @@ mod tests {
     #[test]
     fn close_window_unmap_policy_preserves_slotmap_entry() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5949,12 +5958,119 @@ mod tests {
         );
     }
 
+    #[test]
+    fn close_window_ignored_for_non_closable_window() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let key = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.set_closable(key, false);
+        wm.transition_window(key, WindowState::Mapped);
+        wm.register_managed_layout(Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+
+        wm.close_window(key);
+        assert!(
+            wm.has_window(key),
+            "non-closable window must survive close_window"
+        );
+        assert_eq!(
+            wm.window_state(key),
+            Some(WindowState::Mapped),
+            "non-closable window must stay mapped"
+        );
+    }
+
+    #[test]
+    fn set_closable_toggles() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let key = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        assert!(wm.is_closable(key), "windows are closable by default");
+        wm.set_closable(key, false);
+        assert!(
+            !wm.is_closable(key),
+            "set_closable(false) marks non-closable"
+        );
+        wm.set_closable(key, true);
+        assert!(wm.is_closable(key), "set_closable(true) re-enables closing");
+    }
+
+    #[test]
+    fn window_management_buttons_hides_close_for_non_closable() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let key = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(key, WindowState::Mapped);
+        wm.focus_window_key(key);
+
+        wm.set_closable(key, false);
+        let buttons = wm.window_management_buttons();
+        assert!(
+            !buttons
+                .iter()
+                .any(|b| matches!(b.action, TermWmAction::CloseWindow(k) if k == key)),
+            "non-closable window must not expose a Close button"
+        );
+    }
+
+    #[test]
+    fn wm_menu_items_disables_close_for_non_closable() {
+        use crate::components::{MenuDisplayItem, MenuItem};
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let key = wm.create_window(TestComponent::Noop(crate::components::NoopComponent));
+        wm.transition_window(key, WindowState::Mapped);
+        wm.focus_window_key(key);
+        wm.set_window_title(key, "pinned");
+        wm.set_closable(key, false);
+
+        let items = wm.wm_menu_items();
+        let close_entry = items.iter().find(|entry| match entry {
+            MenuDisplayItem::Item(MenuItem { action, .. }) => {
+                matches!(action, TermWmAction::CloseWindow(k) if *k == key)
+            }
+            MenuDisplayItem::Separator => false,
+        });
+        let MenuDisplayItem::Item(MenuItem { disabled, .. }) = close_entry.expect("Close entry")
+        else {
+            unreachable!("Close entry is an Item");
+        };
+        assert!(
+            *disabled,
+            "Close menu entry must be disabled for non-closable window"
+        );
+    }
+
     // ── shade_window / unshade_window ─────────────────────────────────
 
     #[test]
     fn shade_and_unshade_window() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -5993,7 +6109,7 @@ mod tests {
     #[test]
     fn shade_is_idempotent() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6015,7 +6131,7 @@ mod tests {
     #[test]
     fn dispatch_focused_event_routes_mouse_to_selection_component() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6066,7 +6182,7 @@ mod tests {
     #[test]
     fn phase4_down_dispatches_mouse_action_to_update() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6129,7 +6245,7 @@ mod tests {
     #[test]
     fn phase3_moved_dispatches_mouse_action_to_update() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6192,7 +6308,7 @@ mod tests {
     /// Returns (wm, keys, gap_col, gap_row) where gap is the center of the split handle.
     fn setup_tiling_with_gap() -> (WindowManager<TestComponent>, Vec<WindowKey>, u16, u16) {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::app_context::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6400,7 +6516,7 @@ mod tests {
     #[test]
     fn register_layout_handle_hitboxes_registers_entries() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::app_context::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6449,7 +6565,7 @@ mod tests {
         use crate::layout::{LayoutNode, TilingLayout};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6500,7 +6616,7 @@ mod tests {
         use crate::layout::{LayoutNode, TilingLayout};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6580,7 +6696,7 @@ mod tests {
         impl WmCmp for ConsumeLayer {}
 
         let mut wm = WindowManager::<TestComponent, ConsumeLayer>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             layer_manager::LayerManager::<ConsumeLayer>::new(),
@@ -6632,7 +6748,7 @@ mod tests {
     #[test]
     fn overlay_close_exit_confirm_removes_overlay() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6649,7 +6765,7 @@ mod tests {
     #[test]
     fn overlay_help_visible_and_close() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6666,7 +6782,7 @@ mod tests {
     #[test]
     fn handle_exit_confirm_event_returns_none_without_overlay() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6686,7 +6802,7 @@ mod tests {
         use crate::window::{FloatRect, FloatRectSpec};
 
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6774,7 +6890,7 @@ mod tests {
     #[test]
     fn take_alternate_screen_transition_no_component() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6788,7 +6904,7 @@ mod tests {
     #[test]
     fn take_alternate_screen_transition_delegates() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6805,7 +6921,7 @@ mod tests {
     #[test]
     fn handle_outside_click_empty_registry_returns_false() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6825,7 +6941,7 @@ mod tests {
     #[test]
     fn handle_outside_click_window_hitbox_focuses_window() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6856,7 +6972,7 @@ mod tests {
     #[test]
     fn handle_outside_click_chrome_hitbox_focuses_window() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6889,7 +7005,7 @@ mod tests {
     #[test]
     fn handle_outside_click_layer_no_component_returns_false() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6920,7 +7036,7 @@ mod tests {
     #[test]
     fn handle_outside_click_layer_consumed_returns_true() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6962,7 +7078,7 @@ mod tests {
     #[test]
     fn handle_outside_click_overlay_ignored_by_key() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -6994,7 +7110,7 @@ mod tests {
     #[test]
     fn handle_outside_click_chrome_non_window_skipped() {
         let mut wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -7042,7 +7158,7 @@ mod tests {
     #[test]
     fn help_key_returns_none_initially() {
         let wm = WindowManager::<TestComponent>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -7056,7 +7172,7 @@ mod tests {
     #[test]
     fn help_overlay_bounds_returns_none_when_no_key() {
         let wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -7068,7 +7184,7 @@ mod tests {
     #[test]
     fn help_overlay_bounds_delegates_to_overlay_render_area() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -7091,7 +7207,7 @@ mod tests {
     fn handle_outside_click_layer_action_queued() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent,
             crate::components::NoopOverlay>::with_config(
-            WmConfig::standalone(), Arc::new(AppContext::new("test", "0.0.0")),
+            WmConfig::default(), Arc::new(AppContext::new("test", "0.0.0")),
             None, crate::window::LayerManager::new(),
             std::collections::HashMap::new(),
         );
@@ -7124,7 +7240,7 @@ mod tests {
     #[test]
     fn handle_outside_click_overlay_not_ignored_routes_event() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -7166,7 +7282,7 @@ mod tests {
     fn handle_outside_click_priority_layer_over_window() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent,
             crate::components::NoopOverlay>::with_config(
-            WmConfig::standalone(), Arc::new(AppContext::new("test", "0.0.0")),
+            WmConfig::default(), Arc::new(AppContext::new("test", "0.0.0")),
             None, crate::window::LayerManager::new(),
             std::collections::HashMap::new(),
         );
@@ -7212,7 +7328,7 @@ mod tests {
     #[test]
     fn handle_outside_click_stacked_overlay_ignores_stale() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
-            WmConfig::standalone(),
+            WmConfig::default(),
             Arc::new(AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),
@@ -7290,7 +7406,7 @@ mod tests {
     #[test]
     fn hovered_tiling_handle_obscured_by_any_overlay() {
         let mut wm = WindowManager::<TestComponent, NoopWmComponent, TestOverlay>::with_config(
-            crate::wm_config::WmConfig::standalone(),
+            crate::wm_config::WmConfig::default(),
             std::sync::Arc::new(crate::app_context::AppContext::new("test", "0.0.0")),
             None,
             crate::window::LayerManager::new(),

--- a/crates/term-wm-core/src/wm_config.rs
+++ b/crates/term-wm-core/src/wm_config.rs
@@ -59,8 +59,9 @@ pub fn validate_keybindings(kb: &KeyBindings) -> KeyBindings {
 
 /// Configuration for a `WindowManager`.
 ///
-/// Each feature flag is independently toggleable. Preset constructors
-/// (`standalone`, `minimal`) provide sensible defaults for common use cases.
+/// Each feature flag is independently toggleable. `WmConfig::default()` returns
+/// the full-featured configuration that `AppBuilder::new()` starts from: chrome,
+/// floating windows, panels, and the WM command menu are all enabled.
 ///
 /// Fields marked "initial" set the starting value for a runtime-toggleable
 /// feature — changes made at runtime apply immediately.
@@ -110,16 +111,10 @@ pub struct WmConfig {
 }
 
 impl Default for WmConfig {
+    /// Return the full-featured default configuration: chrome, floating
+    /// windows, panels, and the WM command menu are all enabled, along with
+    /// clipboard, selection, mouse capture, and keyboard/mouse focus.
     fn default() -> Self {
-        Self::standalone()
-    }
-}
-
-impl WmConfig {
-    /// Full standalone window manager preset.
-    ///
-    /// Chrome, floating windows, panel, and WM command menu are all enabled.
-    pub fn standalone() -> Self {
         Self {
             chrome_enabled: true,
             floating_windows_enabled: true,
@@ -133,38 +128,16 @@ impl WmConfig {
             mouse_capture_enabled: true,
             keyboard_focus_enabled: true,
             mouse_focus_click_enabled: true,
-            keybindings: validate_keybindings(&KeyBindings::standalone()),
+            keybindings: validate_keybindings(&KeyBindings::default()),
             hint_visibility: HintVisibility::Always,
             menu_outline_timeout: Duration::from_millis(500),
             drag_snap_timeout: Some(Duration::from_millis(2000)),
             theme: NOIR,
         }
     }
+}
 
-    /// Minimal preset: no chrome, no floating windows, no command menu.
-    /// Bottom keybinding hints are rendered by the panel in inactive mode.
-    pub fn minimal() -> Self {
-        Self {
-            chrome_enabled: false,
-            floating_windows_enabled: false,
-            panels_enabled: false,
-            wm_command_menu_enabled: false,
-            super_passthrough_window: super_passthrough_window_default(),
-            floating_resize_offscreen: false,
-            shadow_enabled: false,
-            clipboard_enabled: true,
-            window_selection_enabled: true,
-            mouse_capture_enabled: true,
-            keyboard_focus_enabled: true,
-            mouse_focus_click_enabled: true,
-            keybindings: validate_keybindings(&KeyBindings::minimal()),
-            hint_visibility: HintVisibility::Always,
-            menu_outline_timeout: Duration::ZERO,
-            drag_snap_timeout: None,
-            theme: NOIR,
-        }
-    }
-
+impl WmConfig {
     pub fn panel_active(&self) -> bool {
         self.panels_enabled
     }

--- a/crates/term-wm-sys-ui-components/src/wm_bottom_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_bottom_panel.rs
@@ -686,4 +686,69 @@ mod tests {
         assert!(rendered.contains("2.0.0"));
         assert!(rendered.contains("my-host"));
     }
+
+    #[test]
+    fn render_overlays_does_not_clobber_command_palette_hints_in_monocle() {
+        use std::sync::Arc;
+
+        use term_wm_console::draw_plan_renderer::render_overlays;
+        use term_wm_core::app_context::AppContext;
+        use term_wm_core::components::NoopComponent;
+        use term_wm_core::components::NoopOverlay;
+        use term_wm_core::config::AppBuilder;
+        use term_wm_core::window::ComponentTag;
+
+        let app_ctx = Arc::new(AppContext::new("test", "0.1.0"));
+        let mut wm = AppBuilder::<WmBottomPanelComponent>::new()
+            .app_ctx(Arc::clone(&app_ctx))
+            .bottom_panel(WmBottomPanelComponent::new(
+                "test",
+                "0.1.0",
+                Some("test-host"),
+            ))
+            .build::<NoopComponent, NoopOverlay>()
+            .expect("test build");
+
+        // Enter cramped monocle (default Auto + narrow viewport) and open the
+        // command palette, which sets input_mode = CommandPalette.
+        wm.update_monocle_mode(40);
+        assert!(wm.is_monocle_cramped(), "test must run in cramped monocle");
+        wm.open_command_palette_overlay(NoopOverlay);
+        assert!(wm.command_menu_visible());
+
+        let area = term_wm_core::Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 24,
+        };
+        wm.register_managed_layout(area);
+
+        let ratatui_area = ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 24,
+        };
+        let buf = Buffer::empty(ratatui_area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area);
+        render_overlays(&mut backend, &mut wm);
+
+        // The render pass must NOT have replaced the layout-phase (filtered)
+        // hints. With the palette open, Global actions like OpenCommandPalette
+        // must be absent and CommandPalette-layer actions present.
+        let hints = wm
+            .get_semantic_component(ComponentTag::BottomPanel)
+            .map(|p| p.keybinding_hints().to_vec())
+            .expect("bottom panel present");
+        let actions: Vec<_> = hints.iter().map(|(a, _)| a.clone()).collect();
+        assert!(
+            !actions.contains(&TermWmAction::OpenCommandPalette),
+            "render_overlays must not clobber palette-filtered hints, got {actions:?}"
+        );
+        assert!(
+            actions.contains(&TermWmAction::FocusNext),
+            "palette-filtered hints must include a CommandPalette-layer action, got {actions:?}"
+        );
+    }
 }

--- a/crates/term-wm-ui-components/Cargo.toml
+++ b/crates/term-wm-ui-components/Cargo.toml
@@ -27,6 +27,7 @@ term-wm-render = { workspace = true }
 term-wm-vt100 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+unicode-width = { workspace = true }
 webbrowser = { workspace = true }
 
 [dev-dependencies]

--- a/crates/term-wm-ui-components/src/command_palette.rs
+++ b/crates/term-wm-ui-components/src/command_palette.rs
@@ -64,6 +64,7 @@ pub struct CommandPaletteComponent {
     nav_keys: KeyBindings,
     list_scroll: ScrollViewComponent<MenuComponent>,
     last_display_sel: usize,
+    last_viewport_rows: usize,
     last_list_area: LayoutRect,
 }
 
@@ -123,6 +124,7 @@ impl CommandPaletteComponent {
             nav_keys,
             list_scroll,
             last_display_sel: 0,
+            last_viewport_rows: 0,
             last_list_area: LayoutRect::default(),
         }
     }
@@ -571,24 +573,22 @@ impl Component<TermWmAction> for CommandPaletteComponent {
 
         // Set content height for ScrollViewComponent and auto-scroll to keep selected item visible
         let total = self.display_nodes.len();
+        let list_height = bounds.height.saturating_sub(1) as usize;
         let handle = self.list_scroll.scroll_handle();
         {
             let mut scroll = handle.scroll.borrow_mut();
             scroll.content_height = total;
-
-            // Only auto-scroll when the selection index changes (not on manual scroll)
-            if display_sel != self.last_display_sel {
-                let list_height = bounds.height.saturating_sub(1) as usize;
-                if list_height > 0 {
-                    if display_sel < scroll.offset_y {
-                        scroll.offset_y = display_sel;
-                    } else if display_sel >= scroll.offset_y.saturating_add(list_height) {
-                        scroll.offset_y = display_sel.saturating_sub(list_height).saturating_add(1);
-                    }
-                }
-            }
+            // Sync physical height (matches list_area.height passed to
+            // list_scroll.render below) so max_offset_y() is accurate even
+            // though this runs before the child ScrollViewComponent renders.
+            scroll.height = list_height;
         }
-        self.last_display_sel = display_sel;
+        handle.ensure_selection_visible(
+            display_sel,
+            list_height,
+            &mut self.last_display_sel,
+            &mut self.last_viewport_rows,
+        );
 
         // Clear background
         let menu_style = Style::default()

--- a/crates/term-wm-ui-components/src/helpers.rs
+++ b/crates/term-wm-ui-components/src/helpers.rs
@@ -2,6 +2,53 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use term_wm_layout_engine::LayoutRect;
+use unicode_width::UnicodeWidthChar;
+
+/// Slice a string by visual columns, padding boundary-crossing wide chars with
+/// spaces so the output stays column-aligned within a horizontally-scrolled
+/// viewport. Zero-width (combining) characters are kept when their base column
+/// falls inside the visible range.
+pub fn slice_by_columns(s: &str, start_col: usize, width: usize) -> String {
+    let mut out = String::new();
+    let mut current_col = 0usize;
+    let end_col = start_col.saturating_add(width);
+
+    for c in s.chars() {
+        let cw = c.width().unwrap_or(0);
+
+        if cw == 0 {
+            if current_col > start_col && current_col <= end_col {
+                out.push(c); // combining mark / zero-width: keep if inside
+            }
+            continue;
+        }
+
+        let next_col = current_col + cw;
+
+        if next_col <= start_col {
+            // Entirely before the viewport — skip.
+        } else if current_col < start_col {
+            // Crosses the left boundary — pad the visible remainder with spaces.
+            let visible = next_col - start_col;
+            let take = visible.min(width);
+            out.push_str(&" ".repeat(take));
+        } else if current_col < end_col {
+            if next_col <= end_col {
+                // Fully inside the viewport.
+                out.push(c);
+            } else {
+                // Crosses the right boundary — pad the visible fraction.
+                let visible = end_col - current_col;
+                out.push_str(&" ".repeat(visible));
+            }
+        } else {
+            // Entirely after the viewport.
+            break;
+        }
+        current_col = next_col;
+    }
+    out
+}
 
 /// Safely converts a signed LayoutRect into an unsigned Ratatui Rect for rendering.
 /// If the LayoutRect is partially off-screen (negative x/y), it crops the

--- a/crates/term-wm-ui-components/src/list.rs
+++ b/crates/term-wm-ui-components/src/list.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
 
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, Borders, List, ListItem};
+use ratatui::widgets::{List, ListItem};
 use term_wm_core::events::{Event, KeyModifiers, MouseButton};
 
-use crate::helpers::{color_to_ratatui, layout_rect_to_clipped_rect};
+use crate::helpers::{layout_rect_to_clipped_rect, slice_by_columns};
 use ratatui::widgets::Widget;
 use term_wm_core::actions::{EventResult, TermWmAction};
 use term_wm_core::components::{Component, ComponentContext};
@@ -15,6 +15,8 @@ pub struct ListComponent {
     items: Vec<String>,
     selected: usize,
     title: String,
+    last_selected: usize,
+    last_viewport_rows: usize,
 }
 
 impl Component<TermWmAction> for ListComponent {
@@ -27,55 +29,42 @@ impl Component<TermWmAction> for ListComponent {
     ) {
         let area = layout_rect_to_clipped_rect(area);
         let backend = crate::helpers::downcast_ratatui(backend);
-        let block = if ctx.focused() {
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!("{} (focus)", self.title))
-                .border_style(Style::default().fg(color_to_ratatui(ctx.config().theme.success)))
-        } else {
-            Block::default()
-                .borders(Borders::ALL)
-                .title(self.title.as_str())
-        };
-        let inner = block.inner(area);
-        block.render(area, &mut backend.buffer);
-
-        if inner.width == 0 || inner.height == 0 {
+        if area.width == 0 || area.height == 0 {
             return;
         }
+        let inner = area;
 
         let total_height = self.items.len();
         let max_width = self.items.iter().map(|s| s.len()).max().unwrap_or(0);
 
-        // Report content size including the border rows/cols so the scrollbar can
-        // reach the last item while the list is rendered inside the border.
+        // Report content size so the scrollbars can reach the last item / column.
         if let Some(handle) = ctx.scroll_handle() {
-            handle.set_content_size(max_width + 2, total_height + 2);
-            // Ensure selection is visible within our logic
-            // Map item index `selected` to virtual coordinate `selected + 1` (skip top border).
-            handle.ensure_vertical_visible(self.selected + 1, self.selected + 2);
+            handle.set_content_size(max_width, total_height);
+            // Keep the selected item visible while preserving manual scroll.
+            let viewport_rows = inner.height as usize;
+            handle.ensure_selection_visible(
+                self.selected,
+                viewport_rows,
+                &mut self.last_selected,
+                &mut self.last_viewport_rows,
+            );
         }
 
         let vp = ctx.viewport();
-        // Viewport offsets include the top border, so item 0 starts at virtual row 1.
-        // Skip rows before that when building the visible slice.
-
-        let skip_n = vp.offset_y.saturating_sub(1);
+        let skip_n = vp.offset_y;
         let items_iter = self.items.iter().enumerate().skip(skip_n);
 
         let list_items: Vec<ListItem> = items_iter
             .take(inner.height as usize)
             .map(|(i, s)| {
-                let mut item = ListItem::new(s.clone());
+                let mut item =
+                    ListItem::new(slice_by_columns(s, vp.offset_x, inner.width as usize));
                 if i == self.selected {
                     item = item.style(Style::default().add_modifier(Modifier::REVERSED));
                 }
                 item
             })
             .collect();
-
-        // When rendering using Ratatui List, it renders items from top of `inner`.
-        // This matches our expectation if `list_items` starts with the first visible item.
 
         let list = List::new(list_items);
         list.render(inner, &mut backend.buffer);
@@ -91,8 +80,8 @@ impl Component<TermWmAction> for ListComponent {
     ) -> EventResult<TermWmAction> {
         if button == MouseButton::Left && ctx.focused() && !self.items.is_empty() {
             let vp = ctx.viewport();
-            let skip_n = vp.offset_y.saturating_sub(1);
-            let visible_row = local_y.saturating_sub(1) as usize;
+            let skip_n = vp.offset_y;
+            let visible_row = local_y as usize;
             let index = skip_n + visible_row;
             if index < self.items.len() {
                 self.selected = index;
@@ -150,12 +139,28 @@ impl ListComponent {
             items: Vec::new(),
             selected: 0,
             title: title.into(),
+            last_selected: 0,
+            last_viewport_rows: 0,
         }
     }
 
     pub fn set_items(&mut self, items: Vec<String>) {
         self.items = items;
         self.selected = 0;
+        self.last_selected = 0;
+        self.last_viewport_rows = 0;
+    }
+
+    /// Replace the items in place WITHOUT resetting the selection or the
+    /// scroll-follow guard. For periodic live-refresh of an existing list
+    /// (e.g. argtuner's trials poll) so a manual scroll is preserved.
+    pub fn update_items(&mut self, items: Vec<String>) {
+        self.items = items;
+        if self.selected >= self.items.len() {
+            self.selected = self.items.len().saturating_sub(1);
+        }
+        // last_selected / last_viewport_rows intentionally untouched: the list
+        // identity is unchanged, so the guard holds and manual scroll persists.
     }
 
     pub fn add_item(&mut self, item: String) {
@@ -186,15 +191,23 @@ impl ListComponent {
         let next = (self.selected as isize + delta).clamp(0, max as isize) as usize;
         self.selected = next;
     }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::collections::VecDeque;
+    use std::rc::Rc;
     use term_wm_core::actions::EventResult;
+    use term_wm_core::component_context::{ScrollBounds, ScrollHandle};
     use term_wm_core::components::Component;
     use term_wm_core::events::{Event, KeyCode, KeyEvent, KeyKind, KeyModifiers};
+    use unicode_width::UnicodeWidthStr;
 
     fn key_event(code: KeyCode) -> Event {
         Event::Key(KeyEvent::new(code, KeyModifiers::NONE, KeyKind::Press))
@@ -272,6 +285,271 @@ mod tests {
         assert_eq!(list.selected(), 1);
         list.set_items(vec!["x".into()]);
         assert_eq!(list.selected(), 0);
+    }
+
+    fn scroll_ctx() -> (ComponentContext, ScrollHandle) {
+        let handle = ScrollHandle {
+            scroll: Rc::new(RefCell::new(ScrollBounds::default())),
+        };
+        let info = handle.info();
+        let ctx = ComponentContext::new(true).with_viewport(info, Some(handle.clone()));
+        (ctx, handle)
+    }
+
+    fn render_list_with_scroll(list: &mut ListComponent, area: LayoutRect, ctx: &ComponentContext) {
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::prelude::Rect {
+            x: area.x as u16,
+            y: area.y as u16,
+            width: area.width,
+            height: area.height,
+        });
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::prelude::Rect {
+                x: area.x as u16,
+                y: area.y as u16,
+                width: area.width,
+                height: area.height,
+            },
+        );
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        list.render(&mut backend, area, ctx, &mut registry);
+    }
+
+    #[test]
+    fn scroll_follow_starts_at_offset_zero() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert_eq!(handle.scroll.borrow().offset_y, 0);
+    }
+
+    #[test]
+    fn scroll_follow_advances_when_selection_moves_past_viewport() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        // Move selection below the visible area: viewport_rows = 10 (full area height).
+        for _ in 0..12 {
+            dispatch(&mut list, &key_event(KeyCode::Down), &ctx);
+        }
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert!(
+            handle.scroll.borrow().offset_y > 0,
+            "offset should advance to keep selection visible"
+        );
+        // Selected row must be within [offset, offset + viewport_rows).
+        let offset = handle.scroll.borrow().offset_y;
+        let selected_row = list.selected();
+        assert!(
+            selected_row >= offset && selected_row < offset + 10,
+            "selected row {} must be visible in [{}..{})",
+            selected_row,
+            offset,
+            offset + 10
+        );
+    }
+
+    #[test]
+    fn scroll_follow_goes_back_when_selection_moves_up() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        for _ in 0..18 {
+            dispatch(&mut list, &key_event(KeyCode::Down), &ctx);
+        }
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert!(handle.scroll.borrow().offset_y > 0);
+
+        for _ in 0..18 {
+            dispatch(&mut list, &key_event(KeyCode::Up), &ctx);
+        }
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        // Item 0 is at content row 0 (borderless), so the scroll-back target is 0.
+        assert_eq!(
+            handle.scroll.borrow().offset_y,
+            0,
+            "offset should reset to top when selection moves to top (got {})",
+            handle.scroll.borrow().offset_y
+        );
+    }
+
+    #[test]
+    fn scroll_follow_does_not_override_manual_scroll() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        // Manual scroll away (mouse), selection unchanged.
+        handle.scroll.borrow_mut().offset_y = 6;
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert_eq!(
+            handle.scroll.borrow().offset_y,
+            6,
+            "manual scroll should be preserved when selection unchanged"
+        );
+    }
+
+    #[test]
+    fn scroll_follow_reengages_after_manual_scroll_when_selection_changes() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        handle.scroll.borrow_mut().offset_y = 6;
+        dispatch(&mut list, &key_event(KeyCode::Down), &ctx);
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        let offset = handle.scroll.borrow().offset_y;
+        assert!(
+            offset > 0,
+            "auto-scroll should engage again after selection changes"
+        );
+    }
+
+    #[test]
+    fn scroll_follow_reruns_on_viewport_shrink() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        for _ in 0..15 {
+            dispatch(&mut list, &key_event(KeyCode::Down), &ctx);
+        }
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        // Shrink the viewport: same selection, smaller viewport_rows -> re-follow.
+        let before = handle.scroll.borrow().offset_y;
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 4,
+            },
+            &ctx,
+        );
+        let after = handle.scroll.borrow().offset_y;
+        assert!(
+            after >= before,
+            "offset should not move backward on viewport shrink with selection unchanged"
+        );
     }
 
     #[test]
@@ -394,7 +672,7 @@ mod tests {
         let ctx = ComponentContext::new(true);
         let result = list.on_mouse_press(
             5,
-            2,
+            1,
             term_wm_core::events::MouseButton::Left,
             term_wm_core::events::KeyModifiers::NONE,
             &ctx,
@@ -447,5 +725,186 @@ mod tests {
         list.update(TermWmAction::ScrollPageUp, &ctx, &mut actions);
         list.update(TermWmAction::ScrollPageDown, &ctx, &mut actions);
         list.update(TermWmAction::ScrollHome, &ctx, &mut actions);
+    }
+
+    #[test]
+    fn set_items_resets_guard_fields() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        list.move_selection(5);
+        let (ctx, _handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert_eq!(list.selected(), 5);
+
+        list.set_items(vec!["new".into()]);
+        assert_eq!(list.selected(), 0);
+        assert_eq!(list.last_selected, 0);
+        assert_eq!(list.last_viewport_rows, 0);
+    }
+
+    #[test]
+    fn update_items_preserves_selection_and_scroll() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        let (ctx, handle) = scroll_ctx();
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+
+        list.move_selection(5);
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        handle.scroll.borrow_mut().offset_y = 6;
+        let last_selected = list.last_selected;
+        let last_viewport_rows = list.last_viewport_rows;
+
+        list.update_items((10..20).map(|i| format!("{}", i)).collect());
+        assert_eq!(
+            list.selected(),
+            5,
+            "selection preserved across update_items"
+        );
+        assert_eq!(list.last_selected, last_selected, "guard field preserved");
+        assert_eq!(
+            list.last_viewport_rows, last_viewport_rows,
+            "guard field preserved"
+        );
+
+        render_list_with_scroll(
+            &mut list,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert_eq!(
+            handle.scroll.borrow().offset_y,
+            6,
+            "manual scroll preserved after update_items"
+        );
+    }
+
+    #[test]
+    fn update_items_clamps_out_of_range_selection() {
+        let mut list = ListComponent::new("t");
+        list.set_items((0..20).map(|i| format!("{}", i)).collect());
+        list.move_selection(18);
+        assert_eq!(list.selected(), 18);
+        list.update_items((0..5).map(|i| format!("{}", i)).collect());
+        assert_eq!(list.selected(), 4);
+    }
+
+    #[test]
+    fn slice_by_columns_pads_boundary_wide_chars() {
+        // '界' is a 2-column CJK char. Column layout of "a界b": a(0), 界(1-2), b(3).
+        let s = "a界b";
+        // Full viewport keeps everything.
+        assert_eq!(slice_by_columns(s, 0, 4), "a界b");
+        // start_col=1: '界' starts exactly at the viewport -> fully inside.
+        assert_eq!(slice_by_columns(s, 1, 3), "界b");
+        // start_col=2: '界' (cols 1-2) straddles the left edge -> pad its visible
+        // 1 column, then 'b'.
+        assert_eq!(slice_by_columns(s, 2, 3), " b");
+        // width=1 at col 1: '界' straddles the right edge -> pad 1 column.
+        assert_eq!(slice_by_columns(s, 1, 1), " ");
+        // width=1 at col 0: only 'a' fits; '界' entirely after -> stop.
+        assert_eq!(slice_by_columns(s, 0, 1), "a");
+        // Right-edge straddle producing trailing padding: "a界" cols a(0), 界(1-2).
+        assert_eq!(slice_by_columns("a界", 0, 2), "a ");
+        // Output never exceeds `width` columns and stays aligned (leading/trailing
+        // space pads a truncated wide char). Shorter sources simply don't fill.
+        for (start, width) in [(0usize, 4usize), (1, 3), (1, 1), (0, 1), (2, 2)] {
+            assert!(
+                slice_by_columns(s, start, width).width() <= width,
+                "slice_by_columns({start},{width}) must not exceed {width} columns"
+            );
+        }
+    }
+
+    #[test]
+    fn horizontal_scroll_slices_columns() {
+        let mut list = ListComponent::new("t");
+        list.set_items(vec!["aa界bb".into()]);
+        let (ctx0, handle) = scroll_ctx();
+        // Force a horizontal viewport offset of 2 columns.
+        handle.scroll.borrow_mut().offset_x = 2;
+        // Refresh the ctx viewport snapshot from the live scroll state.
+        let ctx = ctx0.with_viewport(handle.info(), Some(handle));
+        let area = LayoutRect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 3,
+        };
+        let buffer = ratatui::buffer::Buffer::empty(ratatui::prelude::Rect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 3,
+        });
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            ratatui::prelude::Rect {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 3,
+            },
+        );
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        list.render(&mut backend, area, &ctx, &mut registry);
+
+        // Row 0 should start at column offset 2 of "aa界bb".
+        // "aa界bb" columns: a(0) a(1) 界(2-3) b(4) b(5).
+        // Slice [2..12) -> 界(2-3) b b -> cells: 界, (cont), b, b, ...
+        // The middle slot is the wide-char continuation cell, so check cells
+        // individually rather than joined text.
+        assert_eq!(
+            backend.buffer.cell((0, 0)).map(|c| c.symbol().to_string()),
+            Some("界".into()),
+            "first cell should be the wide char at the slice start"
+        );
+        assert_eq!(
+            backend.buffer.cell((2, 0)).map(|c| c.symbol().to_string()),
+            Some("b".into()),
+            "second visible char should be 'b' after the wide char"
+        );
+        assert_eq!(
+            backend.buffer.cell((3, 0)).map(|c| c.symbol().to_string()),
+            Some("b".into()),
+            "third visible char should be 'b'"
+        );
+        assert_eq!(
+            backend.buffer.cell((0, 1)).map(|c| c.symbol().to_string()),
+            Some(" ".into()),
+            "row 1 must not have been shifted by the offset"
+        );
     }
 }

--- a/crates/term-wm-ui-components/src/scroll_view.rs
+++ b/crates/term-wm-ui-components/src/scroll_view.rs
@@ -20,6 +20,10 @@ use term_wm_layout_engine::LayoutRect;
 /// Minimum scrollbar thumb size in cells.
 const MIN_THUMB_SIZE: i32 = 1;
 
+/// Thumb glyph for horizontal scrollbars (lower half block). Grounds the
+/// thumb to the bottom edge of the row, keeping the track visible above it.
+const HORIZONTAL_SCROLLBAR_THUMB: &str = "▄";
+
 // --- Scroll Logic Helpers (Public API) ---
 
 #[derive(Debug, Default, Clone)]
@@ -165,7 +169,12 @@ pub fn render_scrollbar_oriented(
     let mut state = ScrollbarState::new(content_len)
         .position(offset.min(content_len.saturating_sub(1)))
         .viewport_content_length(view.max(1));
-    let scrollbar = Scrollbar::new(orientation);
+    let scrollbar = match orientation {
+        ScrollbarOrientation::HorizontalBottom | ScrollbarOrientation::HorizontalTop => {
+            Scrollbar::new(orientation).thumb_symbol(HORIZONTAL_SCROLLBAR_THUMB)
+        }
+        _ => Scrollbar::new(orientation),
+    };
     scrollbar.render(area, buffer, &mut state);
 }
 
@@ -683,6 +692,50 @@ mod tests {
             .saturating_add(1)
             .saturating_sub(1);
         assert!(bottom <= max_offset);
+    }
+
+    #[test]
+    fn horizontal_scrollbar_uses_bottom_half_block_thumb() {
+        let area = ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 1,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        let total = 100usize;
+        let view = 10usize;
+        // Position so the thumb sits near the start of the track.
+        render_scrollbar_oriented(
+            &mut buf,
+            area,
+            total,
+            view,
+            0,
+            ScrollbarOrientation::HorizontalBottom,
+        );
+
+        let mut thumb_cols = Vec::new();
+        let mut track_cols = Vec::new();
+        for col in area.x..area.x + area.width {
+            if let Some(cell) = buf.cell((col, area.y)) {
+                match cell.symbol() {
+                    "▄" => thumb_cols.push(col),
+                    "═" => track_cols.push(col),
+                    _ => {}
+                }
+            }
+        }
+        assert!(
+            !thumb_cols.is_empty(),
+            "horizontal scrollbar should render a ▄ thumb, got: {:?}",
+            buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>()
+        );
+        assert!(
+            !track_cols.is_empty(),
+            "horizontal scrollbar should render a ═ track, got: {:?}",
+            buf.content.iter().map(|c| c.symbol()).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/term-wm-ui-components/src/terminal.rs
+++ b/crates/term-wm-ui-components/src/terminal.rs
@@ -1939,7 +1939,7 @@ mod tests {
             crate::scroll_view::ScrollViewComponent<TerminalComponent>,
             NoopWmComponent,
             NoopOverlay,
-        > = AppBuilder::<NoopWmComponent>::bare()
+        > = AppBuilder::<NoopWmComponent>::new()
             .app_ctx(Arc::new(AppContext::new("test", "0.0.0")))
             .build()
             .expect("test build");
@@ -2043,7 +2043,7 @@ mod tests {
             crate::scroll_view::ScrollViewComponent<TerminalComponent>,
             NoopWmComponent,
             NoopOverlay,
-        > = AppBuilder::<NoopWmComponent>::bare()
+        > = AppBuilder::<NoopWmComponent>::new()
             .app_ctx(Arc::new(AppContext::new("test", "0.0.0")))
             .build()
             .expect("test build");

--- a/crates/term-wm-ui-components/src/toggle_list.rs
+++ b/crates/term-wm-ui-components/src/toggle_list.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
 
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, Borders, List, ListItem};
+use ratatui::widgets::{List, ListItem};
 use term_wm_core::events::Event;
 
-use crate::helpers::{color_to_ratatui, layout_rect_to_clipped_rect};
+use crate::helpers::{layout_rect_to_clipped_rect, slice_by_columns};
 use ratatui::widgets::Widget;
 use term_wm_core::actions::{EventResult, TermWmAction};
 use term_wm_core::components::{Component, ComponentContext};
@@ -22,6 +22,8 @@ pub struct ToggleListComponent {
     items: Vec<ToggleItem>,
     selected: usize,
     title: String,
+    last_selected: usize,
+    last_viewport_rows: usize,
 }
 
 impl Component<TermWmAction> for ToggleListComponent {
@@ -34,33 +36,39 @@ impl Component<TermWmAction> for ToggleListComponent {
     ) {
         let area = layout_rect_to_clipped_rect(area);
         let backend = crate::helpers::downcast_ratatui(backend);
-        let block = if ctx.focused() {
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!("{} (focus)", self.title))
-                .border_style(Style::default().fg(color_to_ratatui(ctx.config().theme.success)))
-        } else {
-            Block::default()
-                .borders(Borders::ALL)
-                .title(self.title.as_str())
-        };
-        let inner = block.inner(area);
-        block.render(area, &mut backend.buffer);
-
-        if inner.width == 0 || inner.height == 0 {
+        if area.width == 0 || area.height == 0 {
             return;
         }
+        let inner = area;
 
         let total_count = self.items.len();
-        // Assuming single line items
+        let max_width = self
+            .items
+            .iter()
+            .map(|item| {
+                format!(
+                    "{} {}",
+                    if item.checked { "[x]" } else { "[ ]" },
+                    item.label
+                )
+                .len()
+            })
+            .max()
+            .unwrap_or(0);
         if let Some(handle) = ctx.scroll_handle() {
-            handle.set_content_size(inner.width as usize, total_count + 2);
-            handle.ensure_vertical_visible(self.selected + 1, self.selected + 2);
+            handle.set_content_size(max_width, total_count);
+            // Keep the selected item visible while preserving manual scroll.
+            let viewport_rows = inner.height as usize;
+            handle.ensure_selection_visible(
+                self.selected,
+                viewport_rows,
+                &mut self.last_selected,
+                &mut self.last_viewport_rows,
+            );
         }
 
         let vp = ctx.viewport();
-        // Similar logic to ListComponent
-        let skip_n = vp.offset_y.saturating_sub(1);
+        let skip_n = vp.offset_y;
 
         let items: Vec<ListItem> = self
             .items
@@ -70,7 +78,12 @@ impl Component<TermWmAction> for ToggleListComponent {
             .take(inner.height as usize)
             .map(|(i, item)| {
                 let marker = if item.checked { "[x]" } else { "[ ]" };
-                let mut li = ListItem::new(format!("{marker} {}", item.label));
+                let text = slice_by_columns(
+                    &format!("{marker} {}", item.label),
+                    vp.offset_x,
+                    inner.width as usize,
+                );
+                let mut li = ListItem::new(text);
                 if i == self.selected {
                     li = li.style(Style::default().add_modifier(Modifier::REVERSED));
                 }
@@ -146,6 +159,8 @@ impl ToggleListComponent {
             items: Vec::new(),
             selected: 0,
             title: title.into(),
+            last_selected: 0,
+            last_viewport_rows: 0,
         }
     }
 
@@ -154,6 +169,20 @@ impl ToggleListComponent {
         if self.selected >= self.items.len() {
             self.selected = self.items.len().saturating_sub(1);
         }
+        self.last_selected = 0;
+        self.last_viewport_rows = 0;
+    }
+
+    /// Replace the items in place WITHOUT resetting the selection or the
+    /// scroll-follow guard. For periodic live-refresh of an existing list so a
+    /// manual scroll is preserved.
+    pub fn update_items(&mut self, items: Vec<ToggleItem>) {
+        self.items = items;
+        if self.selected >= self.items.len() {
+            self.selected = self.items.len().saturating_sub(1);
+        }
+        // last_selected / last_viewport_rows intentionally untouched: the list
+        // identity is unchanged, so the guard holds and manual scroll persists.
     }
 
     pub fn items(&self) -> &[ToggleItem] {
@@ -166,6 +195,10 @@ impl ToggleListComponent {
 
     pub fn selected(&self) -> usize {
         self.selected
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
     }
 
     pub fn set_selected(&mut self, selected: usize) {
@@ -376,6 +409,226 @@ mod tests {
         assert_eq!(t.selected(), 4);
         t.set_items(make_items(2));
         assert_eq!(t.selected(), 1);
+    }
+
+    fn scroll_ctx() -> (
+        ComponentContext,
+        term_wm_core::component_context::ScrollHandle,
+    ) {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        let handle = term_wm_core::component_context::ScrollHandle {
+            scroll: Rc::new(RefCell::new(
+                term_wm_core::component_context::ScrollBounds::default(),
+            )),
+        };
+        let info = handle.info();
+        let ctx = ComponentContext::new(true).with_viewport(info, Some(handle.clone()));
+        (ctx, handle)
+    }
+
+    fn render_toggle_with_scroll(
+        t: &mut ToggleListComponent,
+        area: LayoutRect,
+        ctx: &ComponentContext,
+    ) {
+        let buffer = ratatui::buffer::Buffer::empty(Rect {
+            x: area.x as u16,
+            y: area.y as u16,
+            width: area.width,
+            height: area.height,
+        });
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(
+            buffer,
+            Rect {
+                x: area.x as u16,
+                y: area.y as u16,
+                width: area.width,
+                height: area.height,
+            },
+        );
+        let mut registry = term_wm_core::hitbox_registry::HitboxRegistry::new();
+        t.render(&mut backend, area, ctx, &mut registry);
+    }
+
+    #[test]
+    fn scroll_follow_starts_at_offset_zero() {
+        let mut t = ToggleListComponent::new("s");
+        t.set_items(make_items(20));
+        let (ctx, handle) = scroll_ctx();
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert_eq!(handle.scroll.borrow().offset_y, 0);
+    }
+
+    #[test]
+    fn scroll_follow_advances_when_selection_moves_past_viewport() {
+        let mut t = ToggleListComponent::new("s");
+        t.set_items(make_items(20));
+        let (ctx, handle) = scroll_ctx();
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        for _ in 0..12 {
+            t.move_selection(1);
+        }
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        let offset = handle.scroll.borrow().offset_y;
+        let selected_row = t.selected();
+        assert!(
+            selected_row >= offset && selected_row < offset + 10,
+            "selected row {} must be visible in [{}..{})",
+            selected_row,
+            offset,
+            offset + 10
+        );
+    }
+
+    #[test]
+    fn scroll_follow_goes_back_when_selection_moves_up() {
+        let mut t = ToggleListComponent::new("s");
+        t.set_items(make_items(20));
+        let (ctx, handle) = scroll_ctx();
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        for _ in 0..18 {
+            t.move_selection(1);
+        }
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert!(handle.scroll.borrow().offset_y > 0);
+        for _ in 0..18 {
+            t.move_selection(-1);
+        }
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        // Item 0 is at content row 0 (borderless), so the scroll-back target is 0.
+        assert_eq!(
+            handle.scroll.borrow().offset_y,
+            0,
+            "offset should reset to top when selection moves to top (got {})",
+            handle.scroll.borrow().offset_y
+        );
+    }
+
+    #[test]
+    fn scroll_follow_does_not_override_manual_scroll() {
+        let mut t = ToggleListComponent::new("s");
+        t.set_items(make_items(20));
+        let (ctx, handle) = scroll_ctx();
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        handle.scroll.borrow_mut().offset_y = 6;
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        assert_eq!(handle.scroll.borrow().offset_y, 6);
+    }
+
+    #[test]
+    fn scroll_follow_reruns_on_viewport_shrink() {
+        let mut t = ToggleListComponent::new("s");
+        t.set_items(make_items(20));
+        let (ctx, handle) = scroll_ctx();
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        for _ in 0..15 {
+            t.move_selection(1);
+        }
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 10,
+            },
+            &ctx,
+        );
+        let before = handle.scroll.borrow().offset_y;
+        render_toggle_with_scroll(
+            &mut t,
+            LayoutRect {
+                x: 0,
+                y: 0,
+                width: 40,
+                height: 4,
+            },
+            &ctx,
+        );
+        let after = handle.scroll.borrow().offset_y;
+        assert!(after >= before, "offset should not move backward on shrink");
     }
 
     #[test]

--- a/examples/dual_image.rs
+++ b/examples/dual_image.rs
@@ -5,10 +5,14 @@ use term_wm::SvgImageComponent;
 use term_wm::components::AppRootComponent;
 use term_wm::term_wm_app::TermWmApp;
 
+/// Default demo image, resolved against the crate root so it loads regardless
+/// of the current working directory.
+const DEFAULT_SVG: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/assets/zenOSmosis-logo.svg");
+
 fn main() -> io::Result<()> {
     let mut paths: Vec<String> = std::env::args().skip(1).collect();
     if paths.is_empty() {
-        paths.push("assets/zenOSmosis-logo.svg".to_string());
+        paths.push(DEFAULT_SVG.to_string());
     }
     if paths.len() == 1 {
         paths.push(paths[0].clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,34 @@ struct App {
     pty_wakeup_tx: Sender<UnifiedEvent>,
 }
 
+/// Build the window manager the way the `term-wm` binary runs it: full system
+/// chrome (top panel, bottom panel, FAB) and NO explicit menu-action allow-list,
+/// so the full default action set is available.
+fn build_wm(
+    app_ctx: &Arc<AppContext>,
+) -> term_wm::window::WindowManager<AppRootComponent, LayerComponent, OverlayComponent> {
+    let hostname = app_ctx.hostname.as_deref();
+    let app_name = app_ctx.app_name.clone();
+    let app_version = app_ctx.app_version.clone();
+    AppBuilder::<LayerComponent>::new()
+        .app_ctx(Arc::clone(app_ctx))
+        .top_panel(LayerComponent::TopPanel(
+            term_wm_sys_ui_components::WmTopPanelComponent::new(&app_name),
+        ))
+        .bottom_panel(LayerComponent::BottomPanel(
+            term_wm_sys_ui_components::WmBottomPanelComponent::new(
+                &app_name,
+                &app_version,
+                hostname,
+            ),
+        ))
+        .fab(LayerComponent::Fab(
+            term_wm_sys_ui_components::WmFabComponent::new(),
+        ))
+        .build()
+        .expect("standalone build")
+}
+
 impl App {
     fn new_with(
         commands: Vec<String>,
@@ -102,27 +130,8 @@ impl App {
                     .unwrap_or_else(|| "unknown-host".to_string()),
             ),
         );
-        let hostname = app_ctx.hostname.as_deref();
-        let app_name = app_ctx.app_name.clone();
-        let app_version = app_ctx.app_version.clone();
 
-        let wm = AppBuilder::<LayerComponent>::bare()
-            .app_ctx(Arc::clone(&app_ctx))
-            .top_panel(LayerComponent::TopPanel(
-                term_wm_sys_ui_components::WmTopPanelComponent::new(&app_name),
-            ))
-            .bottom_panel(LayerComponent::BottomPanel(
-                term_wm_sys_ui_components::WmBottomPanelComponent::new(
-                    &app_name,
-                    &app_version,
-                    hostname,
-                ),
-            ))
-            .fab(LayerComponent::Fab(
-                term_wm_sys_ui_components::WmFabComponent::new(),
-            ))
-            .build()
-            .expect("standalone build");
+        let wm = build_wm(&app_ctx);
 
         let inner = TermWmApp::from_wm(wm, pty_wakeup_tx.clone());
         let mut app = Self {
@@ -242,6 +251,17 @@ impl WindowManagerHost<AppRootComponent, LayerComponent, OverlayComponent> for A
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn main_build_wm_gets_full_default_menu_actions() {
+        let app_ctx = Arc::new(AppContext::new("term-wm", "0.0.0").with_hostname("test-host"));
+        let wm = build_wm(&app_ctx);
+        assert_eq!(
+            wm.supported_menu_actions(),
+            term_wm::constants::DEFAULT_SUPPORTED_MENU_ACTIONS,
+            "the term-wm binary must not restrict the command-palette actions to a subset"
+        );
+    }
 
     #[test]
     fn build_commands_appends_joined_positional_after_run() {

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -42,17 +42,27 @@ use crate::unified_event_source::UnifiedEvent;
 ///
 /// # Choosing a constructor
 ///
-/// | You want…                                            | Use                              |
-/// |------------------------------------------------------|----------------------------------|
-/// | Standalone app with full system chrome (panels, menu)| `TermWmApp::<C>::new_custom(ctx)` |
-/// | Full control over an already-built `WindowManager`   | `TermWmApp::from_wm(wm, tx)`      |
+/// | You want…                                            | Use                                            |
+/// |------------------------------------------------------|------------------------------------------------|
+/// | Standalone app with system chrome + default keybindings | `TermWmApp::<C>::new_custom(ctx)`        |
+/// | Standalone app with a custom `WmConfig` (e.g. keybindings) | `TermWmApp::<C>::new_with_config(ctx, config)` |
+/// | Standalone app with custom config AND a custom command-palette allow-list | `TermWmApp::<C>::new_with_actions(ctx, config, actions)` |
+/// | Full control over an already-built `WindowManager`   | `TermWmApp::from_wm(wm, tx)`              |
 ///
 /// `new_custom()` is defined on the generic block and works for any
 /// `C: Component<TermWmAction>`. Because `C` does not appear in its
 /// arguments, callers must provide a type annotation or turbofish —
 /// e.g. `TermWmApp::<NoopComponent>::new_custom(ctx)` when only built-in
-/// components are used. `from_wm()` builds the app around a pre-configured
-/// `WindowManager`; the bundled `term-wm` binary uses this path.
+/// components are used.
+///
+/// `new_custom` and `new_with_config` install a fixed, restricted
+/// command-palette allow-list (`CloseMenu`, `ToggleMouseCapture`,
+/// `ToggleClipboardMode`, `ToggleWindowSelection`, `ExitUi`). Use
+/// `new_with_actions` to opt into additional entries such as
+/// `ToggleDebugWindow` or `ToggleSystemPanel`, or to add/remove any action.
+///
+/// `from_wm()` builds the app around a pre-configured `WindowManager`; the
+/// bundled `term-wm` binary uses this path.
 ///
 /// # Example (built-in components only)
 /// ```ignore

--- a/src/term_wm_app.rs
+++ b/src/term_wm_app.rs
@@ -42,23 +42,26 @@ use crate::unified_event_source::UnifiedEvent;
 ///
 /// # Choosing a constructor
 ///
-/// | You want…                                          | Use                              |
-/// |----------------------------------------------------|----------------------------------|
-/// | Only built-in components, no annotation needed     | `TermWmApp::new(ctx)`            |
-/// | Built-in + your own component type (e.g., `MyComp`)| `TermWmApp::<MyComp>::new_custom(ctx)` |
+/// | You want…                                            | Use                              |
+/// |------------------------------------------------------|----------------------------------|
+/// | Standalone app with full system chrome (panels, menu)| `TermWmApp::<C>::new_custom(ctx)` |
+/// | Full control over an already-built `WindowManager`   | `TermWmApp::from_wm(wm, tx)`      |
 ///
-/// The `new()` / `bare()` / `embedded()` convenience methods exist only
-/// on `TermWmApp<NoopComponent>` so Rust can infer `C` without turbofish.
-/// When `C` is your own type you must call `new_custom()` / `bare_custom()`
-/// / `embedded_custom()` instead — they are defined on the generic block
-/// and work for any `C: Component<TermWmAction>`.
+/// `new_custom()` is defined on the generic block and works for any
+/// `C: Component<TermWmAction>`. Because `C` does not appear in its
+/// arguments, callers must provide a type annotation or turbofish —
+/// e.g. `TermWmApp::<NoopComponent>::new_custom(ctx)` when only built-in
+/// components are used. `from_wm()` builds the app around a pre-configured
+/// `WindowManager`; the bundled `term-wm` binary uses this path.
 ///
-/// # Example (built-in only)
+/// # Example (built-in components only)
 /// ```ignore
 /// use term_wm::prelude::*;
+/// use term_wm::components::NoopComponent;
 ///
 /// fn main() -> io::Result<()> {
-///     let mut app = TermWmApp::new(AppContext::new("myapp", "1.0"));
+///     let mut app =
+///         TermWmApp::<NoopComponent>::new_custom(AppContext::new("myapp", "1.0"));
 ///     let key = app.open_window(AppRootComponent::Core(core_component));
 ///     app.run()
 /// }
@@ -98,10 +101,40 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
     /// Create a new standalone app with all system chrome (panels, menu).
     ///
     /// This is the generic constructor — works for any `C: Component<TermWmAction>`.
-    /// When `C = NoopComponent` you can use `TermWmApp::new(ctx)` instead
-    /// (it forwards here) to avoid a type annotation.
+    /// Provide a type annotation or turbofish for `C` (e.g.
+    /// `TermWmApp::<NoopComponent>::new_custom(ctx)` for built-ins only).
     #[cfg(feature = "sys-ui")]
     pub fn new_custom(app_ctx: AppContext) -> Self {
+        Self::new_with_config(app_ctx, WmConfig::default())
+    }
+
+    /// Create a standalone app with system chrome and a custom `WmConfig`
+    /// (e.g. custom keybindings). The chrome wiring (top/bottom panel, FAB,
+    /// notification area, supported menu actions) is identical to
+    /// [`Self::new_custom`]; only the configuration differs.
+    #[cfg(feature = "sys-ui")]
+    pub fn new_with_config(app_ctx: AppContext, config: WmConfig) -> Self {
+        Self::new_with_actions(
+            app_ctx,
+            config,
+            vec![
+                TermWmAction::CloseMenu,
+                TermWmAction::ToggleMouseCapture,
+                TermWmAction::ToggleClipboardMode,
+                TermWmAction::ToggleWindowSelection,
+                TermWmAction::ExitUi,
+            ],
+        )
+    }
+
+    /// Standalone constructor with system chrome + explicit supported command
+    /// palette actions. `new_with_config` delegates here with its default list.
+    #[cfg(feature = "sys-ui")]
+    pub fn new_with_actions(
+        app_ctx: AppContext,
+        config: WmConfig,
+        actions: Vec<TermWmAction>,
+    ) -> Self {
         let app_name = app_ctx.app_name.clone();
         let app_version = app_ctx.app_version.clone();
         let hostname = app_ctx.hostname.clone();
@@ -111,7 +144,8 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
             WmTopPanelComponent,
         };
 
-        let wm = AppBuilder::<LayerComponent>::bare()
+        let wm = AppBuilder::<LayerComponent>::new()
+            .config(config)
             .app_ctx(Arc::new(app_ctx))
             .top_panel(LayerComponent::TopPanel(WmTopPanelComponent::new(
                 &app_name,
@@ -122,47 +156,13 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
                 hostname.as_deref(),
             )))
             .fab(LayerComponent::Fab(WmFabComponent::new()))
-            .supported_menu_actions(vec![
-                TermWmAction::CloseMenu,
-                TermWmAction::ToggleMouseCapture,
-                TermWmAction::ToggleClipboardMode,
-                TermWmAction::ToggleWindowSelection,
-                TermWmAction::ExitUi,
-            ])
+            .supported_menu_actions(actions)
             .build()
             .expect("standalone build");
         let mut wm = wm;
         wm.set_notification_component(LayerComponent::NotificationArea(
             WmNotificationAreaComponent::new(),
         ));
-        let (tx, _) = bounded(256);
-        Self::from_wm(wm, tx)
-    }
-
-    /// Create a bare standalone app without system chrome.
-    ///
-    /// Generic constructor — use `TermWmApp::bare(ctx)` instead when
-    /// `C = NoopComponent` to avoid a type annotation.
-    pub fn bare_custom(app_ctx: AppContext) -> Self {
-        let wm = AppBuilder::<LayerComponent>::bare()
-            .app_ctx(Arc::new(app_ctx))
-            .build()
-            .expect("bare standalone build");
-        let (tx, _) = bounded(256);
-        Self::from_wm(wm, tx)
-    }
-
-    /// Create an embedded app without command menu, suitable for
-    /// embedding in an existing Ratatui application.
-    ///
-    /// Generic constructor — use `TermWmApp::embedded(ctx)` instead when
-    /// `C = NoopComponent` to avoid a type annotation.
-    pub fn embedded_custom(app_ctx: AppContext) -> Self {
-        let wm = AppBuilder::<LayerComponent>::bare()
-            .config(WmConfig::minimal())
-            .app_ctx(Arc::new(app_ctx))
-            .build()
-            .expect("embedded build");
         let (tx, _) = bounded(256);
         Self::from_wm(wm, tx)
     }
@@ -394,33 +394,6 @@ impl<C: Component<TermWmAction>> TermWmApp<C> {
     }
 }
 
-/// Facade constructors for `C = NoopComponent` — enables type inference
-/// for `TermWmApp::new(ctx)` without annotations.
-impl TermWmApp<NoopComponent> {
-    /// Create a new standalone app with all system chrome (panels, menu).
-    #[cfg(feature = "sys-ui")]
-    pub fn new(app_ctx: AppContext) -> Self {
-        Self::new_custom(app_ctx)
-    }
-
-    /// Create a bare standalone app without system chrome.
-    #[cfg(not(feature = "sys-ui"))]
-    pub fn new(app_ctx: AppContext) -> Self {
-        Self::bare(app_ctx)
-    }
-
-    /// Create a bare standalone app without system chrome.
-    pub fn bare(app_ctx: AppContext) -> Self {
-        Self::bare_custom(app_ctx)
-    }
-
-    /// Create an embedded app without command menu, suitable for
-    /// embedding in an existing Ratatui application.
-    pub fn embedded(app_ctx: AppContext) -> Self {
-        Self::embedded_custom(app_ctx)
-    }
-}
-
 impl<C: Component<TermWmAction>>
     WindowManagerHost<AppRootComponent<C>, LayerComponent, OverlayComponent> for TermWmApp<C>
 {
@@ -523,5 +496,30 @@ impl<C: Component<TermWmAction>>
         );
         self.wm
             .open_exit_confirm_overlay(OverlayComponent::ExitConfirm(confirm));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `new_custom` is what `examples/dual_image.rs` uses to build its app.
+    /// It must keep the command-palette actions limited to the allow-list it
+    /// configures — never the full default set.
+    #[cfg(feature = "sys-ui")]
+    #[test]
+    fn new_custom_limits_supported_menu_actions() {
+        let mut app = TermWmApp::<NoopComponent>::new_custom(AppContext::new("test", "0.0.0"));
+        assert_eq!(
+            app.wm().supported_menu_actions(),
+            &[
+                TermWmAction::CloseMenu,
+                TermWmAction::ToggleMouseCapture,
+                TermWmAction::ToggleClipboardMode,
+                TermWmAction::ToggleWindowSelection,
+                TermWmAction::ExitUi,
+            ],
+            "new_custom must expose exactly its configured allow-list, not the full default set"
+        );
     }
 }

--- a/tests/integration_basic.rs
+++ b/tests/integration_basic.rs
@@ -15,7 +15,7 @@ fn default_shell_nonempty() {
 #[test]
 fn mouse_capture_flow_through_window_manager() {
     let ctx = Arc::new(term_wm::AppContext::new("test", "0.0.0"));
-    let mut wm = AppBuilder::<LayerComponent>::bare()
+    let mut wm = AppBuilder::<LayerComponent>::new()
         .app_ctx(ctx)
         .top_panel(LayerComponent::TopPanel(
             term_wm_sys_ui_components::WmTopPanelComponent::new("test"),

--- a/tests/integration_new_window_focus.rs
+++ b/tests/integration_new_window_focus.rs
@@ -7,7 +7,7 @@ use term_wm_ui_facade::layer_component::LayerComponent;
 #[test]
 fn new_window_is_focused() {
     let ctx = Arc::new(term_wm::AppContext::new("test", "0.0.0"));
-    let mut wm = AppBuilder::<LayerComponent>::bare()
+    let mut wm = AppBuilder::<LayerComponent>::new()
         .app_ctx(ctx)
         .top_panel(LayerComponent::TopPanel(
             term_wm_sys_ui_components::WmTopPanelComponent::new("test"),

--- a/tests/integration_tiling.rs
+++ b/tests/integration_tiling.rs
@@ -28,8 +28,10 @@ fn area_lr() -> LayoutRect {
 }
 
 fn wm_with_two_windows() -> (WindowManager<NoopComponent>, [WindowKey; 2]) {
-    let mut config = WmConfig::standalone();
-    config.chrome_enabled = false;
+    let config = WmConfig {
+        chrome_enabled: false,
+        ..Default::default()
+    };
     let mut wm: WindowManager<NoopComponent> = WindowManager::with_config(
         config,
         Arc::new(AppContext::new("test", "0.0.0")),
@@ -451,8 +453,10 @@ mod spatial_isolation {
 
     #[test]
     fn snap_right_preserves_left_sibling() {
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm: WindowManager<NoopComponent> = WindowManager::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -606,8 +610,10 @@ mod drag_snap_pipeline {
         DrawPlanRenderer,
         [WindowKey; 2],
     ) {
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm = WindowManager::<NoopComponent>::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -1215,8 +1221,10 @@ mod drag_snap_pipeline {
 
     #[test]
     fn tile_single_window_on_empty_workspace_occupies_full_screen() {
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm: WindowManager<NoopComponent> = WindowManager::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -1672,8 +1680,10 @@ mod floating_tiled_separation {
 
     #[test]
     fn multiple_floating_stacked_correctly() {
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm: WindowManager<NoopComponent> = WindowManager::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),
@@ -1860,8 +1870,10 @@ mod render_verification {
     /// area during a full render pass through the compositor.
     #[test]
     fn render_tracker_records_render_area() {
-        let mut config = WmConfig::standalone();
-        config.chrome_enabled = false;
+        let config = WmConfig {
+            chrome_enabled: false,
+            ..Default::default()
+        };
         let mut wm = WindowManager::<TestComponent>::with_config(
             config,
             Arc::new(AppContext::new("test", "0.0.0")),

--- a/tests/overlay_dismissal.rs
+++ b/tests/overlay_dismissal.rs
@@ -51,7 +51,7 @@ fn setup_wm_with_palette(
     palette_bounds: Option<LayoutRect>,
 ) -> WindowManager<NoopComponent, NoopWmComponent, TestOverlay> {
     let mut wm = WindowManager::<NoopComponent, NoopWmComponent, TestOverlay>::with_config(
-        WmConfig::standalone(),
+        WmConfig::default(),
         Arc::new(AppContext::new("test", "0.0.0")),
         None,
         LayerManager::new(),

--- a/tests/panic_debug_log.rs
+++ b/tests/panic_debug_log.rs
@@ -13,7 +13,7 @@ use term_wm::app_context::AppContext;
 use term_wm::config::AppBuilder;
 use term_wm::io::{EventSource, RenderTarget};
 use term_wm::runner::{WindowManagerHost, run_event_loop};
-use term_wm::task_scheduler::TaskScheduler;
+use term_wm::task_scheduler::{AppTask, TaskScheduler};
 use term_wm::window::{WindowKey, WindowManager};
 use term_wm_core::components::{NoopComponent, NoopOverlay, NoopWmComponent};
 use term_wm_core::power_profile::PowerProfile;
@@ -144,7 +144,7 @@ fn render_panic_shows_in_debug_log() {
     );
     term_wm_sys_ui_components::install_panic_hook();
 
-    let mut wm = AppBuilder::<NoopWmComponent>::bare()
+    let mut wm = AppBuilder::<NoopWmComponent>::new()
         .app_ctx(Arc::new(AppContext::new("test", "0.0.0")))
         .build::<NoopComponent, NoopOverlay>()
         .expect("test build");
@@ -167,6 +167,7 @@ fn render_panic_shows_in_debug_log() {
         &mut driver,
         &mut app,
         TaskScheduler::<SystemTask>::new(),
+        TaskScheduler::<AppTask<_>>::new(),
         |k| k,
         {
             move |_backend, app| {
@@ -235,9 +236,9 @@ impl EventSource for WakeupDriver {
     }
 }
 
-/// Helper: build a bare WindowManager with one window.
-fn build_bare_wm() -> WindowManager<NoopComponent, NoopWmComponent, NoopOverlay> {
-    let mut wm = AppBuilder::<NoopWmComponent>::bare()
+/// Helper: build a plain WindowManager with one window.
+fn build_test_wm() -> WindowManager<NoopComponent, NoopWmComponent, NoopOverlay> {
+    let mut wm = AppBuilder::<NoopWmComponent>::new()
         .app_ctx(Arc::new(term_wm::app_context::AppContext::new(
             "test", "0.0.0",
         )))
@@ -255,7 +256,7 @@ fn build_bare_wm() -> WindowManager<NoopComponent, NoopWmComponent, NoopOverlay>
 #[test]
 fn background_dirty_bit_triggers_render_without_input() {
     let mut app = SparseApp {
-        wm: build_bare_wm(),
+        wm: build_test_wm(),
         draws: 0,
         window_key: None,
         should_quit: false,
@@ -268,6 +269,7 @@ fn background_dirty_bit_triggers_render_without_input() {
         &mut driver,
         &mut app,
         TaskScheduler::<SystemTask>::new(),
+        TaskScheduler::<AppTask<_>>::new(),
         |k| k,
         |_, app| {
             app.draws += 1;
@@ -335,7 +337,7 @@ fn frame_pacer_deterministic_timing() {
 #[test]
 fn skipped_frame_preserves_dirty_state() {
     let mut app = SparseApp {
-        wm: build_bare_wm(),
+        wm: build_test_wm(),
         draws: 0,
         window_key: None,
         should_quit: false,
@@ -350,6 +352,7 @@ fn skipped_frame_preserves_dirty_state() {
         &mut driver,
         &mut app,
         TaskScheduler::<SystemTask>::new(),
+        TaskScheduler::<AppTask<_>>::new(),
         |k| k,
         |_, app| {
             app.draws += 1;


### PR DESCRIPTION
### Added

- **Application extensibility — spatial & custom actions:** `TermWmAction` now ships a set of app-agnostic viewport actions (`ZoomIn`, `ZoomOut`, `ResetZoom`, `PanLeft`/`PanRight`/`PanUp`/`PanDown`, `CycleViewMode`) that any canvas, plot, or image component can bind keys to, plus a `Custom(u16)` action that lets host applications map keys to their own app-state triggers without modifying the framework enum. Applications bind them via `WmConfig.keybindings`, and the focused component interprets them in `update()`.
- **Repeatable app task scheduling:** hosts can now schedule recurring work from the app itself. A new `AppTask` payload carries the closure, `TaskHandle::schedule_repeating` gained a "fire immediately" mode, cancelled tasks are purged eagerly, and the runner drains app tasks each cycle — keeping the event loop awake and capping the idle poll sleep so scheduled callbacks fire on time even under the power-saver profile.
- **Configurable app construction:** two new standalone constructors, `TermWmApp::new_with_config(ctx, config)` and `TermWmApp::new_with_actions(ctx, config, actions)`, let host apps start from a custom `WmConfig` (e.g. custom keybindings) and/or an explicit command-palette action allow-list. A new `DEFAULT_SUPPORTED_MENU_ACTIONS` constant documents the default palette action set.
- **Non-closable windows:** `wm.set_closable(key, false)` makes a window unclosable — its chrome ✕ button is hidden, the Command Palette's Close entry is disabled, and every close path (including PTY-child exit) is ignored.
- **Smarter list scrolling:** a shared "keep selection visible" scroll-follow now applies to `ListComponent`, `ToggleListComponent`, and the Command Palette — the selected item stays in view without clobbering manual scrolls and re-engages after a viewport resize. A new `update_items()` on the list components replaces items in place while preserving the selection and any manual scroll, for live-refresh UIs.
- **Horizontal scrolling for lists:** a new column-aware `slice_by_columns` helper slices horizontally-scrolled content by visual columns, padding boundary-crossing wide/CJK characters so rows stay column-aligned; the list components can now scroll sideways.

### Changed

- **Config surface simplified:** the confusing `TermWmApp::new/bare/embedded` convenience constructors and the `bare_custom`/`embedded_custom` variants are gone — only `new_custom`, `from_wm`, `new_with_config`, and `new_with_actions` remain. The `WmConfig::standalone()`/`minimal()` and `KeyBindings::standalone()`/`minimal()` presets were removed; `WmConfig::default()` is now the single full-featured configuration. `AppBuilder::bare()` is now `AppBuilder::new()`.
- **Shared workspace dependencies:** every crate's dependencies now route through `[workspace.dependencies]` (single-source versioning) instead of being declared per-crate.
- **Horizontal scrollbar thumb** now renders as a lower-half block (`▄`) grounded to the bottom edge of the row, keeping the track visible above it.
- **Inner borders removed** from the list components, so each item row maps one-to-one to a content row.
- **Bottom-panel keybinding hints** are now computed from a single shared source and no longer mutated during the render pass — the hints set during layout are exactly what's drawn.
- **`examples/dual_image.rs`** resolves its default demo image against the crate root, so it loads regardless of the current working directory.

### Fixed

- **Monocle + Command Palette showed unfiltered keybindings:** with the Command Palette open in cramped monocle mode, the bottom panel re-pushed the *unfiltered* hint set during rendering, clobbering the layer-filtered hints set during layout (so Global actions like Ctrl+A appeared alongside palette actions). The render pass no longer mutates the panel, so palette-layer-filtered hints are shown consistently in every mode.
- **`examples/dual_image.rs` could not find its default image** when launched from a directory other than the project root.

### Dependencies

- `resvg` 0.47.0 → 0.48.1
- `serial_test` 3.5.0 → 4.0.1
- `windows-sys` 0.59 → 0.61