### PR TITLE
Fix Cargo.lock determinism related to local patch changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,6 +3312,8 @@ dependencies = [
 [[package]]
 name = "term-wm-vt100"
 version = "0.16.2-patch2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c417631d01b30907cf0117f4e39870408d05346f702d47bcb515ce3af0b7ac27"
 dependencies = [
  "itoa",
  "unicode-width",


### PR DESCRIPTION
- The development machine has an untracked, gitignored .cargo/config.toml: [patch.crates-io] term-wm-vt100 = { path = "../term-wm-vt100" }
- That patch is active only there (the sibling ../term-wm-vt100 checkout exists on this machine). With it active, cargo resolves term-wm-vt100 as a path dependency, so the lockfile entry has no source/checksum.
- On any other machine (no config.toml, or the sibling path missing), cargo resolves it from crates.io, so the lockfile entry has source = "registry+..." + checksum