### PR TITLE
feat(window-list/FAB): Clicking a window title scrolls it fully into view; Monocle FAB content dodging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [0.9.16-alpha] - 2026-08-09
+
+### Added
+
+- **Clicking a window title scrolls it fully into view:** in the top-panel window strip, clicking a partially visible tab now brings it fully into view immediately (previously the scroll waited for mouse release), and a title physically longer than the visible area left-aligns so its start is shown. A plain click still just focuses the window; drag-to-reorder is unaffected — the click's scroll target is applied on the next render pass and never mid-drag.
+- **Monocle FAB never overlaps application content (content dodging):** the Floating Action Button stays fixed on the bottom-right row, and when the focused app draws content underneath its footprint (e.g. a full-width status line like opencode's bottom border), the application viewport is given one fewer row so the app renders its own bottom line *above* the reserved FAB row instead of being covered. Detection scans only the FAB's footprint columns (not the whole row) against the window's *current* bottom row from the previous frame's composited content, and latches while content remains — so a left-aligned shell prompt keeps full height, a status-line app reformats natively (PTY resize / SIGWINCH) with no resize loop, and the FAB only ever floats over empty space. The FAB's footprint and hitbox now use true display-column width (wide/CJK-glyph safe, consistent between the render-time detection and the component).
+
 ## [0.9.15-alpha] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on Keep a Changelog and this project adheres to
 - **Clicking a window title scrolls it fully into view:** in the top-panel window strip, clicking a partially visible tab now brings it fully into view immediately (previously the scroll waited for mouse release), and a title physically longer than the visible area left-aligns so its start is shown. A plain click still just focuses the window; drag-to-reorder is unaffected — the click's scroll target is applied on the next render pass and never mid-drag.
 - **Monocle FAB never overlaps application content (content dodging):** the Floating Action Button stays fixed on the bottom-right row, and when the focused app draws content underneath its footprint (e.g. a full-width status line like opencode's bottom border), the application viewport is given one fewer row so the app renders its own bottom line *above* the reserved FAB row instead of being covered. Detection scans only the FAB's footprint columns (not the whole row) against the window's *current* bottom row from the previous frame's composited content, and latches while content remains — so a left-aligned shell prompt keeps full height, a status-line app reformats natively (PTY resize / SIGWINCH) with no resize loop, and the FAB only ever floats over empty space. The FAB's footprint and hitbox now use true display-column width (wide/CJK-glyph safe, consistent between the render-time detection and the component).
 
+### Fixed
+
+- **Coverage reporting hanging on `connection_error_is_printed_to_stderr`:** the test's fake-gateway acceptor thread ran an infinite `accept()` loop and was dropped (detached), leaking a thread that stayed blocked on `accept()` forever — coverage tooling waits on spawned threads at process exit, so the suite hung for 60+ seconds under coverage. The acceptor now uses a non-blocking listener (`ListenerNonblockingMode::Accept`) that yields on `WouldBlock`, stops via an `Arc<AtomicBool>` flag, and is explicitly `join()`ed, so the thread always terminates.
+
 ## [0.9.15-alpha] - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "term-bench"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "clap",
  "crossterm",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "term-session"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "clap",
  "hostname",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-client"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "crossbeam-channel",
  "crossterm",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-mock"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "libc",
  "term-session-muxio-service-definitions",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-muxio-service-definitions"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "bitcode",
  "interprocess",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "term-session-server"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "libc",
  "muxio-core",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "term-size-box"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -3166,12 +3166,13 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
  "webbrowser",
 ]
 
 [[package]]
 name = "term-wm-console"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "criterion",
  "crossbeam-channel",
@@ -3190,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-core"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "bitflags 2.13.1",
  "console",
@@ -3212,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-crossterm-adapter"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "crossterm",
  "insta",
@@ -3221,21 +3222,21 @@ dependencies = [
 
 [[package]]
 name = "term-wm-events"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "term-wm-layout-engine",
 ]
 
 [[package]]
 name = "term-wm-layout-engine"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "term-wm-pty-engine"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "arboard",
  "base64 0.23.1",
@@ -3254,11 +3255,11 @@ dependencies = [
 
 [[package]]
 name = "term-wm-render"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 
 [[package]]
 name = "term-wm-sys-ui-components"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3274,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-components"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "crossterm",
  "indoc",
@@ -3300,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "term-wm-ui-facade"
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 dependencies = [
  "term-wm-core",
  "term-wm-render",
@@ -3311,8 +3312,6 @@ dependencies = [
 [[package]]
 name = "term-wm-vt100"
 version = "0.16.2-patch2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c417631d01b30907cf0117f4e39870408d05346f702d47bcb515ce3af0b7ac27"
 dependencies = [
  "itoa",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.9.15-alpha"
+version = "0.9.16-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/term-wm"
 license = "MIT OR Apache-2.0"
@@ -88,22 +88,22 @@ slotmap = "1.1"
 smallvec = "1.15"
 strum = { version = "0.28", features = ["derive"] }
 tempfile = "3.24.0"
-term-session = { path = "crates/term-session", version = "0.9.15-alpha" }
-term-session-client = { path = "crates/term-session-client", version = "0.9.15-alpha" }
-term-session-mock = { path = "crates/term-session-mock", version = "0.9.15-alpha" }
-term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.15-alpha" }
-term-session-server = { path = "crates/term-session-server", version = "0.9.15-alpha" }
-term-wm = { path = ".", version = "0.9.15-alpha" }
-term-wm-console = { path = "crates/term-wm-console", version = "0.9.15-alpha" }
-term-wm-core = { path = "crates/term-wm-core", version = "0.9.15-alpha" }
-term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.15-alpha" }
-term-wm-events = { path = "crates/term-wm-events", version = "0.9.15-alpha" }
-term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.15-alpha" }
-term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.15-alpha" }
-term-wm-render = { path = "crates/term-wm-render", version = "0.9.15-alpha" }
-term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.15-alpha" }
-term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.15-alpha" }
-term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.15-alpha" }
+term-session = { path = "crates/term-session", version = "0.9.16-alpha" }
+term-session-client = { path = "crates/term-session-client", version = "0.9.16-alpha" }
+term-session-mock = { path = "crates/term-session-mock", version = "0.9.16-alpha" }
+term-session-muxio-service-definitions = { path = "crates/term-session-muxio-service-definitions", version = "0.9.16-alpha" }
+term-session-server = { path = "crates/term-session-server", version = "0.9.16-alpha" }
+term-wm = { path = ".", version = "0.9.16-alpha" }
+term-wm-console = { path = "crates/term-wm-console", version = "0.9.16-alpha" }
+term-wm-core = { path = "crates/term-wm-core", version = "0.9.16-alpha" }
+term-wm-crossterm-adapter = { path = "crates/term-wm-crossterm-adapter", version = "0.9.16-alpha" }
+term-wm-events = { path = "crates/term-wm-events", version = "0.9.16-alpha" }
+term-wm-layout-engine = { path = "crates/term-wm-layout-engine", version = "0.9.16-alpha" }
+term-wm-pty-engine = { path = "crates/term-wm-pty-engine", version = "0.9.16-alpha" }
+term-wm-render = { path = "crates/term-wm-render", version = "0.9.16-alpha" }
+term-wm-sys-ui-components = { path = "crates/term-wm-sys-ui-components", version = "0.9.16-alpha" }
+term-wm-ui-components = { path = "crates/term-wm-ui-components", version = "0.9.16-alpha" }
+term-wm-ui-facade = { path = "crates/term-wm-ui-facade", version = "0.9.16-alpha" }
 term-wm-vt100 = "0.16.2-patch2"
 textwrap = "0.16.2"
 thiserror = "2.0.18"
@@ -152,6 +152,7 @@ term-wm-ui-components = { workspace = true }
 term-wm-ui-facade = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+unicode-width = { workspace = true }
 webbrowser = { workspace = true }
 
 [build-dependencies]

--- a/crates/term-session/tests/daemon_tests.rs
+++ b/crates/term-session/tests/daemon_tests.rs
@@ -862,26 +862,57 @@ async fn cli_stop_requires_force_when_live_sessions() {
 /// each connection (no muxio handshake), so Attach fails deterministically
 /// without auto-spawning a new daemon (probe succeeds because something is
 /// bound). Unix-only: the redirect is a unix `dup2` mechanism.
+///
+/// Why garbage instead of just closing? This is deliberate fault injection, not
+/// a Muxio bug. Dropping the connection outright would surface as a bare EOF /
+/// connection-reset, which RPC layers often treat as a benign or retryable
+/// disconnect — potentially bypassing the error path under test. Writing an
+/// invalid frame guarantees the connection completes but the protocol framing
+/// fails with a hard decode error, forcing the failure up through the client's
+/// error-routing pipeline so it reaches stderr.
 #[cfg(unix)]
 #[test]
 fn connection_error_is_printed_to_stderr() {
-    use interprocess::local_socket::{GenericNamespaced, ListenerOptions, ToNsName, prelude::*};
+    use interprocess::local_socket::{
+        GenericNamespaced, ListenerNonblockingMode, ListenerOptions, ToNsName, prelude::*,
+    };
     use std::io::Write;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
 
     let gateway = unique_gateway("silent-exit");
     let name = gateway
         .as_str()
         .to_ns_name::<GenericNamespaced>()
         .expect("gateway ns name");
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop_flag.clone();
     let listener = ListenerOptions::new()
         .name(name)
         .try_overwrite(true)
         .create_sync()
         .expect("bind dummy gateway");
+    listener
+        .set_nonblocking(ListenerNonblockingMode::Accept)
+        .expect("set nonblocking");
     let acceptor = std::thread::spawn(move || {
-        while let Ok(mut stream) = listener.accept() {
-            // Garbage + close: muxio decode fails rather than silently EOF.
-            let _ = stream.write_all(b"not-a-muxio-frame");
+        // Feed garbage + close to every connection (the client's probe first,
+        // then the real RPC connection) so muxio decode fails rather than
+        // silently EOF. Non-blocking accept keeps the loop yielding; the stop
+        // flag makes the thread exit cleanly so it can be joined instead of
+        // leaking (a leaked thread blocks coverage instrumentation at exit).
+        while !stop_clone.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok(mut stream) => {
+                    // Garbage + close: muxio decode fails rather than silently EOF.
+                    let _ = stream.write_all(b"not-a-muxio-frame");
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
         }
     });
 
@@ -901,5 +932,8 @@ fn connection_error_is_printed_to_stderr() {
         "client must exit non-zero, got status: {:?}",
         out.status.code()
     );
-    drop(acceptor);
+    // Signal the acceptor to stop, then wait for it to exit so no leaked thread
+    // survives to block coverage instrumentation at process exit.
+    stop_flag.store(true, Ordering::Relaxed);
+    acceptor.join().expect("acceptor thread failed");
 }

--- a/crates/term-wm-console/src/draw_plan_renderer.rs
+++ b/crates/term-wm-console/src/draw_plan_renderer.rs
@@ -52,6 +52,44 @@ struct ChromeHitboxParams {
     header_enabled: bool,
 }
 
+/// True if any cell in `[x_start, x_end)` on row `y` has a non-space symbol.
+/// Coordinates are clipped to `buffer.area` and accessed via the Option-returning
+/// `Buffer::cell`, so a clipped or offscreen range can never panic.
+///
+/// Used to detect whether app content collides with the FAB's bottom-right
+/// footprint. `y` is the window's current bottom row, which moves when the FAB
+/// row is reserved — checking the relative row (not a fixed screen row) is what
+/// prevents SIGWINCH oscillation.
+pub fn row_has_content_in_range(
+    buffer: &ratatui::buffer::Buffer,
+    x_start: i32,
+    x_end: i32,
+    y: i32,
+) -> bool {
+    let buf = buffer.area;
+    let buf_top = i32::from(buf.y);
+    let buf_bottom = buf_top.saturating_add(i32::from(buf.height));
+    if y < buf_top || y >= buf_bottom {
+        return false;
+    }
+    let left = x_start.max(i32::from(buf.x));
+    let right = x_end.min(i32::from(buf.x).saturating_add(i32::from(buf.width)));
+    if left >= right {
+        return false;
+    }
+    // Direct slice scan over Ratatui's contiguous `content` array. The row/column
+    // bounds are clamped (and y validated) once above, so the loop itself does zero
+    // per-cell bounds checks and LLVM can auto-vectorize the ASCII-space scan in
+    // --release. All indices are provably within `content.len()`.
+    let buf_w = usize::from(buf.width);
+    let row_offset = (y as usize - buf.y as usize) * buf_w;
+    let start_idx = row_offset + (left as usize - buf.x as usize);
+    let end_idx = row_offset + (right as usize - buf.x as usize);
+    buffer.content[start_idx..end_idx]
+        .iter()
+        .any(|c| !c.symbol().starts_with(' '))
+}
+
 /// Register chrome hitboxes for a window (resize, drag, close, maximize buttons).
 /// `frame_size` is (width, height) of the window frame. `screen_origin` is the screen-space
 /// top-left coordinate (x, y). Also registers a content-area hitbox.
@@ -844,10 +882,14 @@ pub fn render_overlays<C: Component<TermWmAction>, L: WmComponent, O: Overlay<Te
         // Bottom panel overlay in monocle mode — keybinding hints. Hints are
         // set during the layout phase (register_managed_layout); the render
         // phase only draws the component's already-established state.
+        // Anchor to the ABSOLUTE screen bottom (last_frame_area), not the
+        // managed area: the FAB row reservation shrinks managed_area by one
+        // row, which would otherwise raise the panel up to row H-2.
+        let screen = wm.last_frame_area();
         let bottom_area = LayoutRect {
-            x: full_area.x,
-            y: full_area.y + i32::from(full_area.height).saturating_sub(1),
-            width: full_area.width,
+            x: screen.x,
+            y: screen.y + i32::from(screen.height).saturating_sub(1),
+            width: screen.width,
             height: 1,
         };
         let mut bottom_hb = HitboxRegistry::new();
@@ -2393,5 +2435,46 @@ mod tests {
         }
         assert_eq!(symbol(12), "═", "edge right of the occluder must light up");
         assert_eq!(symbol(13), "═", "edge right of the occluder must light up");
+    }
+
+    #[test]
+    fn row_has_content_in_range_detects_content_in_range() {
+        let mut buffer = Buffer::empty(RatatuiRect::new(0, 0, 20, 3));
+        buffer.cell_mut((15, 2)).expect("cell").set_symbol("x");
+        assert!(row_has_content_in_range(&buffer, 12, 18, 2));
+        // Content outside the range is not detected.
+        assert!(!row_has_content_in_range(&buffer, 0, 10, 2));
+    }
+
+    #[test]
+    fn row_has_content_in_range_blank_row_is_false() {
+        let buffer = Buffer::empty(RatatuiRect::new(0, 0, 20, 3));
+        assert!(!row_has_content_in_range(&buffer, 0, 20, 1));
+    }
+
+    #[test]
+    fn row_has_content_in_range_offscreen_does_not_panic() {
+        let mut buffer = Buffer::empty(RatatuiRect::new(0, 0, 20, 3));
+        buffer.cell_mut((5, 2)).expect("cell").set_symbol("x");
+        // Row outside the buffer height.
+        assert!(!row_has_content_in_range(&buffer, 0, 20, 9));
+        // Range wholly outside the buffer width (e.g. stale x from a resize).
+        assert!(!row_has_content_in_range(&buffer, 50, 60, 2));
+        // Partially offscreen range is clipped and still detects in-bounds content.
+        assert!(row_has_content_in_range(&buffer, -5, 6, 2));
+        // Empty range.
+        assert!(!row_has_content_in_range(&buffer, 10, 10, 2));
+    }
+
+    #[test]
+    fn row_has_content_in_range_nonzero_buffer_origin() {
+        // Buffer origin is not (0,0); the slice-scan row/column offset math must
+        // account for area.x/area.y (e.g. a clipped or translated sub-viewport).
+        let mut buffer = Buffer::empty(RatatuiRect::new(10, 20, 20, 3));
+        buffer.cell_mut((15, 21)).expect("cell").set_symbol("x");
+        assert!(row_has_content_in_range(&buffer, 14, 16, 21));
+        assert!(!row_has_content_in_range(&buffer, 11, 13, 21));
+        // Row 21 is the buffer's middle row; rows outside its area are rejected.
+        assert!(!row_has_content_in_range(&buffer, 14, 16, 23));
     }
 }

--- a/crates/term-wm-core/src/window/window_manager/layout.rs
+++ b/crates/term-wm-core/src/window/window_manager/layout.rs
@@ -12,6 +12,22 @@ use crate::window::entry::WindowMode;
 use crate::window::window_manager::Window;
 use crate::window::{FloatRectSpec, WindowKey, WindowState};
 
+/// Rows reserved for the FAB at the bottom of the screen in cramped monocle.
+/// The focused window is given one fewer row so it never renders beneath the FAB.
+const FAB_RESERVED_ROWS: u16 = 1;
+
+/// Shrink `area` by the FAB's reserved bottom row when the FAB is shown in
+/// cramped monocle. `height` is never shrunk below 1.
+fn reserve_fab_row(area: Rect, cramped_monocle: bool) -> Rect {
+    if cramped_monocle && area.height > 1 {
+        let mut a = area;
+        a.height = a.height.saturating_sub(FAB_RESERVED_ROWS);
+        a
+    } else {
+        area
+    }
+}
+
 impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> WindowManager<C, L, O> {
     pub fn scroll(&self, key: WindowKey) -> super::ScrollState {
         self.scroll.get(&key).copied().unwrap_or_default()
@@ -384,7 +400,13 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         };
         self.bottom_claimed = bottom_rect;
         let prev_managed = self.managed_area;
-        self.managed_area = managed_area;
+        // Cramped monocle: the FAB occupies the bottom-right of the screen. Reserve
+        // the bottom row for it while the app draws content under the FAB's footprint,
+        // so the focused window never renders beneath it; the PTY resizes to the shorter
+        // area and apps format status lines above the row natively. The flag is set by
+        // the render pass on the previous frame, so this lags content by one frame.
+        let apply_padding = self.is_monocle_cramped() && self.has_bottom_content();
+        self.managed_area = reserve_fab_row(managed_area, apply_padding);
         // First real frame: the true viewport is now known. If no tiling layout
         // was built yet (startup windows were tiled lazily, not at 0x0), build
         // the tree now from the mapped, non-floating windows in creation order

--- a/crates/term-wm-core/src/window/window_manager/mod.rs
+++ b/crates/term-wm-core/src/window/window_manager/mod.rs
@@ -390,6 +390,10 @@ pub struct WindowManager<
     pub(crate) input_mode: crate::actions::WmInputMode,
     /// Whether the FAB component is enabled
     pub(crate) fab_enabled: bool,
+    /// True when the app draws content under the FAB's footprint on its bottom
+    /// row (populated by the render pass each frame; consumed by the layout pass
+    /// on the next frame to reserve the FAB's bottom row in cramped monocle).
+    bottom_content: bool,
     /// Namespaced semantic registry for programmatic component lookup.
     /// Hotkeys and structural routing query this instead of hardcoded fields.
     pub semantic_registry: HashMap<layer_manager::ComponentTag, layer_manager::LayerId>,
@@ -886,6 +890,7 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
             last_snap_cursor: None,
             input_mode: crate::actions::WmInputMode::Passthrough,
             fab_enabled: true,
+            bottom_content: false,
             tap_swap_state: None,
         }
     }
@@ -951,6 +956,20 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
     /// Set the FAB enabled state.
     pub fn set_fab_enabled(&mut self, enabled: bool) {
         self.fab_enabled = enabled;
+    }
+
+    /// True when the focused window draws content under the FAB's footprint on
+    /// its bottom row. Populated by the render pass; consumed by the layout pass
+    /// (register_managed_layout) on the next frame to reserve the FAB's row.
+    pub fn has_bottom_content(&self) -> bool {
+        self.bottom_content
+    }
+
+    /// Record whether the app draws content under the FAB's footprint. Cleared by
+    /// the render pass whenever cramped monocle is inactive to avoid a stale flag
+    /// falsely padding the first frame after re-entering cramped monocle.
+    pub fn set_bottom_content_flag(&mut self, has: bool) {
+        self.bottom_content = has;
     }
 
     /// Get a mutable reference to the FAB component.
@@ -2601,6 +2620,13 @@ impl<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmAction>> Windo
         self.managed_area
     }
 
+    /// The full screen area passed to `register_managed_layout`, before any FAB
+    /// row reservation shrinks `managed_area`. Used to anchor chrome (e.g. the
+    /// bottom-panel overlay) to the absolute screen bottom regardless of the offset.
+    pub fn last_frame_area(&self) -> LayoutRect {
+        self.last_frame_area
+    }
+
     pub fn overlays(&self) -> &SlotMap<OverlayKey, O> {
         &self.overlays
     }
@@ -3091,6 +3117,149 @@ mod tests {
             key_a,
             "monocle mode must prevent mouse focus switching"
         );
+    }
+
+    #[test]
+    fn cramped_monocle_reserves_fab_bottom_row() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        let key = keys[0];
+        wm.managed_layout = Some(crate::layout::TilingLayout::new(
+            crate::layout::LayoutNode::leaf(key),
+        ));
+        wm.update_monocle_mode(50);
+        assert!(
+            wm.is_monocle_cramped(),
+            "width 50 < 80 must be cramped monocle"
+        );
+        wm.set_bottom_content_flag(true);
+
+        wm.register_managed_layout(crate::Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 24,
+        });
+        assert_eq!(
+            wm.managed_area().height,
+            23,
+            "cramped monocle must reserve the FAB's bottom row when content detected"
+        );
+    }
+
+    #[test]
+    fn cramped_monocle_without_content_does_not_reserve() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        let key = keys[0];
+        wm.managed_layout = Some(crate::layout::TilingLayout::new(
+            crate::layout::LayoutNode::leaf(key),
+        ));
+        wm.update_monocle_mode(50);
+        assert!(wm.is_monocle_cramped());
+        wm.set_bottom_content_flag(false);
+
+        wm.register_managed_layout(crate::Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 24,
+        });
+        assert_eq!(
+            wm.managed_area().height,
+            24,
+            "no reservation when the FAB footprint has no content"
+        );
+    }
+
+    #[test]
+    fn wide_terminal_does_not_reserve_fab_row() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        let key = keys[0];
+        wm.managed_layout = Some(crate::layout::TilingLayout::new(
+            crate::layout::LayoutNode::leaf(key),
+        ));
+        wm.update_monocle_mode(100);
+        assert!(
+            !wm.is_monocle_cramped(),
+            "width 100 >= 80 must not be cramped"
+        );
+        // Even with a stale content flag, a non-cramped viewport must not reserve.
+        wm.set_bottom_content_flag(true);
+
+        wm.register_managed_layout(crate::Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 24,
+        });
+        assert_eq!(
+            wm.managed_area().height,
+            24,
+            "no reservation when not cramped"
+        );
+    }
+
+    #[test]
+    fn reserve_fab_row_does_not_shrink_below_one() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        let keys = make_keys(&mut wm, 1);
+        let key = keys[0];
+        wm.managed_layout = Some(crate::layout::TilingLayout::new(
+            crate::layout::LayoutNode::leaf(key),
+        ));
+        wm.update_monocle_mode(50);
+        wm.set_bottom_content_flag(true);
+
+        // A 1-row-tall area is never shrunk below height 1, even when cramped.
+        wm.register_managed_layout(crate::Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 1,
+        });
+        assert_eq!(wm.managed_area().height, 1, "height must never reach 0");
+    }
+
+    #[test]
+    fn bottom_content_flag_defaults_false_and_toggles() {
+        let mut wm = WindowManager::<TestComponent>::with_config(
+            WmConfig::default(),
+            Arc::new(AppContext::new("test", "0.0.0")),
+            None,
+            crate::window::LayerManager::new(),
+            std::collections::HashMap::new(),
+        );
+        assert!(!wm.has_bottom_content(), "flag defaults to false");
+        wm.set_bottom_content_flag(true);
+        assert!(wm.has_bottom_content(), "setter records true");
+        wm.set_bottom_content_flag(false);
+        assert!(!wm.has_bottom_content(), "setter clears the flag");
     }
 
     #[test]

--- a/crates/term-wm-sys-ui-components/src/wm_bottom_panel.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_bottom_panel.rs
@@ -751,4 +751,71 @@ mod tests {
             "palette-filtered hints must include a CommandPalette-layer action, got {actions:?}"
         );
     }
+
+    #[test]
+    fn bottom_panel_overlay_stays_on_absolute_bottom_when_fab_row_reserved() {
+        use std::sync::Arc;
+        use term_wm_console::draw_plan_renderer::render_overlays;
+        use term_wm_core::app_context::AppContext;
+        use term_wm_core::components::NoopComponent;
+        use term_wm_core::components::NoopOverlay;
+        use term_wm_core::config::AppBuilder;
+
+        let app_ctx = Arc::new(AppContext::new("test", "0.1.0"));
+        let mut wm = AppBuilder::<WmBottomPanelComponent>::new()
+            .app_ctx(Arc::clone(&app_ctx))
+            .bottom_panel(WmBottomPanelComponent::new(
+                "test",
+                "0.1.0",
+                Some("test-host"),
+            ))
+            .build::<NoopComponent, NoopOverlay>()
+            .expect("test build");
+
+        // Cramped monocle + command palette open + FAB row reserved (app content
+        // detected under the FAB footprint) → managed_area is 23 rows tall.
+        wm.update_monocle_mode(40);
+        assert!(wm.is_monocle_cramped());
+        wm.set_bottom_content_flag(true);
+        wm.open_command_palette_overlay(NoopOverlay);
+        assert!(wm.command_menu_visible());
+
+        let area = term_wm_core::Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 24,
+        };
+        wm.register_managed_layout(area);
+        assert_eq!(wm.managed_area().height, 23, "FAB row must be reserved");
+
+        let ratatui_area = ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 24,
+        };
+        let buf = Buffer::empty(ratatui_area);
+        let mut backend = term_wm_console::RatatuiBackend::new_simple(buf, ratatui_area);
+        render_overlays(&mut backend, &mut wm);
+
+        // The bottom-panel hints must stay on the ABSOLUTE bottom row (23), NOT
+        // rise up to the reserved row above it (22).
+        let has_non_space = |row: u16| {
+            (0..40).any(|x| {
+                backend
+                    .buffer
+                    .cell((x, row))
+                    .is_some_and(|c| !c.symbol().starts_with(' '))
+            })
+        };
+        assert!(
+            has_non_space(23),
+            "hints must render on absolute bottom row 23"
+        );
+        assert!(
+            !has_non_space(22),
+            "hints must NOT rise up to row 22 when the FAB row is reserved"
+        );
+    }
 }

--- a/crates/term-wm-sys-ui-components/src/wm_fab.rs
+++ b/crates/term-wm-sys-ui-components/src/wm_fab.rs
@@ -1,5 +1,6 @@
 use ratatui::style::Style;
 use term_wm_layout_engine::LayoutRect;
+use unicode_width::UnicodeWidthStr;
 
 use term_wm_core::{
     actions::{EventResult, TermWmAction},
@@ -64,7 +65,10 @@ impl Component<TermWmAction> for WmFabComponent {
         }
 
         let label = menu_icon(ctx.app_name());
-        let width = label.chars().count() as u16;
+        // Display column width, not char count — wide glyphs (Nerd Font, emoji)
+        // span 2 columns for a single char, so the footprint and hitbox must use
+        // the rendered width (kept in lockstep with render_app's detection).
+        let width = UnicodeWidthStr::width(label.as_str()) as u16;
 
         self.fab_rect = LayoutRect {
             x: area.x + i32::from(area.width).saturating_sub(i32::from(width)),

--- a/crates/term-wm-ui-components/src/tab_bar.rs
+++ b/crates/term-wm-ui-components/src/tab_bar.rs
@@ -41,6 +41,28 @@ const CLOSE_BUTTON_WIDTH: u16 = 2;
 /// Close glyph rendered on closable tabs.
 const CLOSE_GLYPH: &str = "✕";
 
+/// Horizontal scroll that makes a tab at logical `lx` of `width` columns fully visible.
+/// Tabs wider than the viewport are left-aligned (show the leftmost columns).
+fn scroll_into_view_target(
+    h: i32,
+    lx: i32,
+    width: i32,
+    viewport_width: i32,
+    max_scroll: i32,
+) -> i32 {
+    let target = if width > viewport_width || lx < h {
+        // Tabs wider than the viewport, or clipped on the left, align to their
+        // left edge (show the leftmost columns of the title).
+        lx.max(0)
+    } else if lx.saturating_add(width) > h.saturating_add(viewport_width) {
+        // Clipped on the right → reveal the right edge.
+        (lx.saturating_add(width) - viewport_width).max(0)
+    } else {
+        h // already fully visible
+    };
+    target.min(max_scroll).max(0)
+}
+
 /// A single tab: an opaque key plus its display label.
 #[derive(Debug, Clone)]
 pub struct TabItem<K> {
@@ -99,6 +121,9 @@ pub struct TabBarComponent<K> {
     last_auto_focus: Option<K>,
     last_auto_viewport: i32,
     last_focused_logical_bounds: Option<(i32, i32)>,
+    // Tab clicked by the user; scrolled into view on the next render pass.
+    // Never consumed while a drag is in progress (see render()).
+    pending_scroll_to: Option<K>,
 }
 
 impl<K: Copy + PartialEq + Eq + std::hash::Hash + std::fmt::Debug + 'static> TabBarComponent<K> {
@@ -119,6 +144,7 @@ impl<K: Copy + PartialEq + Eq + std::hash::Hash + std::fmt::Debug + 'static> Tab
             last_auto_focus: None,
             last_auto_viewport: 0,
             last_focused_logical_bounds: None,
+            pending_scroll_to: None,
         }
     }
 
@@ -286,19 +312,34 @@ impl<K: Copy + PartialEq + Eq + std::hash::Hash + std::fmt::Debug + 'static>
             && auto_scroll
             && let Some((flx, fw)) = focused_range
         {
-            let h = i32::from(self.h_scroll);
-            let vp_end = h.saturating_add(scroll_viewport_width);
-            if flx < h {
-                self.h_scroll = flx.max(0) as u16;
-            } else if flx.saturating_add(i32::from(fw)) > vp_end {
-                self.h_scroll =
-                    (flx.saturating_add(i32::from(fw)) - scroll_viewport_width).max(0) as u16;
-            }
-            self.h_scroll = self.h_scroll.min(max_scroll);
+            self.h_scroll = scroll_into_view_target(
+                i32::from(self.h_scroll),
+                flx,
+                i32::from(fw),
+                scroll_viewport_width,
+                i32::from(max_scroll),
+            ) as u16;
         }
         self.last_auto_focus = self.active_key;
         self.last_auto_viewport = scroll_viewport_width;
         self.last_focused_logical_bounds = focused_bounds;
+
+        // Consume a click-requested scroll. drag_state must be checked BEFORE
+        // `.take()`: the `if let` scrutinee runs first, so taking would evict the
+        // pending target on the frame after a click while the button is still held
+        // (drag_state Some → guard fails) — silently breaking click-to-scroll.
+        if self.drag_state.is_none()
+            && let Some(key) = self.pending_scroll_to.take()
+            && let Some((_, lx, width)) = entry_geometry.iter().find(|(k, ..)| *k == key)
+        {
+            self.h_scroll = scroll_into_view_target(
+                i32::from(self.h_scroll),
+                *lx,
+                i32::from(*width),
+                scroll_viewport_width,
+                i32::from(max_scroll),
+            ) as u16;
+        }
 
         self.entries_start_x = entries_start_x;
         self.scroll_viewport_width = scroll_viewport_width;
@@ -549,6 +590,12 @@ impl<K: Copy + PartialEq + Eq + std::hash::Hash + std::fmt::Debug + 'static> Tab
             return EventResult::Action(TabBarEvent::Close(key));
         }
         if let Some((key, rect)) = self.hit_test_tab(column, row) {
+            // Queue a scroll-into-view for the next render pass. We deliberately
+            // do NOT touch h_scroll here: entry_geometry/item_hits are only
+            // refreshed during render(), and mutating h_scroll mid-event would
+            // desync DragState::grab_col (from the prior frame's hit rects) if a
+            // Drag arrives before the next render.
+            self.pending_scroll_to = Some(key);
             let grab_col = i32::from(column) - rect.x;
             let drop_index = self.items.iter().position(|t| t.key == key).unwrap_or(0);
             self.drag_state = Some(DragState {
@@ -661,6 +708,10 @@ mod tests {
 
     /// Render the bar at a fixed rect with the given items.
     fn render_bar(bar: &mut TabBarComponent<usize>, width: u16, height: u16, rect: LayoutRect) {
+        // Mirrors the production lifecycle (WmTopPanelComponent calls
+        // bar.begin_frame() before render): clears per-frame hit state so
+        // item_hits don't accumulate across renders.
+        bar.begin_frame();
         let mut backend = make_backend(width, height);
         let c = ctx();
         let mut reg = term_wm_core::hitbox_registry::HitboxRegistry::new();
@@ -951,5 +1002,161 @@ mod tests {
             bar.h_scroll, bar.max_scroll,
             "auto-scroll re-follows the active tab after a structural reorder"
         );
+    }
+
+    #[test]
+    fn clicking_partially_visible_tab_scrolls_it_into_view() {
+        let mut bar = TabBarComponent::<usize>::new();
+        bar.set_items(make_items(&[0, 1, 2, 3, 4, 5, 6, 7], false));
+        bar.set_active(Some(0));
+        let r = rect(0, 0, 30, 1);
+        render_bar(&mut bar, 30, 1, r);
+        // Manual scroll so tab 6 (lx=60, width 10) is half-hidden at the right
+        // edge: with h_scroll=40, viewport 26 wide, tab 6 spans vp cols 20..26.
+        bar.h_scroll = 40;
+        render_bar(&mut bar, 30, 1, r);
+        let c = ctx();
+
+        let res = bar.handle_events(&mouse(MouseEventKind::Press(MouseButton::Left), 23, 0), &c);
+        assert!(matches!(res, EventResult::Action(TabBarEvent::Select(6))));
+        assert_eq!(bar.h_scroll, 40, "press must not mutate h_scroll");
+        assert_eq!(bar.pending_scroll_to, Some(6));
+
+        // Release completes the click (a real click = press + release), clearing
+        // the drag state so the next render consumes the pending scroll.
+        let _ = bar.handle_events(
+            &mouse(MouseEventKind::Release(MouseButton::Left), 23, 0),
+            &c,
+        );
+        assert_eq!(bar.h_scroll, 40, "release must not mutate h_scroll");
+
+        // Next render consumes the pending scroll and brings tab 6 fully in view.
+        render_bar(&mut bar, 30, 1, r);
+        assert_eq!(bar.h_scroll, 44, "tab 6 right edge lands at viewport end");
+        let vp_x = 60_i32.saturating_sub(i32::from(bar.h_scroll));
+        let vp_end = vp_x.saturating_add(10);
+        assert!(
+            vp_x >= 0 && vp_end <= bar.scroll_viewport_width,
+            "tab 6 fully within viewport"
+        );
+        assert_eq!(bar.pending_scroll_to, None, "pending target consumed");
+    }
+
+    #[test]
+    fn clicking_oversized_tab_left_aligns() {
+        let mut bar = TabBarComponent::<usize>::new();
+        let mut items = make_items(&[0], false);
+        items[0].label = "a".repeat(50); // truncated to MAX_ENTRY_LABEL (40 cols)
+        bar.set_items(items);
+        bar.set_active(Some(0));
+        let r = rect(0, 0, 20, 1);
+        render_bar(&mut bar, 20, 1, r);
+        let (_, lx0, _) = bar.entry_geometry[0];
+        assert!(lx0 >= 0, "single tab starts at logical x 0");
+
+        // Scroll to the end so only the tab's tail is visible.
+        bar.h_scroll = bar.max_scroll;
+        render_bar(&mut bar, 20, 1, r);
+        let c = ctx();
+
+        // Click the visible portion → next render left-aligns the oversized tab.
+        let res = bar.handle_events(&mouse(MouseEventKind::Press(MouseButton::Left), 5, 0), &c);
+        assert!(matches!(res, EventResult::Action(TabBarEvent::Select(0))));
+        assert_eq!(bar.pending_scroll_to, Some(0));
+
+        // Release completes the click so the pending scroll is consumed.
+        let _ = bar.handle_events(&mouse(MouseEventKind::Release(MouseButton::Left), 5, 0), &c);
+
+        render_bar(&mut bar, 20, 1, r);
+        assert_eq!(
+            bar.h_scroll, 0,
+            "oversized tab left-aligns to its logical origin"
+        );
+    }
+
+    #[test]
+    fn clicking_active_tab_reeveals_it() {
+        let mut bar = TabBarComponent::<usize>::new();
+        bar.set_items(make_items(&[0, 1, 2, 3, 4, 5, 6, 7], false));
+        bar.set_active(Some(6));
+        let r = rect(0, 0, 30, 1);
+        render_bar(&mut bar, 30, 1, r);
+        // Active tab 6 is fully in view after the first render; now scroll it
+        // partially out again without changing focus.
+        bar.h_scroll = 40;
+        render_bar(&mut bar, 30, 1, r);
+        let c = ctx();
+
+        // Clicking the already-active tab doesn't trip the auto-scroll guard,
+        // but the pending path still reveals it.
+        let res = bar.handle_events(&mouse(MouseEventKind::Press(MouseButton::Left), 23, 0), &c);
+        assert!(matches!(res, EventResult::Action(TabBarEvent::Select(6))));
+
+        // Release completes the click so the pending scroll is consumed.
+        let _ = bar.handle_events(
+            &mouse(MouseEventKind::Release(MouseButton::Left), 23, 0),
+            &c,
+        );
+
+        render_bar(&mut bar, 30, 1, r);
+        assert_eq!(
+            bar.h_scroll, 44,
+            "clicked active tab scrolled back into view"
+        );
+    }
+
+    #[test]
+    fn drag_reorder_still_works_after_pending_scroll() {
+        let mut bar = TabBarComponent::<usize>::new();
+        bar.set_items(make_items(&[0, 1, 2, 3, 4, 5, 6, 7], false));
+        bar.set_active(Some(0));
+        let r = rect(0, 0, 30, 1);
+        render_bar(&mut bar, 30, 1, r);
+        bar.h_scroll = 40;
+        render_bar(&mut bar, 30, 1, r);
+        let c = ctx();
+
+        // Press a partially-visible tab: queues a scroll, arms a drag.
+        let res = bar.handle_events(&mouse(MouseEventKind::Press(MouseButton::Left), 23, 0), &c);
+        assert!(matches!(res, EventResult::Action(TabBarEvent::Select(6))));
+        assert_eq!(bar.h_scroll, 40, "press does not mutate h_scroll");
+        assert!(bar.drag_state.is_some());
+
+        // Drag to column 10 WITHOUT a render: drop target uses the current
+        // h_scroll (40) + logical geometry → virtual_col = 10 - 2 + 40 = 48,
+        // which lands before tab 4 (lx 40..50).
+        let res = bar.handle_events(&mouse(MouseEventKind::Drag(MouseButton::Left), 10, 0), &c);
+        assert!(matches!(res, EventResult::Consumed));
+        assert_eq!(bar.h_scroll, 40, "drag must not alter h_scroll");
+        assert_eq!(
+            bar.drag_state.as_ref().unwrap().drop_index,
+            4,
+            "reorder target computed from current scroll, no drift"
+        );
+
+        // A render while the button is held must NOT consume the pending scroll.
+        render_bar(&mut bar, 30, 1, r);
+        assert_eq!(
+            bar.pending_scroll_to,
+            Some(6),
+            "pending survives active drag"
+        );
+
+        // Release commits the reorder.
+        let res = bar.handle_events(
+            &mouse(MouseEventKind::Release(MouseButton::Left), 10, 0),
+            &c,
+        );
+        assert!(matches!(
+            res,
+            EventResult::Action(TabBarEvent::Reorder {
+                key: 6,
+                target_index: 4
+            })
+        ));
+
+        // Next render applies the pending scroll.
+        render_bar(&mut bar, 30, 1, r);
+        assert_eq!(bar.h_scroll, 44, "pending scroll applies after release");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use term_wm_console::RatatuiBackend;
 use term_wm_console::draw_plan_renderer::{
     ColorConvert, DrawPlanRenderer, composite_window, overlay_shadow_data, render_cursor_overlay,
     render_drop_shadow, render_ghost_preview, render_handles_masked, render_overlays,
-    render_panels, render_resize_outline,
+    render_panels, render_resize_outline, row_has_content_in_range,
 };
 use term_wm_core::actions::TermWmAction;
 use term_wm_core::components::{Component, Overlay, WmComponent};
@@ -251,6 +251,46 @@ pub fn render_app<C: Component<TermWmAction>, L: WmComponent, O: Overlay<TermWmA
 
     // Render panels AFTER windows
     render_panels(backend, wm);
+
+    // Detect whether the app draws content under the FAB's footprint on its
+    // bottom row, so the layout pass can reserve the FAB's row next frame in
+    // cramped monocle. Runs before the FAB draws (no self-trigger; the buffer is
+    // recreated each frame). The flag is cleared whenever cramped monocle is
+    // inactive so a stale value can't falsely pad the first frame after
+    // re-entering cramped monocle.
+    if wm.is_monocle_cramped() {
+        // The FAB's label is the shared menu icon; its DISPLAY width (not char count)
+        // is the footprint the app must not collide with. Wide glyphs (Nerd Font,
+        // emoji) span 2 terminal columns but a single char, so `.chars().count()`
+        // would under-size the footprint and miss collisions under the label's left
+        // edge. Matches the FAB component's own width (also display-based).
+        let fab_width = {
+            let ctx = wm.component_context(true);
+            let icon = term_wm_ui_components::helpers::menu_icon(ctx.app_name());
+            unicode_width::UnicodeWidthStr::width(icon.as_str()) as u16
+        };
+        let has = if fab_width == 0 {
+            false
+        } else {
+            let wa = wm.managed_area();
+            let bottom_y = wa.y + i32::from(wa.height).saturating_sub(1);
+            // The FAB is right-aligned to the screen; recompute its footprint from
+            // the CURRENT frame's geometry (a stored x would be stale after a resize
+            // and could clamp the range to empty).
+            let x_start = wa.x + i32::from(wa.width).saturating_sub(i32::from(fab_width));
+            let x_end = wa.x + i32::from(wa.width);
+            // Downcast locally (matching the empty-state block) to avoid holding a
+            // &mut borrow of `backend` across render_panels / the FAB render below.
+            if let Some(rb) = backend.as_any_mut().downcast_mut::<RatatuiBackend>() {
+                row_has_content_in_range(&rb.buffer, x_start, x_end, bottom_y)
+            } else {
+                false
+            }
+        };
+        wm.set_bottom_content_flag(has);
+    } else {
+        wm.set_bottom_content_flag(false);
+    }
 
     // Render FAB only in cramped monocle mode.
     // Hidden when command palette is open; the bottom panel overlay fills the row.


### PR DESCRIPTION
### Added

- **Clicking a window title scrolls it fully into view:** in the top-panel window strip, clicking a partially visible tab now brings it fully into view immediately (previously the scroll waited for mouse release), and a title physically longer than the visible area left-aligns so its start is shown. A plain click still just focuses the window; drag-to-reorder is unaffected — the click's scroll target is applied on the next render pass and never mid-drag.
- **Monocle FAB never overlaps application content (content dodging):** the Floating Action Button stays fixed on the bottom-right row, and when the focused app draws content underneath its footprint (e.g. a full-width status line like opencode's bottom border), the application viewport is given one fewer row so the app renders its own bottom line *above* the reserved FAB row instead of being covered. Detection scans only the FAB's footprint columns (not the whole row) against the window's *current* bottom row from the previous frame's composited content, and latches while content remains — so a left-aligned shell prompt keeps full height, a status-line app reformats natively (PTY resize / SIGWINCH) with no resize loop, and the FAB only ever floats over empty space. The FAB's footprint and hitbox now use true display-column width (wide/CJK-glyph safe, consistent between the render-time detection and the component).

### Fixed

- **Coverage reporting hanging on `connection_error_is_printed_to_stderr`:** the test's fake-gateway acceptor thread ran an infinite `accept()` loop and was dropped (detached), leaking a thread that stayed blocked on `accept()` forever — coverage tooling waits on spawned threads at process exit, so the suite hung for 60+ seconds under coverage. The acceptor now uses a non-blocking listener (`ListenerNonblockingMode::Accept`) that yields on `WouldBlock`, stops via an `Arc<AtomicBool>` flag, and is explicitly `join()`ed, so the thread always terminates.